### PR TITLE
fix(install): add lib/ directory copy for response_analyzer.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -75,7 +75,8 @@ create_install_dirs() {
     mkdir -p "$INSTALL_DIR"
     mkdir -p "$RALPH_HOME"
     mkdir -p "$RALPH_HOME/templates"
-    
+    mkdir -p "$RALPH_HOME/lib"
+
     log "SUCCESS" "Directories created: $INSTALL_DIR, $RALPH_HOME"
 }
 
@@ -85,6 +86,9 @@ install_scripts() {
     
     # Copy templates to Ralph home
     cp -r "$SCRIPT_DIR/templates/"* "$RALPH_HOME/templates/"
+
+    # Copy lib scripts (response_analyzer.sh, circuit_breaker.sh)
+    cp -r "$SCRIPT_DIR/lib/"* "$RALPH_HOME/lib/"
     
     # Create the main ralph command
     cat > "$INSTALL_DIR/ralph" << 'EOF'
@@ -141,7 +145,8 @@ EOF
     chmod +x "$INSTALL_DIR/ralph-import"
     chmod +x "$RALPH_HOME/ralph_monitor.sh"
     chmod +x "$RALPH_HOME/ralph_import.sh"
-    
+    chmod +x "$RALPH_HOME/lib/"*.sh
+
     log "SUCCESS" "Ralph scripts installed to $INSTALL_DIR"
 }
 


### PR DESCRIPTION
## Summary
- Add `mkdir -p "$RALPH_HOME/lib"` to `create_install_dirs()` to create the lib directory
- Add `cp -r "$SCRIPT_DIR/lib/"* "$RALPH_HOME/lib/"` to `install_scripts()` to copy lib scripts
- Add `chmod +x "$RALPH_HOME/lib/"*.sh` to make lib scripts executable

This fixes the issue where `ralph_loop.sh` fails because `response_analyzer.sh` and `circuit_breaker.sh` (required at lines 10-11) are not installed to `~/.ralph/lib/`.

## Test plan
- [ ] Run `./install.sh` on a clean system
- [ ] Verify `~/.ralph/lib/` directory exists
- [ ] Verify `response_analyzer.sh` and `circuit_breaker.sh` are present and executable
- [ ] Run `ralph --monitor` to confirm no sourcing errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced installation process by improving library script management and initialization during setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->