### PR TITLE
Fix ralph-import to handle absolute file paths

### DIFF
--- a/ralph_import.sh
+++ b/ralph_import.sh
@@ -596,8 +596,6 @@ main() {
     # Copy source file to project (uses basename since we cd'd into project)
     local source_basename
     source_basename=$(basename "$source_file")
-
-
     if [[ "$source_file" == /* ]]; then
         cp "$source_file" "$source_basename"
     else


### PR DESCRIPTION
Previously, ralph-import would prepend '../' to the source file path after cd'ing into the project directory. This breaks when an absolute path is provided (e.g., /Users/foo/file.md becomes ..//Users/foo/file.md).

This fix checks if the path is absolute (starts with /) before prepending '../'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced path handling to support both absolute and relative source paths when copying files into project directories, broadening input file compatibility.

* **Style**
  * Fixed formatting consistency in control flow statement.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->