### PR TITLE
fix(tests): add --version handler to mock claude commands in prd_import tests

### DIFF
--- a/tests/integration/test_prd_import.bats
+++ b/tests/integration/test_prd_import.bats
@@ -105,6 +105,13 @@ create_mock_claude_success() {
     cat > "$MOCK_BIN_DIR/claude" << 'MOCK_CLAUDE_EOF'
 #!/bin/bash
 # Mock Claude Code CLI that creates expected output files
+
+# Handle --version flag first (before reading stdin)
+if [[ "$1" == "--version" ]]; then
+    echo "Claude Code CLI version 2.0.80"
+    exit 0
+fi
+
 # Read from stdin (conversion prompt)
 cat > /dev/null
 
@@ -255,6 +262,13 @@ create_mock_claude_failure() {
     cat > "$MOCK_BIN_DIR/claude" << 'MOCK_CLAUDE_FAIL_EOF'
 #!/bin/bash
 # Mock Claude Code CLI that fails
+
+# Handle --version flag first
+if [[ "$1" == "--version" ]]; then
+    echo "Claude Code CLI version 2.0.80"
+    exit 0
+fi
+
 echo "Error: Mock Claude Code failed"
 exit 1
 MOCK_CLAUDE_FAIL_EOF
@@ -699,6 +713,13 @@ create_mock_claude_json_success() {
     cat > "$MOCK_BIN_DIR/claude" << 'MOCK_CLAUDE_JSON_EOF'
 #!/bin/bash
 # Mock Claude Code CLI that outputs JSON format and creates expected files
+
+# Handle --version flag first
+if [[ "$1" == "--version" ]]; then
+    echo "Claude Code CLI version 2.0.80"
+    exit 0
+fi
+
 # Read from stdin (conversion prompt)
 cat > /dev/null
 
@@ -776,6 +797,13 @@ create_mock_claude_json_partial() {
     cat > "$MOCK_BIN_DIR/claude" << 'MOCK_CLAUDE_PARTIAL_EOF'
 #!/bin/bash
 # Mock Claude Code CLI that outputs JSON but only creates some files
+
+# Handle --version flag first
+if [[ "$1" == "--version" ]]; then
+    echo "Claude Code CLI version 2.0.80"
+    exit 0
+fi
+
 cat > /dev/null
 
 # Only create PROMPT.md (missing @fix_plan.md and specs/requirements.md)
@@ -811,6 +839,13 @@ create_mock_claude_json_error() {
     cat > "$MOCK_BIN_DIR/claude" << 'MOCK_CLAUDE_JSON_ERROR_EOF'
 #!/bin/bash
 # Mock Claude Code CLI that outputs JSON error response
+
+# Handle --version flag first
+if [[ "$1" == "--version" ]]; then
+    echo "Claude Code CLI version 2.0.80"
+    exit 0
+fi
+
 cat > /dev/null
 
 # Output JSON error response
@@ -838,6 +873,13 @@ create_mock_claude_text_output() {
     cat > "$MOCK_BIN_DIR/claude" << 'MOCK_CLAUDE_TEXT_EOF'
 #!/bin/bash
 # Mock Claude Code CLI that outputs text (older CLI version)
+
+# Handle --version flag first
+if [[ "$1" == "--version" ]]; then
+    echo "Claude Code CLI version 2.0.80"
+    exit 0
+fi
+
 cat > /dev/null
 
 # Create files
@@ -1057,6 +1099,13 @@ CAPTURE_ARGS_EOF
 @test "ralph-import handles malformed JSON and falls back to text parsing" {
     cat > "$MOCK_BIN_DIR/claude" << 'MALFORMED_JSON_EOF'
 #!/bin/bash
+
+# Handle --version flag first
+if [[ "$1" == "--version" ]]; then
+    echo "Claude Code CLI version 2.0.80"
+    exit 0
+fi
+
 cat > /dev/null
 
 # Create files
@@ -1097,6 +1146,13 @@ MALFORMED_JSON_EOF
 @test "ralph-import extracts specific error message from JSON error" {
     cat > "$MOCK_BIN_DIR/claude" << 'DETAILED_ERROR_EOF'
 #!/bin/bash
+
+# Handle --version flag first
+if [[ "$1" == "--version" ]]; then
+    echo "Claude Code CLI version 2.0.80"
+    exit 0
+fi
+
 cat > /dev/null
 
 # Output detailed JSON error


### PR DESCRIPTION
## Problem
Test 240 (`ralph-import accepts and processes .md file format`) was stalling during the quickstart installation because mock `claude` commands in `test_prd_import.bats` were hanging indefinitely.

## Root Cause
All mock `claude` commands started with `cat > /dev/null` which blocks waiting for stdin. When `ralph_import.sh` calls `claude --version` during its dependency check (line 188), no stdin is provided, causing the command to hang.

## Solution
Added `--version` flag handler to all 7 mock `claude` command generators before the stdin read:

```bash
# Handle --version flag first
if [[ "$1" == "--version" ]]; then
    echo "Claude Code CLI version 2.0.80"
    exit 0
fi
```

## Changes
- ✅ Fixed `create_mock_claude_success()`
- ✅ Fixed `create_mock_claude_failure()`
- ✅ Fixed `create_mock_claude_json_success()`
- ✅ Fixed `create_mock_claude_json_partial()`
- ✅ Fixed `create_mock_claude_json_error()`
- ✅ Fixed `create_mock_claude_text_output()`
- ✅ Fixed inline mocks in tests 32 and 33

## Testing
All 33 tests in `test_prd_import.bats` now pass without stalling:
```bash
./node_modules/.bin/bats tests/integration/test_prd_import.bats -t
# 1..33
# ok 1 ralph-import accepts and processes .md file format
# ... (all 33 tests passing)
```

## Impact
- Fixes test 240 hang during quickstart installation
- Allows full test suite (308 tests) to complete successfully
- No functional changes to production code

## Related Issue
Discovered during quickstart installation following: https://github.com/frankbria/ralph-claude-code?tab=readme-ov-file#quick-start-1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced integration test mocks to support version flag handling, enabling consistent version reporting across test scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->