### PR TITLE
feat(circuit-breaker): allow configuring thresholds via environment variables

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -324,9 +324,15 @@ fi
 **Conflict Resolution:** When `STATUS: COMPLETE` but `EXIT_SIGNAL: false` in RALPH_STATUS, the explicit EXIT_SIGNAL takes precedence. This allows Claude to mark a phase complete while indicating more phases remain.
 
 ### Circuit Breaker Thresholds
-- `CB_NO_PROGRESS_THRESHOLD=3` - Open circuit after 3 loops with no file changes
-- `CB_SAME_ERROR_THRESHOLD=5` - Open circuit after 5 loops with repeated errors
-- `CB_OUTPUT_DECLINE_THRESHOLD=70%` - Open circuit if output declines by >70%
+All thresholds are configurable via environment variables:
+```bash
+# Override thresholds for long-running tasks
+CB_NO_PROGRESS_THRESHOLD=10 CB_SAME_ERROR_THRESHOLD=8 ralph --monitor
+```
+
+- `CB_NO_PROGRESS_THRESHOLD` (default: 3) - Open circuit after N loops with no file changes
+- `CB_SAME_ERROR_THRESHOLD` (default: 5) - Open circuit after N loops with repeated errors
+- `CB_OUTPUT_DECLINE_THRESHOLD` (default: 70) - Open circuit if output declines by >N%
 
 ### Error Detection
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -192,8 +192,9 @@ Ralph follows consistent bash conventions across all scripts:
 source "$(dirname "${BASH_SOURCE[0]}")/lib/date_utils.sh"
 
 # Configuration constants (UPPER_CASE)
+# Use env var defaults for user-configurable values
 MAX_CALLS_PER_HOUR=100
-CB_NO_PROGRESS_THRESHOLD=3
+CB_NO_PROGRESS_THRESHOLD=${CB_NO_PROGRESS_THRESHOLD:-3}
 STATUS_FILE="status.json"
 
 # Colors for output

--- a/README.md
+++ b/README.md
@@ -417,11 +417,15 @@ MAX_CONSECUTIVE_DONE_SIGNALS=2   # Exit after 2 "done" signals
 TEST_PERCENTAGE_THRESHOLD=30     # Flag if 30%+ loops are test-only
 ```
 
-**Circuit Breaker Thresholds:**
+**Circuit Breaker Thresholds (configurable via environment variables):**
 ```bash
-CB_NO_PROGRESS_THRESHOLD=3       # Open circuit after 3 loops with no file changes
-CB_SAME_ERROR_THRESHOLD=5        # Open circuit after 5 loops with repeated errors
-CB_OUTPUT_DECLINE_THRESHOLD=70   # Open circuit if output declines by >70%
+# Defaults (can be overridden at runtime)
+CB_NO_PROGRESS_THRESHOLD=3       # Open circuit after N loops with no file changes
+CB_SAME_ERROR_THRESHOLD=5        # Open circuit after N loops with repeated errors
+CB_OUTPUT_DECLINE_THRESHOLD=70   # Open circuit if output declines by >N%
+
+# Example: increase thresholds for long-running tasks
+CB_NO_PROGRESS_THRESHOLD=10 ralph --monitor
 ```
 
 **Completion Indicators with EXIT_SIGNAL Gate:**

--- a/lib/circuit_breaker.sh
+++ b/lib/circuit_breaker.sh
@@ -16,9 +16,12 @@ CB_STATE_OPEN="OPEN"            # Failure detected, execution halted
 RALPH_DIR="${RALPH_DIR:-.ralph}"
 CB_STATE_FILE="$RALPH_DIR/.circuit_breaker_state"
 CB_HISTORY_FILE="$RALPH_DIR/.circuit_breaker_history"
-CB_NO_PROGRESS_THRESHOLD=3      # Open circuit after N loops with no progress
-CB_SAME_ERROR_THRESHOLD=5       # Open circuit after N loops with same error
-CB_OUTPUT_DECLINE_THRESHOLD=70  # Open circuit if output declines by >70%
+
+# Configurable thresholds via environment variables
+# Users can override: CB_NO_PROGRESS_THRESHOLD=10 ralph --monitor
+CB_NO_PROGRESS_THRESHOLD=${CB_NO_PROGRESS_THRESHOLD:-3}      # Open circuit after N loops with no progress
+CB_SAME_ERROR_THRESHOLD=${CB_SAME_ERROR_THRESHOLD:-5}        # Open circuit after N loops with same error
+CB_OUTPUT_DECLINE_THRESHOLD=${CB_OUTPUT_DECLINE_THRESHOLD:-70}  # Open circuit if output declines by >70%
 
 # Colors
 RED='\033[0;31m'


### PR DESCRIPTION
## Summary
Fixes #99

Makes circuit breaker thresholds configurable via environment variables, allowing users to override defaults for long-running tasks where Claude may do multiple loops of reasoning before writing files.

## Changes
- Modified `lib/circuit_breaker.sh` to use bash default syntax `${VAR:-default}` for all three threshold variables
- Updated `CLAUDE.md` documentation with usage examples
- Updated `README.md` with configurable threshold documentation
- Updated `CONTRIBUTING.md` code example to show env var pattern

## Usage
```bash
# Override thresholds for tasks needing more reasoning loops
CB_NO_PROGRESS_THRESHOLD=10 ralph --monitor

# Or set multiple thresholds
CB_NO_PROGRESS_THRESHOLD=20 CB_SAME_ERROR_THRESHOLD=8 ralph --monitor
```

## Testing
All 310 existing tests pass. The change is backward-compatible - default values remain the same.

---
🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Circuit breaker thresholds are now configurable via environment variables (CB_NO_PROGRESS_THRESHOLD, CB_SAME_ERROR_THRESHOLD, CB_OUTPUT_DECLINE_THRESHOLD). Runtime customization is supported while maintaining backward compatibility with default values.

* **Documentation**
  * Enhanced configuration documentation with environment variable examples and threshold reference information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->