### PR TITLE
fix(analyzer): handle Claude CLI JSON array output format

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 This is the Ralph for Claude Code repository - an autonomous AI development loop system that enables continuous development cycles with intelligent exit detection and rate limiting.
 
-**Version**: v0.10.0 | **Tests**: 310 passing (100% pass rate) | **CI/CD**: GitHub Actions
+**Version**: v0.10.1 | **Tests**: 318 passing (100% pass rate) | **CI/CD**: GitHub Actions
 
 ## Core Architecture
 
@@ -357,7 +357,7 @@ Ralph uses advanced error detection with two-stage filtering to eliminate false 
 |------|-------|-------------|
 | `test_cli_parsing.bats` | 27 | CLI argument parsing for all 12 flags |
 | `test_cli_modern.bats` | 29 | Modern CLI commands (Phase 1.1) + build_claude_command fix |
-| `test_json_parsing.bats` | 36 | JSON output format parsing + Claude CLI format + session management |
+| `test_json_parsing.bats` | 44 | JSON output format parsing + Claude CLI format + session management + array format |
 | `test_session_continuity.bats` | 26 | Session lifecycle management + circuit breaker integration |
 | `test_exit_detection.bats` | 20 | Exit signal detection |
 | `test_rate_limiting.bats` | 15 | Rate limiting behavior |
@@ -380,6 +380,18 @@ bats tests/unit/test_cli_parsing.bats
 ```
 
 ## Recent Improvements
+
+### JSON Array Format Support (v0.10.1)
+- Fixed `parse_json_response` to handle Claude CLI JSON array output format (issue #112)
+- Claude CLI outputs `[{type: "system", ...}, {type: "assistant", ...}, {type: "result", ...}]`
+- Previously expected single JSON object, now supports three formats:
+  1. Flat format: `{ status, exit_signal, work_type, ... }`
+  2. Claude CLI object format: `{ result, sessionId, metadata: {...} }`
+  3. Claude CLI array format: `[ {type: "result", ...}, ... ]`
+- Extracts `result` type message from array and normalizes to object format
+- Preserves `session_id` from init message for session continuity
+- Added 8 new tests for JSON array format handling
+- Test count: 318 (up from 310)
 
 ### .ralph/ Subfolder Structure (v0.10.0) - BREAKING CHANGE
 - **Breaking**: Moved all Ralph-specific files to `.ralph/` subfolder


### PR DESCRIPTION
## Summary
Fixes #112

The `parse_json_response` function in `lib/response_analyzer.sh` was failing when processing Claude Code CLI output because it assumed a single JSON object, but Claude CLI outputs a **JSON array**:

```json
[
  {"type": "system", "subtype": "init", "session_id": "..."},
  {"type": "assistant", "message": {...}},
  {"type": "result", "subtype": "success", "result": "...", "is_error": false}
]
```

This caused Ralph to crash after Loop #1 with `jq: invalid JSON text passed to --argjson`.

## Changes
- Detect if JSON is an array before parsing using `jq -e 'type == "array"'`
- Extract the "result" type message from the array (contains the actual completion data)
- Preserve session_id from the init message for session continuity
- Normalize to object format for existing parsing logic
- Clean up temporary file after processing

## Files Changed
- `lib/response_analyzer.sh` - JSON array format detection and normalization (+30 lines)
- `tests/unit/test_json_parsing.bats` - 8 new tests for array format handling (+158 lines)
- `CLAUDE.md` - Documentation updates (version, test count, recent improvements)

## Test Plan
- [x] All 318 tests passing (100% pass rate)
- [x] 8 new tests for JSON array format:
  - `detect_output_format identifies JSON array as json`
  - `parse_json_response handles Claude CLI JSON array format`
  - `parse_json_response extracts session_id from Claude CLI array init message`
  - `parse_json_response handles empty array gracefully`
  - `parse_json_response handles array without result type message`
  - `parse_json_response extracts is_error from Claude CLI array result`
  - `analyze_response handles Claude CLI JSON array and extracts signals`
  - `analyze_response persists session_id from Claude CLI array format`
- [x] Backward compatibility verified (existing tests still pass)

---
🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added support for Claude CLI JSON array format outputs with enhanced message extraction and session continuity handling

* **Tests**
  * Expanded test coverage to 318 tests with comprehensive validation of JSON array format handling

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->