### PR TITLE
fix(monitor): update log path to use .ralph/ subdirectory

### DIFF
--- a/ralph_monitor.sh
+++ b/ralph_monitor.sh
@@ -4,7 +4,7 @@
 set -e
 
 STATUS_FILE="status.json"
-LOG_FILE="logs/ralph.log"
+LOG_FILE=".ralph/logs/ralph.log"
 REFRESH_INTERVAL=2
 
 # Colors


### PR DESCRIPTION
## Summary

Fixes the `ralph_monitor.sh` script to use the correct log path for Ralph v0.10.0's new directory structure.

## Problem

After PR #109 (feat: migrate Ralph files to .ralph/ subfolder), the monitor script was still hardcoded to read from `logs/ralph.log` instead of `.ralph/logs/ralph.log`.

This caused the monitor dashboard to display outdated or incorrect logs when Ralph was running with the new directory structure.

## Changes

- Update `LOG_FILE` path from `logs/ralph.log` to `.ralph/logs/ralph.log` in `ralph_monitor.sh`

## Testing

Tested with Ralph v0.10.0:
1. Created a Ralph project with `.ralph/` structure
2. Ran `ralph --monitor`  
3. Confirmed monitor now displays correct, up-to-date logs from `.ralph/logs/ralph.log`

## Related Issues

- Related: #109 (feat: migrate Ralph files to .ralph/ subfolder)

## Checklist

- [x] Code follows project conventions
- [x] Tested with Ralph v0.10.0
- [x] Single line change, minimal impact
- [x] Aligns with v0.10.0 directory structure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated log file location to a hidden directory for better organization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->