### PR TITLE
fix(monitor): forward all CLI parameters to inner ralph loop

### DIFF
--- a/ralph_loop.sh
+++ b/ralph_loop.sh
@@ -117,20 +117,47 @@ setup_tmux_session() {
     fi
     
     # Start ralph loop in the left pane (exclude tmux flag to avoid recursion)
+    # Forward all CLI parameters that were set by the user
     local ralph_cmd
     if command -v ralph &> /dev/null; then
         ralph_cmd="ralph"
     else
         ralph_cmd="'$ralph_home/ralph_loop.sh'"
     fi
-    
+
+    # Forward --calls if non-default
     if [[ "$MAX_CALLS_PER_HOUR" != "100" ]]; then
         ralph_cmd="$ralph_cmd --calls $MAX_CALLS_PER_HOUR"
     fi
+    # Forward --prompt if non-default
     if [[ "$PROMPT_FILE" != "$RALPH_DIR/PROMPT.md" ]]; then
         ralph_cmd="$ralph_cmd --prompt '$PROMPT_FILE'"
     fi
-    
+    # Forward --output-format if non-default (default is json)
+    if [[ "$CLAUDE_OUTPUT_FORMAT" != "json" ]]; then
+        ralph_cmd="$ralph_cmd --output-format $CLAUDE_OUTPUT_FORMAT"
+    fi
+    # Forward --verbose if enabled
+    if [[ "$VERBOSE_PROGRESS" == "true" ]]; then
+        ralph_cmd="$ralph_cmd --verbose"
+    fi
+    # Forward --timeout if non-default (default is 15)
+    if [[ "$CLAUDE_TIMEOUT_MINUTES" != "15" ]]; then
+        ralph_cmd="$ralph_cmd --timeout $CLAUDE_TIMEOUT_MINUTES"
+    fi
+    # Forward --allowed-tools if non-default
+    if [[ "$CLAUDE_ALLOWED_TOOLS" != "Write,Bash(git *),Read" ]]; then
+        ralph_cmd="$ralph_cmd --allowed-tools '$CLAUDE_ALLOWED_TOOLS'"
+    fi
+    # Forward --no-continue if session continuity disabled
+    if [[ "$CLAUDE_USE_CONTINUE" == "false" ]]; then
+        ralph_cmd="$ralph_cmd --no-continue"
+    fi
+    # Forward --session-expiry if non-default (default is 24)
+    if [[ "$CLAUDE_SESSION_EXPIRY_HOURS" != "24" ]]; then
+        ralph_cmd="$ralph_cmd --session-expiry $CLAUDE_SESSION_EXPIRY_HOURS"
+    fi
+
     tmux send-keys -t "$session_name:0.0" "$ralph_cmd" Enter
     
     # Focus on left pane (main ralph loop)


### PR DESCRIPTION
## Summary

Fixes #120

When using `--monitor` flag, the tmux session now correctly forwards all CLI parameters to the inner `ralph_loop.sh` execution. Previously, only `--calls` and `--prompt` were forwarded, causing parameters like `--output-format text` to be silently ignored.

## Changes

- Modified `setup_tmux_session()` in `ralph_loop.sh` to forward all 6 additional CLI parameters:
  - `--output-format` (json/text) - was the reported bug
  - `--verbose` (boolean flag)
  - `--timeout` (minutes, default 15)
  - `--allowed-tools` (tool permissions)
  - `--no-continue` (disable session continuity)
  - `--session-expiry` (hours, default 24)
- Each parameter is only forwarded if it differs from default value to keep the command clean
- Added 8 new unit tests for parameter forwarding validation

## Test Plan

1. Verify existing tests pass: `npx bats tests/unit/test_cli_parsing.bats`
2. Test manual reproduction case:
   ```bash
   ralph --monitor --output-format text --verbose
   # Should now show "[INFO] Using modern CLI mode (text output)" instead of JSON
   ```
3. Test multiple parameters:
   ```bash
   ralph --monitor --output-format text --timeout 30 --verbose
   # All parameters should be forwarded to the inner loop
   ```

## Test Results

- All 329 tests pass (up from 321 with 8 new tests)
- New tests cover all 6 parameter types plus combination scenarios

---
🤖 Generated with Claude Code (issue-hunter-pro)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced the monitor flow to properly forward all CLI parameters to the inner Ralph loop. Your configuration settings for output format, verbosity, timeout, allowed tools, continue behavior, and session expiry are now consistently applied throughout the monitoring process.

* **Tests**
  * Added comprehensive test coverage for monitor parameter forwarding to ensure all parameters are correctly propagated.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->