### PR TITLE
fix(exit-detection): use explicit EXIT_SIGNAL instead of confidence threshold

### DIFF
--- a/ralph_loop.sh
+++ b/ralph_loop.sh
@@ -384,12 +384,14 @@ should_exit_gracefully() {
         return 0
     fi
     
-    # 3. Safety circuit breaker - force exit after 5 consecutive completion indicators
-    # Bug #2 Fix: Prevents infinite loops when EXIT_SIGNAL is not explicitly set
-    # but completion patterns clearly indicate work is done. Threshold of 5 is higher
-    # than normal threshold (2) to avoid false positives while preventing API waste.
+    # 3. Safety circuit breaker - force exit after 5 consecutive EXIT_SIGNAL=true responses
+    # Note: completion_indicators only accumulates when Claude explicitly sets EXIT_SIGNAL=true
+    # (not based on confidence score). This safety breaker catches cases where Claude signals
+    # completion 5+ times but the normal exit path (completion_indicators >= 2 + EXIT_SIGNAL=true)
+    # didn't trigger for some reason. Threshold of 5 prevents API waste while being higher than
+    # the normal threshold (2) to avoid false positives.
     if [[ $recent_completion_indicators -ge 5 ]]; then
-        log_status "WARN" "🚨 SAFETY CIRCUIT BREAKER: Force exit after 5 consecutive completion indicators ($recent_completion_indicators)" >&2
+        log_status "WARN" "🚨 SAFETY CIRCUIT BREAKER: Force exit after 5 consecutive EXIT_SIGNAL=true responses ($recent_completion_indicators)" >&2
         echo "safety_circuit_breaker"
         return 0
     fi

--- a/tests/unit/test_exit_detection.bats
+++ b/tests/unit/test_exit_detection.bats
@@ -519,3 +519,183 @@ EOF
     # EXIT_SIGNAL=false should take precedence, continue working
     assert_equal "$result" ""
 }
+
+# =============================================================================
+# UPDATE_EXIT_SIGNALS TESTS (Issue: Confidence-based completion indicators)
+# =============================================================================
+# These tests verify that update_exit_signals() only adds to completion_indicators
+# when EXIT_SIGNAL is true, not based on confidence score alone.
+# This is critical for JSON mode where confidence is always >= 70.
+
+# Source the response_analyzer library for direct testing
+# Note: These tests source the library to test update_exit_signals() directly
+
+# Test 32: update_exit_signals should NOT add to completion_indicators when exit_signal=false
+@test "update_exit_signals does NOT add to completion_indicators when exit_signal=false" {
+    # Source the response analyzer library
+    source "${BATS_TEST_DIRNAME}/../../lib/response_analyzer.sh"
+
+    # Initialize exit signals file
+    echo '{"test_only_loops": [], "done_signals": [], "completion_indicators": []}' > "$EXIT_SIGNALS_FILE"
+
+    # Create analysis file with HIGH confidence (70) but exit_signal=false
+    # This simulates JSON mode where confidence is always >= 70
+    cat > "$RESPONSE_ANALYSIS_FILE" << 'EOF'
+{
+    "loop_number": 1,
+    "timestamp": "2026-01-12T10:00:00Z",
+    "output_format": "json",
+    "analysis": {
+        "has_completion_signal": false,
+        "is_test_only": false,
+        "is_stuck": false,
+        "has_progress": true,
+        "files_modified": 5,
+        "confidence_score": 70,
+        "exit_signal": false,
+        "work_summary": "Implementing feature, still in progress"
+    }
+}
+EOF
+
+    # Call update_exit_signals
+    update_exit_signals "$RESPONSE_ANALYSIS_FILE" "$EXIT_SIGNALS_FILE"
+
+    # Verify completion_indicators was NOT incremented
+    local indicator_count=$(jq '.completion_indicators | length' "$EXIT_SIGNALS_FILE")
+    assert_equal "$indicator_count" "0"
+}
+
+# Test 33: update_exit_signals SHOULD add to completion_indicators when exit_signal=true
+@test "update_exit_signals adds to completion_indicators when exit_signal=true" {
+    # Source the response analyzer library
+    source "${BATS_TEST_DIRNAME}/../../lib/response_analyzer.sh"
+
+    # Initialize exit signals file
+    echo '{"test_only_loops": [], "done_signals": [], "completion_indicators": []}' > "$EXIT_SIGNALS_FILE"
+
+    # Create analysis file with exit_signal=true
+    cat > "$RESPONSE_ANALYSIS_FILE" << 'EOF'
+{
+    "loop_number": 1,
+    "timestamp": "2026-01-12T10:00:00Z",
+    "output_format": "json",
+    "analysis": {
+        "has_completion_signal": true,
+        "is_test_only": false,
+        "is_stuck": false,
+        "has_progress": false,
+        "files_modified": 0,
+        "confidence_score": 100,
+        "exit_signal": true,
+        "work_summary": "All tasks complete"
+    }
+}
+EOF
+
+    # Call update_exit_signals
+    update_exit_signals "$RESPONSE_ANALYSIS_FILE" "$EXIT_SIGNALS_FILE"
+
+    # Verify completion_indicators WAS incremented
+    local indicator_count=$(jq '.completion_indicators | length' "$EXIT_SIGNALS_FILE")
+    assert_equal "$indicator_count" "1"
+
+    # Verify the loop number was recorded
+    local loop_recorded=$(jq '.completion_indicators[0]' "$EXIT_SIGNALS_FILE")
+    assert_equal "$loop_recorded" "1"
+}
+
+# Test 34: update_exit_signals accumulates completion_indicators only on exit_signal=true
+@test "update_exit_signals accumulates completion_indicators only when exit_signal=true" {
+    # Source the response analyzer library
+    source "${BATS_TEST_DIRNAME}/../../lib/response_analyzer.sh"
+
+    # Initialize exit signals file
+    echo '{"test_only_loops": [], "done_signals": [], "completion_indicators": []}' > "$EXIT_SIGNALS_FILE"
+
+    # Loop 1: exit_signal=false (should NOT add)
+    cat > "$RESPONSE_ANALYSIS_FILE" << 'EOF'
+{
+    "loop_number": 1,
+    "analysis": {
+        "has_completion_signal": false,
+        "is_test_only": false,
+        "has_progress": true,
+        "confidence_score": 80,
+        "exit_signal": false
+    }
+}
+EOF
+    update_exit_signals "$RESPONSE_ANALYSIS_FILE" "$EXIT_SIGNALS_FILE"
+
+    # Loop 2: exit_signal=false (should NOT add)
+    cat > "$RESPONSE_ANALYSIS_FILE" << 'EOF'
+{
+    "loop_number": 2,
+    "analysis": {
+        "has_completion_signal": true,
+        "is_test_only": false,
+        "has_progress": true,
+        "confidence_score": 90,
+        "exit_signal": false
+    }
+}
+EOF
+    update_exit_signals "$RESPONSE_ANALYSIS_FILE" "$EXIT_SIGNALS_FILE"
+
+    # Loop 3: exit_signal=true (SHOULD add)
+    cat > "$RESPONSE_ANALYSIS_FILE" << 'EOF'
+{
+    "loop_number": 3,
+    "analysis": {
+        "has_completion_signal": true,
+        "is_test_only": false,
+        "has_progress": false,
+        "confidence_score": 100,
+        "exit_signal": true
+    }
+}
+EOF
+    update_exit_signals "$RESPONSE_ANALYSIS_FILE" "$EXIT_SIGNALS_FILE"
+
+    # Verify only 1 completion indicator (from loop 3)
+    local indicator_count=$(jq '.completion_indicators | length' "$EXIT_SIGNALS_FILE")
+    assert_equal "$indicator_count" "1"
+
+    local loop_recorded=$(jq '.completion_indicators[0]' "$EXIT_SIGNALS_FILE")
+    assert_equal "$loop_recorded" "3"
+}
+
+# Test 35: JSON mode simulation - 5 loops with exit_signal=false should NOT trigger safety breaker
+@test "update_exit_signals JSON mode - 5 loops with exit_signal=false does not fill completion_indicators" {
+    # Source the response analyzer library
+    source "${BATS_TEST_DIRNAME}/../../lib/response_analyzer.sh"
+
+    # Initialize exit signals file
+    echo '{"test_only_loops": [], "done_signals": [], "completion_indicators": []}' > "$EXIT_SIGNALS_FILE"
+
+    # Simulate 5 JSON mode loops with high confidence but exit_signal=false
+    # This is the exact scenario that caused the bug
+    for i in 1 2 3 4 5; do
+        cat > "$RESPONSE_ANALYSIS_FILE" << EOF
+{
+    "loop_number": $i,
+    "output_format": "json",
+    "analysis": {
+        "has_completion_signal": false,
+        "is_test_only": false,
+        "has_progress": true,
+        "files_modified": 3,
+        "confidence_score": 70,
+        "exit_signal": false,
+        "work_summary": "Working on feature $i"
+    }
+}
+EOF
+        update_exit_signals "$RESPONSE_ANALYSIS_FILE" "$EXIT_SIGNALS_FILE"
+    done
+
+    # Verify completion_indicators is EMPTY (not filled with 5 indicators)
+    local indicator_count=$(jq '.completion_indicators | length' "$EXIT_SIGNALS_FILE")
+    assert_equal "$indicator_count" "0"
+}


### PR DESCRIPTION
## Summary
- Fix premature exit after exactly 5 loops in JSON output mode
- Replace confidence-based heuristic with explicit EXIT_SIGNAL checking
- Add 4 TDD tests validating the fix

## Problem
In JSON output mode, `update_exit_signals()` used a confidence threshold (≥60) to populate `completion_indicators`. JSON mode always has confidence ≥70 due to deterministic scoring:
- +50 for successful JSON parsing
- +20 for having a `result` field

This caused every successful JSON response to increment `completion_indicators`, triggering the safety circuit breaker after exactly 5 loops—even when Claude explicitly set `EXIT_SIGNAL: false`.

## Solution
Replace confidence-based logic in `update_exit_signals()` with explicit EXIT_SIGNAL checking:
```bash
# Before (buggy)
local confidence=$(jq -r '.analysis.confidence_score' "$analysis_file")
if [[ $confidence -ge 60 ]]; then
    signals=$(echo "$signals" | jq ".completion_indicators += [$loop_number]")
fi

# After (fixed)
local exit_signal=$(jq -r '.analysis.exit_signal // false' "$analysis_file")
if [[ "$exit_signal" == "true" ]]; then
    signals=$(echo "$signals" | jq ".completion_indicators += [$loop_number]")
fi
```

## Test plan
- [x] Test 32: Verifies `completion_indicators` NOT updated when `exit_signal=false`
- [x] Test 33: Verifies `completion_indicators` IS updated when `exit_signal=true`
- [x] Test 34: Verifies accumulation only on `exit_signal=true`
- [x] Test 35: Simulates 5 JSON mode loops with `exit_signal=false` (exact bug scenario)
- [x] All 424 tests pass (100% pass rate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v0.11.1

* **Bug Fixes**
  * Fixed completion indicator detection to use explicit exit signals instead of confidence thresholds, reducing premature exits and improving reliability.

* **Tests**
  * Added 4 new unit tests validating exit signal detection and safety circuit breaker behavior.

* **Chores**
  * Version bumped to v0.11.1.
  * Updated documentation reflecting behavioral improvements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->