### PR TITLE
fix(test): robust variable init in session continuity test 199

### DIFF
--- a/tests/unit/test_session_continuity.bats
+++ b/tests/unit/test_session_continuity.bats
@@ -596,6 +596,10 @@ EOF
 @test "reset_session prevents issue #91 scenario (stale completion indicators)" {
     # Issue #91: Ralph exits immediately when stale completion_indicators exist
 
+    # Ensure variables are set before use (defensive against env differences)
+    export RESPONSE_ANALYSIS_FILE="$RALPH_DIR/.response_analysis"
+    export RALPH_SESSION_HISTORY_FILE="$RALPH_DIR/.ralph_session_history"
+
     # Simulate the issue scenario:
     # 1. Previous session ended with completion_indicators: [1,2]
     # 2. Previous session had EXIT_SIGNAL: true
@@ -608,10 +612,6 @@ EOF
 
     local exit_signal=$(jq -r '.analysis.exit_signal' "$RESPONSE_ANALYSIS_FILE")
     [[ "$exit_signal" == "true" ]]
-
-    # Now simulate user running --reset-session (which should clear these files)
-    export RALPH_SESSION_HISTORY_FILE="$RALPH_DIR/.ralph_session_history"
-    export RESPONSE_ANALYSIS_FILE="$RALPH_DIR/.response_analysis"
 
     # Define reset_session with the fix
     reset_session() {


### PR DESCRIPTION
## Summary
Fixes flaky CI failure in test 199 (`reset_session prevents issue #91 scenario`) where `RESPONSE_ANALYSIS_FILE` could be empty in some CI environments, causing "No such file or directory".

Moves `export RESPONSE_ANALYSIS_FILE` and `RALPH_SESSION_HISTORY_FILE` before their first use in the test body, rather than relying solely on `setup()` state.

## Context
This failure was blocking PR #126 (fix for issue #120). The test passes locally but fails on the fork's CI runner.

## Test plan
- [x] Test 199 passes locally
- [x] All 44 session continuity tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test setup for session continuity validation by refining environment variable handling and removing redundant declarations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->