### PR TITLE
ci(workflow): add concurrency blocks to prevent duplicate runs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,6 +10,11 @@ on:
       - ".gitignore"
       - "pyproject.toml"
 
+# Cancel in-progress runs for the same PR to avoid duplicate reviews
+concurrency:
+  group: claude-code-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   claude-review:
     runs-on: ubuntu-latest

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,11 @@ on:
   pull_request_review:
     types: [submitted]
 
+# Cancel in-progress runs for the same issue/PR to avoid duplicate responses
+concurrency:
+  group: claude-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   claude:
     if: |

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -11,6 +11,11 @@ on:
       - ".gitignore"
       - "pyproject.toml"
 
+# Cancel in-progress runs for the same PR to avoid duplicate reviews
+concurrency:
+  group: opencode-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   opencode-review:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Add concurrency control to all review workflows to prevent duplicate runs when PRs are updated rapidly or multiple comments are posted in quick succession.

## Changes

Added concurrency blocks to:

| Workflow | Concurrency Group |
|----------|------------------|
| `opencode-review.yml` | `opencode-review-{PR#}` |
| `claude-code-review.yml` | `claude-code-review-{PR#}` |
| `claude.yml` | `claude-{issue/PR#}` |

## Behavior

When a new workflow run starts for the same PR/issue:
- `cancel-in-progress: true` - Cancels any currently running workflow for that PR/issue
- Prevents duplicate reviews and wasted compute time
- Ensures only the most recent code is reviewed

## Test Plan

- [x] Syntax validated (YAML is valid)
- [ ] Test by rapidly pushing commits to a PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized automated review workflows to prevent duplicate reviews and responses on pull requests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->