### PR TITLE
fix: Recognize STATUS: COMPLETE as progress in circuit breaker

### DIFF
--- a/lib/circuit_breaker.sh
+++ b/lib/circuit_breaker.sh
@@ -120,7 +120,8 @@ record_loop_result() {
         has_completion_signal=$(jq -r '.analysis.has_completion_signal // false' "$response_analysis_file" 2>/dev/null || echo "false")
 
         # Also check exit_signal (Claude explicitly signaling completion)
-        local exit_signal=$(jq -r '.analysis.exit_signal // false' "$response_analysis_file" 2>/dev/null || echo "false")
+        local exit_signal
+        exit_signal=$(jq -r '.analysis.exit_signal // false' "$response_analysis_file" 2>/dev/null || echo "false")
         if [[ "$exit_signal" == "true" ]]; then
             has_completion_signal="true"
         fi


### PR DESCRIPTION
## Summary
- Fix circuit breaker false positive when Claude completes work and commits it immediately
- Add multiple progress detection sources beyond just git diff

## Problem
The circuit breaker was only detecting progress through `git diff` changes. When Claude completed work and committed it, subsequent loops showed 0 uncommitted changes, causing the circuit breaker to trip after 3 loops with "No progress detected."

This was happening in projects like mcli where Claude would:
1. Complete a task (e.g., "Add Pydantic validation models")
2. Commit the changes immediately
3. Report `STATUS: COMPLETE` with `FILES_MODIFIED: 6`
4. On next loop, `git diff` shows 0 changes
5. Circuit breaker sees "no progress" → trips after 3 loops

## Solution
Add multiple progress detection sources in `record_loop_result()`:

1. **Git diff changes** (existing) - uncommitted file changes
2. **has_completion_signal** from `.response_analysis` - Claude's `STATUS: COMPLETE`
3. **files_modified** from RALPH_STATUS block - Claude's reported file count

If any of these indicate progress, reset the consecutive_no_progress counter.

## Test plan
- [ ] Run existing bats tests
- [ ] Test with a project that commits work immediately
- [ ] Verify circuit breaker doesn't trip when STATUS: COMPLETE is reported

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved progress detection to treat external completion signals and reported file modifications as valid progress in addition to git changes, reducing false no-progress states and improving completion reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->