### PR TITLE
feat(exit): detect permission denials and halt loop (Issue #101)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -378,6 +378,28 @@ fi
 - `CB_NO_PROGRESS_THRESHOLD=3` - Open circuit after 3 loops with no file changes
 - `CB_SAME_ERROR_THRESHOLD=5` - Open circuit after 5 loops with repeated errors
 - `CB_OUTPUT_DECLINE_THRESHOLD=70%` - Open circuit if output declines by >70%
+- `CB_PERMISSION_DENIAL_THRESHOLD=2` - Open circuit after 2 loops with permission denials (Issue #101)
+
+### Permission Denial Detection (Issue #101)
+
+When Claude Code is denied permission to execute commands (e.g., `npm install`), Ralph detects this from the `permission_denials` array in the JSON output and halts the loop immediately:
+
+1. **Detection**: The `parse_json_response()` function extracts `permission_denials` from Claude Code output
+2. **Fields tracked**:
+   - `has_permission_denials` (boolean)
+   - `permission_denial_count` (integer)
+   - `denied_commands` (array of command strings)
+3. **Exit behavior**: When `has_permission_denials=true`, Ralph exits with reason "permission_denied"
+4. **User guidance**: Ralph displays instructions to update `ALLOWED_TOOLS` in `.ralphrc`
+
+**Example `.ralphrc` tool patterns:**
+```bash
+# Broad patterns (recommended for development)
+ALLOWED_TOOLS="Write,Read,Edit,Bash(git *),Bash(npm *),Bash(pytest)"
+
+# Specific patterns (more restrictive)
+ALLOWED_TOOLS="Write,Read,Edit,Bash(git commit),Bash(npm install)"
+```
 
 ### Error Detection
 

--- a/README.md
+++ b/README.md
@@ -681,6 +681,11 @@ tail -f .ralph/logs/ralph.log
 - **tmux Session Lost** - Use `tmux list-sessions` and `tmux attach` to reconnect
 - **Session Expired** - Sessions expire after 24 hours by default; use `--reset-session` to start fresh
 - **timeout: command not found (macOS)** - Install GNU coreutils: `brew install coreutils`
+- **Permission Denied** - Ralph halts when Claude Code is denied permission for commands:
+  1. Edit `.ralphrc` and update `ALLOWED_TOOLS` to include required tools
+  2. Common patterns: `Bash(npm *)`, `Bash(git *)`, `Bash(pytest)`
+  3. Run `ralph --reset-session` after updating `.ralphrc`
+  4. Restart with `ralph --monitor`
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- Detect permission denials from Claude Code JSON output
- Halt loop immediately when permissions are denied
- Provide clear guidance for updating `.ralphrc` ALLOWED_TOOLS

## Problem
Ralph was executing Claude Code with stdout/stderr redirected to files, which prevented interactive approval prompts from reaching the user. When commands like `npm install` were denied permission, Ralph silently continued looping without alerting the user or pausing for intervention (Issue #101).

## Solution
Implement a three-pronged approach:
1. **Detection**: Parse `permission_denials` array from Claude Code JSON output
2. **Exit condition**: Halt loop with reason "permission_denied" when denials detected
3. **User guidance**: Display clear instructions for updating `.ralphrc`

## Implementation

### Response Analyzer (`lib/response_analyzer.sh`)
- Add extraction of `permission_denials` array in `parse_json_response()`
- Track `has_permission_denials`, `permission_denial_count`, `denied_commands`
- Include permission denial fields in `analyze_response()` output

### Main Loop (`ralph_loop.sh`)
- Add permission denial check to `should_exit_gracefully()` (highest priority)
- Display helpful error message with guidance:
  - Which commands were denied
  - Current ALLOWED_TOOLS configuration
  - Instructions to update `.ralphrc`

### Circuit Breaker (`lib/circuit_breaker.sh`)
- Add `CB_PERMISSION_DENIAL_THRESHOLD=2` constant
- Track `consecutive_permission_denials` in state file
- Open circuit after 2 consecutive loops with permission denials

## Test plan
- [x] Add 6 tests for permission denial parsing in `test_json_parsing.bats`
- [x] Add 5 tests for permission denial exit condition in `test_exit_detection.bats`
- [x] All 452 tests pass (100% pass rate)

## Documentation
- [x] Update CLAUDE.md with permission denial detection documentation
- [x] Update README.md Common Issues section

Fixes #101

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added permission denial detection that automatically stops execution when commands lack required permissions.
  * New circuit breaker threshold to exit after repeated permission denials instead of continuous retries.

* **Documentation**
  * Added troubleshooting guidance for resolving permission denied errors.
  * Updated documentation with permission denial configuration details and resolution steps.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->