### PR TITLE
Fix grep -c exit code causing arithmetic syntax error

### DIFF
--- a/ralph_loop.sh
+++ b/ralph_loop.sh
@@ -495,8 +495,10 @@ should_exit_gracefully() {
     # Fix #144: Only match valid markdown checkboxes, not date entries like [2026-01-29]
     # Valid patterns: "- [ ]" (uncompleted) and "- [x]" or "- [X]" (completed)
     if [[ -f "$RALPH_DIR/fix_plan.md" ]]; then
-        local uncompleted_items=$(grep -cE "^[[:space:]]*- \[ \]" "$RALPH_DIR/fix_plan.md" 2>/dev/null || echo "0")
-        local completed_items=$(grep -cE "^[[:space:]]*- \[[xX]\]" "$RALPH_DIR/fix_plan.md" 2>/dev/null || echo "0")
+        local uncompleted_items=$(grep -cE "^[[:space:]]*- \[ \]" "$RALPH_DIR/fix_plan.md" 2>/dev/null || true)
+        [[ -z "$uncompleted_items" ]] && uncompleted_items=0
+        local completed_items=$(grep -cE "^[[:space:]]*- \[[xX]\]" "$RALPH_DIR/fix_plan.md" 2>/dev/null || true)
+        [[ -z "$completed_items" ]] && completed_items=0
         local total_items=$((uncompleted_items + completed_items))
 
         if [[ $total_items -gt 0 ]] && [[ $completed_items -eq $total_items ]]; then
@@ -602,7 +604,8 @@ build_loop_context() {
     # Extract incomplete tasks from fix_plan.md
     # Bug #3 Fix: Support indented markdown checkboxes with [[:space:]]* pattern
     if [[ -f "$RALPH_DIR/fix_plan.md" ]]; then
-        local incomplete_tasks=$(grep -cE "^[[:space:]]*- \[ \]" "$RALPH_DIR/fix_plan.md" 2>/dev/null || echo "0")
+        local incomplete_tasks=$(grep -cE "^[[:space:]]*- \[ \]" "$RALPH_DIR/fix_plan.md" 2>/dev/null || true)
+        [[ -z "$incomplete_tasks" ]] && incomplete_tasks=0
         context+="Remaining tasks: ${incomplete_tasks}. "
     fi
 


### PR DESCRIPTION
## Summary

- `grep -c` outputs `"0"` to stdout when finding 0 matches, but exits with code 1
- `|| echo "0"` fallback triggers on exit code 1, appending another `"0"` to the output
- Variable ends up as `"0\n0"` instead of `"0"`, causing bash arithmetic error: `line 500: 0 0: syntax error in expression`
- Affects 3 locations in `ralph_loop.sh` (lines 498, 499, 605)

## Fix

Replace `|| echo "0"` with `|| true` so grep's stdout output is preserved. Add `[[ -z "$var" ]] && var=0` fallback for actual errors (e.g. missing file).

## Test plan

- [ ] Run Ralph with a `fix_plan.md` that has only unchecked `- [ ]` items (0 completed) — previously crashed here
- [ ] Run Ralph with a `fix_plan.md` that has some `- [x]` items
- [ ] Run Ralph without a `fix_plan.md` present

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling resilience when processing task data. The system now gracefully handles missing or inaccessible files without emitting errors, while maintaining accurate task counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->