### PR TITLE
fix: improve permission denial display to show tool names

### DIFF
--- a/lib/response_analyzer.sh
+++ b/lib/response_analyzer.sh
@@ -200,11 +200,13 @@ parse_json_response() {
         has_permission_denials="true"
     fi
 
-    # Extract denied commands for logging/display
-    # Note: Commands are nested under tool_input.command in the permission_denials array
+    # Extract denied tool names and commands for logging/display
+    # Shows tool_name for non-Bash tools, and for Bash tools shows the command that was denied
+    # This handles both cases: AskUserQuestion denial shows "AskUserQuestion",
+    # while Bash denial shows "Bash(git commit -m ...)" with truncated command
     local denied_commands_json="[]"
     if [[ $permission_denial_count -gt 0 ]]; then
-        denied_commands_json=$(jq -r '[.permission_denials[].tool_input.command // empty]' "$output_file" 2>/dev/null || echo "[]")
+        denied_commands_json=$(jq -r '[.permission_denials[] | if .tool_name == "Bash" then "Bash(\(.tool_input.command // "?" | split("\n")[0] | .[0:60]))" else .tool_name // "unknown" end]' "$output_file" 2>/dev/null || echo "[]")
     fi
 
     # Normalize values


### PR DESCRIPTION
## Summary

Improves the permission denial error message to handle both Bash and non-Bash tool denials.

The previous fix (#143, commit 627ad7d) only extracted `.tool_input.command`, which works for Bash denials but shows nothing for non-Bash tool denials like `AskUserQuestion` (which has no command field).

## Changes

- For **Bash denials**: shows `Bash(git commit -m ...)` with truncated command (60 chars, first line)
- For **non-Bash tool denials**: shows the tool name like `AskUserQuestion`

## Example Output

Before (with current fix):
```
🚫 Permission denied for 1 command(s): 
```

After (with this fix):
```
🚫 Permission denied for 1 command(s): AskUserQuestion
🚫 Permission denied for 2 command(s): Bash(git commit -m "..."), Bash(npm install)
```

## Test Plan

- [x] Tested with `AskUserQuestion` denial - correctly shows tool name
- [x] Tested with Bash command denial - correctly shows `Bash(command)`

Fixes the remaining gap from #143.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clarity of denied command information by preserving tool context and enhancing command formatting for better troubleshooting visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->