### PR TITLE
fix: auto-terminate tmux session when Ralph loop exits

### DIFF
--- a/ralph_loop.sh
+++ b/ralph_loop.sh
@@ -270,7 +270,12 @@ setup_tmux_session() {
         ralph_cmd="$ralph_cmd --auto-reset-circuit"
     fi
 
-    tmux send-keys -t "$session_name:${base_win}.0" "$ralph_cmd" Enter
+    # Chain tmux kill-session after the loop command so the entire tmux
+    # session is torn down when the Ralph loop exits (graceful completion,
+    # circuit breaker, error, or manual interrupt). Without this, the
+    # tail -f and ralph_monitor.sh panes keep the session alive forever.
+    # Issue: https://github.com/frankbria/ralph-claude-code/issues/176
+    tmux send-keys -t "$session_name:${base_win}.0" "$ralph_cmd; tmux kill-session -t $session_name 2>/dev/null" Enter
 
     # Focus on left pane (main ralph loop)
     tmux select-pane -t "$session_name:${base_win}.0"


### PR DESCRIPTION
## Summary

Fixes #176 — When running `ralph --monitor`, the tmux session persists indefinitely after the Ralph loop completes because `tail -f` (pane 1) and `ralph_monitor.sh` (pane 2) keep running even after the loop in pane 0 exits.

This chains a `tmux kill-session` command after the Ralph loop command in pane 0, so the entire tmux session is automatically torn down when the loop exits — whether via graceful completion, circuit breaker trip, error, or manual interrupt.

## Change

**`ralph_loop.sh` → `setup_tmux_session()`:**

```diff
- tmux send-keys -t "$session_name:${base_win}.0" "$ralph_cmd" Enter
+ tmux send-keys -t "$session_name:${base_win}.0" "$ralph_cmd; tmux kill-session -t $session_name 2>/dev/null" Enter
```

The `2>/dev/null` suppresses errors if the session was already killed (e.g., user manually closed it).

## Test plan

- [ ] Run `ralph --monitor` on a project with a small fix plan
- [ ] Wait for Ralph to complete (EXIT_SIGNAL=true)
- [ ] Verify tmux session is automatically terminated (no orphaned `tail -f` or monitor processes)
- [ ] Verify Ctrl+C during loop also tears down the session
- [ ] Verify `tmux ls` shows no leftover ralph sessions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session cleanup to ensure the application properly terminates in all scenarios, including normal completion, errors, and interrupts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->