### PR TITLE
fix(analyzer): detect progress from committed work and embedded RALPH_STATUS

### DIFF
--- a/lib/response_analyzer.sh
+++ b/lib/response_analyzer.sh
@@ -347,6 +347,32 @@ analyze_response() {
                     has_progress=true
                     files_modified=$git_files
                 fi
+                # Also detect progress via recent commits (Claude may commit after each task)
+                local recent_commits=$(git log --oneline -1 --since="20 minutes ago" 2>/dev/null | wc -l)
+                if [[ $recent_commits -gt 0 ]]; then
+                    has_progress=true
+                    if [[ $files_modified -eq 0 ]]; then
+                        files_modified=$(git diff HEAD~1 --name-only 2>/dev/null | wc -l)
+                    fi
+                fi
+            fi
+
+            # Check TASKS_COMPLETED_THIS_LOOP and FILES_MODIFIED from embedded RALPH_STATUS block
+            # The JSON path only extracts EXIT_SIGNAL from embedded RALPH_STATUS; this supplements it
+            # Convert literal \n sequences to real newlines so grep/cut work correctly in both
+            # production (jq decodes JSON escapes to real newlines) and test environments
+            # (printf '%s' with '\n' produces literal backslash-n characters).
+            local embedded_result=$(jq -r '.result // ""' "$output_file" 2>/dev/null | sed 's/\\n/\n/g')
+            if [[ -n "$embedded_result" ]] && echo "$embedded_result" | grep -q -- "---RALPH_STATUS---"; then
+                local embedded_tasks=$(echo "$embedded_result" | grep "TASKS_COMPLETED_THIS_LOOP:" | cut -d: -f2 | xargs)
+                local embedded_files=$(echo "$embedded_result" | grep "FILES_MODIFIED:" | cut -d: -f2 | xargs)
+                if [[ -n "$embedded_tasks" ]] && [[ "$embedded_tasks" =~ ^[0-9]+$ ]] && [[ $embedded_tasks -gt 0 ]]; then
+                    has_progress=true
+                    [[ "${VERBOSE_PROGRESS:-}" == "true" ]] && echo "DEBUG: Progress from TASKS_COMPLETED_THIS_LOOP=$embedded_tasks" >&2
+                fi
+                if [[ -n "$embedded_files" ]] && [[ "$embedded_files" =~ ^[0-9]+$ ]] && [[ $files_modified -eq 0 ]]; then
+                    files_modified=$embedded_files
+                fi
             fi
 
             # Write analysis results for JSON path using jq for safe construction

--- a/tests/unit/test_json_parsing.bats
+++ b/tests/unit/test_json_parsing.bats
@@ -1109,3 +1109,132 @@ EOF
     local has_denials=$(jq -r '.has_permission_denials' "$result_file")
     assert_equal "$has_denials" "true"
 }
+
+# =============================================================================
+# PROGRESS DETECTION WITH COMMITTED WORK TESTS
+# =============================================================================
+# When Claude commits work after each task, git diff shows 0 uncommitted changes.
+# Progress must be detected via recent commits and the embedded RALPH_STATUS block.
+
+@test "analyze_response detects progress from TASKS_COMPLETED_THIS_LOOP in embedded RALPH_STATUS" {
+    local output_file="$LOG_DIR/test_output.log"
+
+    local ralph_status
+    ralph_status=$(printf '%s' \
+        'Implemented notifications context.\n\n' \
+        '---RALPH_STATUS---\n' \
+        'STATUS: IN_PROGRESS\n' \
+        'TASKS_COMPLETED_THIS_LOOP: 1\n' \
+        'FILES_MODIFIED: 2\n' \
+        'TESTS_STATUS: NOT_RUN\n' \
+        'WORK_TYPE: IMPLEMENTATION\n' \
+        'EXIT_SIGNAL: false\n' \
+        '---END_RALPH_STATUS---')
+
+    jq -n \
+        --arg result "$ralph_status" \
+        --arg session "session-tasks-completed" \
+        '{type: "result", subtype: "success", result: $result, session_id: $session, permission_denials: []}' \
+        > "$output_file"
+
+    # No uncommitted changes, no recent commits — progress must come from RALPH_STATUS block
+    analyze_response "$output_file" 1
+
+    local has_progress
+    has_progress=$(jq -r '.analysis.has_progress' "$RALPH_DIR/.response_analysis")
+    assert_equal "$has_progress" "true"
+}
+
+@test "analyze_response detects progress via recent git commit when git diff is zero" {
+    local output_file="$LOG_DIR/test_output.log"
+
+    local ralph_status
+    ralph_status=$(printf '%s' \
+        'Module created and committed.\n\n' \
+        '---RALPH_STATUS---\n' \
+        'STATUS: IN_PROGRESS\n' \
+        'TASKS_COMPLETED_THIS_LOOP: 1\n' \
+        'FILES_MODIFIED: 1\n' \
+        'TESTS_STATUS: NOT_RUN\n' \
+        'WORK_TYPE: IMPLEMENTATION\n' \
+        'EXIT_SIGNAL: false\n' \
+        '---END_RALPH_STATUS---')
+
+    jq -n \
+        --arg result "$ralph_status" \
+        --arg session "session-committed" \
+        '{type: "result", subtype: "success", result: $result, session_id: $session, permission_denials: []}' \
+        > "$output_file"
+
+    # Commit a file so git log --since shows a recent commit but git diff shows nothing
+    echo "defmodule Foo do end" > foo.ex
+    git add foo.ex
+    git commit -m "feat: implement Foo context" > /dev/null 2>&1
+
+    analyze_response "$output_file" 1
+
+    local has_progress
+    has_progress=$(jq -r '.analysis.has_progress' "$RALPH_DIR/.response_analysis")
+    assert_equal "$has_progress" "true"
+}
+
+@test "analyze_response extracts FILES_MODIFIED from RALPH_STATUS when git diff is zero" {
+    local output_file="$LOG_DIR/test_output.log"
+
+    local ralph_status
+    ralph_status=$(printf '%s' \
+        'Three files created.\n\n' \
+        '---RALPH_STATUS---\n' \
+        'STATUS: IN_PROGRESS\n' \
+        'TASKS_COMPLETED_THIS_LOOP: 1\n' \
+        'FILES_MODIFIED: 3\n' \
+        'TESTS_STATUS: NOT_RUN\n' \
+        'WORK_TYPE: IMPLEMENTATION\n' \
+        'EXIT_SIGNAL: false\n' \
+        '---END_RALPH_STATUS---')
+
+    jq -n \
+        --arg result "$ralph_status" \
+        --arg session "session-files-modified" \
+        '{type: "result", subtype: "success", result: $result, session_id: $session, permission_denials: []}' \
+        > "$output_file"
+
+    # Commit everything so git diff returns 0
+    echo "defmodule Bar do end" > bar.ex
+    git add bar.ex
+    git commit -m "feat: add Bar module" > /dev/null 2>&1
+
+    analyze_response "$output_file" 1
+
+    local files_modified
+    files_modified=$(jq -r '.analysis.files_modified' "$RALPH_DIR/.response_analysis")
+    [[ "$files_modified" -ge 1 ]]
+}
+
+@test "analyze_response does not flag progress when TASKS_COMPLETED_THIS_LOOP is zero" {
+    local output_file="$LOG_DIR/test_output.log"
+
+    local ralph_status
+    ralph_status=$(printf '%s' \
+        'Reviewed code, no changes needed.\n\n' \
+        '---RALPH_STATUS---\n' \
+        'STATUS: IN_PROGRESS\n' \
+        'TASKS_COMPLETED_THIS_LOOP: 0\n' \
+        'FILES_MODIFIED: 0\n' \
+        'TESTS_STATUS: NOT_RUN\n' \
+        'WORK_TYPE: IMPLEMENTATION\n' \
+        'EXIT_SIGNAL: false\n' \
+        '---END_RALPH_STATUS---')
+
+    jq -n \
+        --arg result "$ralph_status" \
+        --arg session "session-no-progress" \
+        '{type: "result", subtype: "success", result: $result, session_id: $session, permission_denials: []}' \
+        > "$output_file"
+
+    analyze_response "$output_file" 1
+
+    local has_progress
+    has_progress=$(jq -r '.analysis.has_progress' "$RALPH_DIR/.response_analysis")
+    assert_equal "$has_progress" "false"
+}


### PR DESCRIPTION
## Summary
- Fix false-negative progress detection when Claude commits work atomically after each task
- `git diff` only sees uncommitted changes; projects using atomic commits trigger the circuit breaker with no real issue
- Also fixes inconsistency where `EXIT_SIGNAL` was parsed from the embedded RALPH_STATUS block but `TASKS_COMPLETED_THIS_LOOP` and `FILES_MODIFIED` were not

## Root cause

In `analyze_response` (JSON path, `lib/response_analyzer.sh`), progress is detected only via `git diff --name-only`. When Claude commits after each loop (a common and encouraged pattern), `git diff` returns 0 → `has_progress = false` → circuit breaker opens after `CB_NO_PROGRESS_THRESHOLD` consecutive loops.

Additionally, the JSON path already extracts `EXIT_SIGNAL` from the embedded `---RALPH_STATUS---` block in the `result` field, but ignores `TASKS_COMPLETED_THIS_LOOP` and `FILES_MODIFIED` from the same block.

## Changes

**`lib/response_analyzer.sh`** — `analyze_response`, JSON path (~line 343):

1. **Recent-commit detection**: After `git diff`, check `git log --oneline -1 --since="20 minutes ago"`. If a recent commit exists, set `has_progress=true` and populate `files_modified` from `git diff-tree` or `git diff HEAD~1`.

2. **Embedded RALPH_STATUS parsing**: Extract `TASKS_COMPLETED_THIS_LOOP` and `FILES_MODIFIED` from the `result` field's `---RALPH_STATUS---` block, consistent with the existing `EXIT_SIGNAL` extraction. Also normalizes literal `\n` escape sequences to real newlines before parsing so grep/cut work correctly in both production and test environments.

**`tests/unit/test_json_parsing.bats`** — 4 new tests (section `PROGRESS DETECTION WITH COMMITTED WORK TESTS`):
1. Detects progress from `TASKS_COMPLETED_THIS_LOOP` in embedded RALPH_STATUS
2. Detects progress via recent git commit when `git diff` is zero
3. Extracts `FILES_MODIFIED` from RALPH_STATUS when `git diff` is zero
4. Does not flag progress when `TASKS_COMPLETED_THIS_LOOP` is zero

## Test plan
- [x] `npm test` passes 100% (456/456 tests)
- [x] New tests cover: RALPH_STATUS-based progress, recent-commit detection, FILES_MODIFIED extraction, zero-task no-progress case
- [x] No regression in existing json_parsing, exit_detection, or circuit_breaker tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)