### PR TITLE
fix(enable): prevent wizard from exiting on non-fatal source checks (#193)

### DIFF
--- a/ralph_enable.sh
+++ b/ralph_enable.sh
@@ -237,12 +237,12 @@ phase_environment_detection() {
     echo "Available task sources:"
     if [[ "$DETECTED_BEADS_AVAILABLE" == "true" ]]; then
         local beads_count
-        beads_count=$(get_beads_count)
+        beads_count=$(get_beads_count 2>/dev/null || echo "0")
         print_detection_result "beads" "$beads_count open issues" "true"
     fi
     if [[ "$DETECTED_GITHUB_AVAILABLE" == "true" ]]; then
         local gh_count
-        gh_count=$(get_github_issue_count)
+        gh_count=$(get_github_issue_count 2>/dev/null || echo "0")
         print_detection_result "GitHub Issues" "$gh_count open issues" "true"
     fi
     if [[ ${#DETECTED_PRD_FILES[@]} -gt 0 ]]; then
@@ -289,14 +289,14 @@ phase_task_source_selection() {
 
     if [[ "$DETECTED_BEADS_AVAILABLE" == "true" ]]; then
         local beads_count
-        beads_count=$(get_beads_count)
+        beads_count=$(get_beads_count 2>/dev/null || echo "0")
         options+=("Import from beads ($beads_count issues)")
         option_keys+=("beads")
     fi
 
     if [[ "$DETECTED_GITHUB_AVAILABLE" == "true" ]]; then
         local gh_count
-        gh_count=$(get_github_issue_count)
+        gh_count=$(get_github_issue_count 2>/dev/null || echo "0")
         options+=("Import from GitHub Issues ($gh_count issues)")
         option_keys+=("github")
     fi


### PR DESCRIPTION
## Summary
- Prevents `ralph-enable` from exiting early under `set -e` when task source counters return non-zero.
- Adds safe fallbacks for `get_beads_count` and `get_github_issue_count` in interactive flow.
- Keeps the setup wizard running and defaults counts to 0 when those integrations are unavailable.

## Test plan
- Run `ralph-enable` in a project without authenticated `gh` and verify wizard completes.
- Run `ralph-enable` with available integrations and verify counts still display.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling for data retrieval operations by implementing fallback mechanisms that default to zero values when retrieval fails, preventing system failures during environment detection and task source selection phases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->