### PR TITLE
fix(tests): use UTC in get_past_timestamp to fix cooldown tests on non-UTC systems

### DIFF
--- a/tests/unit/test_circuit_breaker_recovery.bats
+++ b/tests/unit/test_circuit_breaker_recovery.bats
@@ -230,7 +230,7 @@ get_past_timestamp() {
     if future_timestamp=$(date -d "@$future_epoch" -Iseconds 2>/dev/null); then
         : # success
     else
-        future_timestamp=$(date -r "$future_epoch" +"%Y-%m-%dT%H:%M:%S+00:00" 2>/dev/null || skip "Cannot create future timestamp")
+        future_timestamp=$(date -u -r "$future_epoch" +"%Y-%m-%dT%H:%M:%S+00:00" 2>/dev/null || skip "Cannot create future timestamp")
     fi
     create_open_state "$future_timestamp"
     export CB_COOLDOWN_MINUTES=30


### PR DESCRIPTION
## Summary

Fix cooldown timer tests that fail on non-UTC systems (e.g., JST, EST) by using UTC in `get_past_timestamp`.

The `get_past_timestamp` helper generates ISO timestamps for testing cooldown expiration. Without explicit UTC, the timestamp uses the local timezone, but `parse_iso_to_epoch` expects UTC. This mismatch causes cooldown tests to incorrectly pass or fail depending on the system timezone.

## Changes
- `tests/unit/test_circuit_breaker_recovery.bats` — add `-u` flag to `date` command in `get_past_timestamp`

## Test plan
- [ ] Cooldown timer tests pass on UTC systems
- [ ] Cooldown timer tests pass on non-UTC systems (e.g., TZ=Asia/Tokyo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Ensures timestamps produced by fallback routines are consistently formatted in UTC for both past and future timestamps, preventing inconsistent timezone display when system date behavior varies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->