### PR TITLE
feat(monitor): add KEEP_MONITOR_AFTER_EXIT option

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,7 @@ CLAUDE_CODE_CMD="claude"
 MAX_CALLS_PER_HOUR=100
 CLAUDE_TIMEOUT_MINUTES=15
 CLAUDE_OUTPUT_FORMAT="json"
+KEEP_MONITOR_AFTER_EXIT=false  # Keep tmux monitor panes alive after loop exits
 
 # Tool permissions
 ALLOWED_TOOLS="Write,Read,Edit,Bash(git *),Bash(npm *),Bash(pytest)"

--- a/lib/enable_core.sh
+++ b/lib/enable_core.sh
@@ -708,6 +708,7 @@ CLAUDE_CODE_CMD="${claude_cmd}"
 MAX_CALLS_PER_HOUR=100
 CLAUDE_TIMEOUT_MINUTES=15
 CLAUDE_OUTPUT_FORMAT="json"
+KEEP_MONITOR_AFTER_EXIT=false  # Keep tmux monitor panes alive after loop exits
 
 # Tool permissions
 # Comma-separated list of allowed tools

--- a/ralph_loop.sh
+++ b/ralph_loop.sh
@@ -92,9 +92,10 @@ VALID_TOOL_PATTERNS=(
 
 # Exit detection configuration
 EXIT_SIGNALS_FILE="$RALPH_DIR/.exit_signals"
-RESPONSE_ANALYSIS_FILE="$RALPH_DIR/.response_analysis"
-MAX_CONSECUTIVE_TEST_LOOPS=3
+KEEP_MONITOR_AFTER_EXIT="${KEEP_MONITOR_AFTER_EXIT:-false}"
 MAX_CONSECUTIVE_DONE_SIGNALS=2
+MAX_CONSECUTIVE_TEST_LOOPS=3
+RESPONSE_ANALYSIS_FILE="$RALPH_DIR/.response_analysis"
 TEST_PERCENTAGE_THRESHOLD=30  # If more than 30% of recent loops are test-only, flag it
 
 # .ralphrc configuration file
@@ -333,12 +334,14 @@ setup_tmux_session() {
         ralph_cmd="$ralph_cmd --auto-reset-circuit"
     fi
 
-    # Chain tmux kill-session after the loop command so the entire tmux
-    # session is torn down when the Ralph loop exits (graceful completion,
-    # circuit breaker, error, or manual interrupt). Without this, the
-    # tail -f and ralph_monitor.sh panes keep the session alive forever.
-    # Issue: https://github.com/frankbria/ralph-claude-code/issues/176
-    tmux send-keys -t "$session_name:${base_win}.0" "$ralph_cmd; tmux kill-session -t $session_name 2>/dev/null" Enter
+    # When the Ralph loop exits (graceful completion, circuit breaker,
+    # error, or manual interrupt), either tear down the tmux session
+    # (default, Issue #176) or keep monitor panes alive (Issue #213).
+    if [[ "$KEEP_MONITOR_AFTER_EXIT" == "true" ]]; then
+        tmux send-keys -t "$session_name:${base_win}.0" "$ralph_cmd; echo '[Ralph exited. Press Ctrl+C or type exit to close.]'" Enter
+    else
+        tmux send-keys -t "$session_name:${base_win}.0" "$ralph_cmd; tmux kill-session -t $session_name 2>/dev/null" Enter
+    fi
 
     # Focus on left pane (main ralph loop)
     tmux select-pane -t "$session_name:${base_win}.0"
@@ -1932,6 +1935,9 @@ done
 
 # Only execute when run directly, not when sourced
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    # Load .ralphrc early so setup_tmux_session can read KEEP_MONITOR_AFTER_EXIT
+    load_ralphrc
+
     # If tmux mode requested, set it up
     if [[ "$USE_TMUX" == "true" ]]; then
         check_tmux_available


### PR DESCRIPTION
## Summary

- Add `KEEP_MONITOR_AFTER_EXIT` config option (default: `false`) to `.ralphrc`
- When `true`, tmux monitor panes (`tail -f` + status dashboard) stay alive after Ralph loop exits
- Default behavior (auto-terminate per #176) is preserved

## Changes

**`ralph_loop.sh`** — 2 changes:
1. New variable `KEEP_MONITOR_AFTER_EXIT="${KEEP_MONITOR_AFTER_EXIT:-false}"` in config section
2. Conditional in `setup_tmux_session()`: skip `tmux kill-session` when option is enabled

## Usage

```bash
# .ralphrc
KEEP_MONITOR_AFTER_EXIT=true
```

## Test plan

- [ ] Run `ralph --monitor` with `KEEP_MONITOR_AFTER_EXIT=false` (default) — verify session auto-terminates on exit
- [ ] Run `ralph --monitor` with `KEEP_MONITOR_AFTER_EXIT=true` — verify monitor panes stay alive after loop exits
- [ ] Verify exit message `[Ralph exited. Press Ctrl+C or type exit to close.]` appears in pane 0

Closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added KEEP_MONITOR_AFTER_EXIT configuration option to control whether tmux monitor panes persist after Ralph loop completion (default: disabled).
  * Added MAX_CONSECUTIVE_TEST_LOOPS configuration option for improved exit-detection behavior.

* **Documentation**
  * Updated .ralphrc configuration example with new options, defaults, and descriptions for monitoring behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->