### PR TITLE
fix(live): show sub-agent progress in tmux live output

### DIFF
--- a/ralph_loop.sh
+++ b/ralph_loop.sh
@@ -1195,7 +1195,7 @@ execute_claude_code() {
         # These are required for stream-json to work properly
         LIVE_CMD_ARGS+=("--verbose" "--include-partial-messages")
 
-        # jq filter: show text + tool names + newlines for readability
+        # jq filter: show text + tool names + sub-agent progress + newlines for readability
         local jq_filter='
             if .type == "stream_event" then
                 if .event.type == "content_block_delta" and .event.delta.type == "text_delta" then
@@ -1207,6 +1207,10 @@ execute_claude_code() {
                 else
                     empty
                 end
+            elif .type == "system" and .subtype == "task_started" then
+                "\n\n🚀 Agent: " + (.description // "started") + "\n"
+            elif .type == "system" and .subtype == "task_progress" then
+                "📌 " + (.description // "working...") + "\n"
             else
                 empty
             end'


### PR DESCRIPTION
## Problem

When Claude dispatches a sub-agent via the `Agent` tool, the tmux live output pane (`tail -f live.log`) freezes — no updates for the entire duration of the sub-agent's execution (often 15-50+ minutes).

**Root cause:** The jq filter in live mode only handles `type: "stream_event"` entries. Sub-agent progress is reported as `type: "system"` with `subtype: "task_started"` / `subtype: "task_progress"`, which the filter drops via `else empty`.

## Fix

Add two conditions to the jq filter to surface sub-agent events:

- `task_started` → `🚀 Agent: <description>`
- `task_progress` → `📌 <description>`

**Before:** tmux pane shows nothing after `⚡ [Agent]`
**After:**
```
⚡ [Agent]

🚀 Agent: MARS-3594 rework: expand rate limit monitoring
📌 Running Check worktree in listenhub-api-server
📌 Reading src/lib/ratelimt.ts
📌 Running Run full lint
📌 Running Commit the changes
📌 Running Verify commit state
```

## Test plan

- [x] Tested against real stream-json log (1033 lines) — all 35 sub-agent progress events now visible
- [x] Verified no impact on normal (non-agent) text streaming
- [x] Deployed to `~/.ralph/ralph_loop.sh` and confirmed working in live tmux session

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for task_started and task_progress system events in streaming execution. These events now generate human-readable output during live stream operations, providing enhanced visibility into task initialization and real-time progress updates. Observable output is expanded while preserving all existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->