### PR TITLE
fix(monitor): suppress I/O errors on broken tmux pty (#188)

### DIFF
--- a/ralph_loop.sh
+++ b/ralph_loop.sh
@@ -410,8 +410,9 @@ log_status() {
     esac
     
     # Write to stderr so log messages don't interfere with function return values
-    echo -e "${color}[$timestamp] [$level] $message${NC}" >&2
-    echo "[$timestamp] [$level] $message" >> "$LOG_DIR/ralph.log"
+    # 2>/dev/null suppresses "Input/output error" when tmux pty is broken (Issue #188)
+    echo -e "${color}[$timestamp] [$level] $message${NC}" >&2 2>/dev/null
+    echo "[$timestamp] [$level] $message" >> "$LOG_DIR/ralph.log" 2>/dev/null
 }
 
 # Update status JSON for external monitoring

--- a/ralph_monitor.sh
+++ b/ralph_monitor.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 # Ralph Status Monitor - Live terminal dashboard for the Ralph loop
-set -e
+# Note: set -e intentionally removed — the monitor is a display-only loop
+# that must be resilient to transient write errors on broken tmux ptys (Issue #188)
 
 STATUS_FILE=".ralph/status.json"
 LOG_FILE=".ralph/logs/ralph.log"

--- a/tests/unit/test_cli_modern.bats
+++ b/tests/unit/test_cli_modern.bats
@@ -1766,3 +1766,36 @@ EOF
     run bash -c "sed -n '/Layer 1.*Timeout guard/,/fi  # end timeout/p' '$script' | grep -q 'rm -f.*RESPONSE_ANALYSIS_FILE'"
     assert_success
 }
+
+# --- Monitor I/O Error Fix (Issue #188) ---
+
+@test "log_status stderr write is guarded against I/O errors" {
+    # When tmux pty becomes unavailable, echo >&2 fails with "Input/output error"
+    # The stderr write must have 2>/dev/null to suppress this
+    local script="${BATS_TEST_DIRNAME}/../../ralph_loop.sh"
+
+    # Extract log_status function and check stderr write has error suppression
+    local func_body
+    func_body=$(sed -n '/^log_status()/,/^}/p' "$script")
+
+    echo "$func_body" | grep '>&2' | grep -q '2>/dev/null'
+}
+
+@test "log_status log-file write is guarded against errors" {
+    # The log-file append should also be guarded for robustness
+    local script="${BATS_TEST_DIRNAME}/../../ralph_loop.sh"
+
+    local func_body
+    func_body=$(sed -n '/^log_status()/,/^}/p' "$script")
+
+    echo "$func_body" | grep 'ralph.log' | grep -q '2>/dev/null'
+}
+
+@test "ralph_monitor.sh does not use set -e" {
+    # set -e in the monitor causes crashes when echo fails on broken pty
+    local script="${BATS_TEST_DIRNAME}/../../ralph_monitor.sh"
+
+    # Should NOT have set -e
+    run grep -c '^set -e' "$script"
+    [[ "$output" == "0" ]]
+}


### PR DESCRIPTION
## Summary
Fixes #188: ralph monitor gives input/output error

When the tmux pane's pty becomes unavailable (pane closed, session killed), `echo >&2` in `log_status` fails with `Input/output error`, crashing the loop.

- Guard stderr write in `log_status()` with `2>/dev/null`
- Guard log-file write in `log_status()` with `2>/dev/null`
- Remove `set -e` from `ralph_monitor.sh` — display-only loop must tolerate write errors

## Test Plan
- [x] 3 new tests (TDD approach)
- [x] All 587 tests passing, 0 failures

Closes #188

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved runtime stability by gracefully handling transient I/O errors in logging and monitoring functions, preventing script interruptions in terminal sessions.

* **Tests**
  * Added test coverage for error handling behavior in logging operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->