### PR TITLE
feat: add block-no-verify PreToolUse hook to protect git hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,12 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          { "type": "command", "command": "npx --yes block-no-verify@1.1.2" }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Closes #221. Adds .claude/settings.json with a PreToolUse hook running npx block-no-verify@1.1.2 before every Bash command. This prevents Claude Code from using the bypass flag with git during Ralph autonomous loops. Since Ralph already has .claude/ for memory, this is a minimal addition that protects all users. See https://github.com/tupe12334/block-no-verify for details. Disclosure: I am the author of block-no-verify.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added development environment configuration to optimize internal tool usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->