### PR TITLE
feat(loop): add --dry-run mode to simulate loop without API calls (#19)

### DIFF
--- a/ralph_loop.sh
+++ b/ralph_loop.sh
@@ -1245,8 +1245,7 @@ execute_claude_code() {
     local timestamp=$(date '+%Y-%m-%d_%H-%M-%S')
     local output_file="$LOG_DIR/claude_output_${timestamp}.log"
     local loop_count=$1
-    local calls_made
-    calls_made=$(increment_call_counter)
+    local calls_made=0
 
     # Fix #141: Capture git HEAD SHA at loop start to detect commits as progress
     # Store in file for access by progress detection after Claude execution
@@ -1255,10 +1254,6 @@ execute_claude_code() {
         loop_start_sha=$(git rev-parse HEAD 2>/dev/null || echo "")
     fi
     echo "$loop_start_sha" > "$RALPH_DIR/.loop_start_sha"
-
-    log_status "LOOP" "Executing Claude Code (Call $calls_made/$MAX_CALLS_PER_HOUR)"
-    local timeout_seconds=$((CLAUDE_TIMEOUT_MINUTES * 60))
-    log_status "INFO" "⏳ Starting Claude Code execution... (timeout: ${CLAUDE_TIMEOUT_MINUTES}m)"
 
     # Dry-run mode: simulate execution without calling Claude API
     if [[ "$DRY_RUN" == "true" ]]; then
@@ -1270,6 +1265,11 @@ execute_claude_code() {
         log_status "INFO" "[DRY RUN] Simulation complete — no API call was made"
         return 0
     fi
+
+    calls_made=$(increment_call_counter)
+    log_status "LOOP" "Executing Claude Code (Call $calls_made/$MAX_CALLS_PER_HOUR)"
+    local timeout_seconds=$((CLAUDE_TIMEOUT_MINUTES * 60))
+    log_status "INFO" "⏳ Starting Claude Code execution... (timeout: ${CLAUDE_TIMEOUT_MINUTES}m)"
 
     # Build loop context (always, regardless of session mode)
     local loop_context=""

--- a/tests/unit/test_dry_run.bats
+++ b/tests/unit/test_dry_run.bats
@@ -27,6 +27,7 @@ setup() {
     export CLAUDE_CODE_CMD="claude"
     export CLAUDE_OUTPUT_FORMAT="json"
     export CLAUDE_TIMEOUT_MINUTES="15"
+    export MAX_CALLS_PER_HOUR="100"
 
     mkdir -p "$LOG_DIR"
 
@@ -34,33 +35,6 @@ setup() {
     echo "0" > "$CALL_COUNT_FILE"
     echo "$(date +%Y%m%d%H)" > "$TIMESTAMP_FILE"
     echo '{"test_only_loops": [], "done_signals": [], "completion_indicators": []}' > "$EXIT_SIGNALS_FILE"
-
-    # Color variables expected by log_status
-    RED='\033[0;31m'
-    GREEN='\033[0;32m'
-    YELLOW='\033[1;33m'
-    BLUE='\033[0;34m'
-    PURPLE='\033[0;35m'
-    NC='\033[0m'
-
-    log_status() {
-        local level=$1
-        local message=$2
-        echo "[$level] $message"
-    }
-
-    increment_call_counter() {
-        local count
-        count=$(cat "$CALL_COUNT_FILE" 2>/dev/null || echo 0)
-        count=$((count + 1))
-        echo "$count" > "$CALL_COUNT_FILE"
-        echo "$count"
-    }
-
-    build_loop_context() { echo ""; }
-    init_claude_session() { echo ""; }
-    build_claude_command() { return 0; }
-    portable_timeout() { shift; "$@"; }
 }
 
 teardown() {
@@ -89,33 +63,14 @@ teardown() {
 }
 
 @test "--dry-run mode skips actual Claude execution and logs what would run" {
-    # Define execute_claude_code inline to test dry-run behavior in isolation
-    execute_claude_code() {
-        local loop_count=$1
-        local calls_made
-        calls_made=$(increment_call_counter)
+    # Source the real script to exercise the actual execute_claude_code implementation
+    # The guard `if [[ "${BASH_SOURCE[0]}" == "${0}" ]]` prevents main() from running
+    source "$RALPH_SCRIPT"
 
-        log_status "LOOP" "Executing Claude Code (Call $calls_made/$MAX_CALLS_PER_HOUR)"
-        local timeout_seconds=$((CLAUDE_TIMEOUT_MINUTES * 60))
-        log_status "INFO" "Starting Claude Code execution... (timeout: ${CLAUDE_TIMEOUT_MINUTES}m)"
+    # Override build_loop_context to keep the test fast (no file I/O needed)
+    build_loop_context() { echo ""; }
 
-        if [[ "$DRY_RUN" == "true" ]]; then
-            log_status "INFO" "[DRY RUN] Skipping actual Claude Code execution"
-            log_status "INFO" "[DRY RUN] Would execute: $CLAUDE_CODE_CMD with prompt: $PROMPT_FILE"
-            log_status "INFO" "[DRY RUN] Output format: $CLAUDE_OUTPUT_FORMAT, Timeout: ${CLAUDE_TIMEOUT_MINUTES}m"
-            log_status "INFO" "[DRY RUN] Simulating 2-second execution delay..."
-            sleep 2
-            log_status "INFO" "[DRY RUN] Simulation complete — no API call was made"
-            return 0
-        fi
-
-        # In non-dry-run this would call claude; fail in test if reached
-        echo "ERROR: real claude execution attempted in test" >&2
-        return 1
-    }
-
-    DRY_RUN=true
-    MAX_CALLS_PER_HOUR=100
+    export DRY_RUN=true
 
     run execute_claude_code 1
 
@@ -125,11 +80,18 @@ teardown() {
     [[ "$output" == *"no API call was made"* ]]
 }
 
-@test "--dry-run mode does not attempt real execution (no api call on second call either)" {
-    # Verify the script flag sets DRY_RUN and help shows the flag
-    run bash "$RALPH_SCRIPT" --dry-run --help
-    assert_success
-    # Flag accepted and help displayed — confirms parsing works
-    [[ "$output" == *"dry-run"* ]]
-    [[ "$output" == *"Simulate loop execution"* ]]
+@test "--dry-run mode does not increment the API call counter" {
+    # Source the real script
+    source "$RALPH_SCRIPT"
+
+    build_loop_context() { echo ""; }
+
+    export DRY_RUN=true
+    echo "0" > "$CALL_COUNT_FILE"
+
+    execute_claude_code 1
+
+    local counter
+    counter=$(cat "$CALL_COUNT_FILE")
+    [[ "$counter" == "0" ]]
 }


### PR DESCRIPTION
## Summary

- Adds `--dry-run` CLI flag to simulate loop execution without making actual Claude Code API calls
- Inserts dry-run early-exit in `execute_claude_code()` with clear `[DRY RUN]` log messages showing what would be executed
- Adds `DRY_RUN=false` configuration variable (overridable via env or `.ralphrc`)
- Updates help text with dry-run description

## Test plan

- [ ] Run `npm test` — all 629 tests pass, 0 failures
- [ ] New `tests/unit/test_dry_run.bats` with 4 TDD tests covers: flag acceptance, help text, execution skip, logging output
- [ ] `ralph --dry-run --help` shows `--dry-run` in options list
- [ ] `ralph --dry-run` in a project directory prints `[DRY RUN]` logs and exits without calling Claude

Closes #19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--dry-run` command-line option to preview intended execution with simulated timing and logging; prevents actual external calls and leaves invocation counters unchanged.

* **Tests**
  * Added tests covering dry-run acceptance and help text, simulated execution logging, and verification that real execution paths and call counts are not performed/modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->