### PR TITLE
feat(notifications): add cross-platform desktop notification system (#22)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,7 +233,7 @@ CLAUDE_MIN_VERSION="2.0.76"           # Minimum Claude CLI version
 CLAUDE_AUTO_UPDATE=true               # Auto-update Claude CLI at startup (set false for air-gapped environments)
 CLAUDE_MODEL=""                       # Model override (e.g. claude-sonnet-4-6); empty = CLI default (Issue #228)
 CLAUDE_EFFORT=""                      # Effort level override (e.g. high, low); empty = CLI default (Issue #228)
-ENABLE_NOTIFICATIONS=false            # Desktop notifications (Issue #22); set true or use --notify flag
+ENABLE_NOTIFICATIONS=false            # Desktop notifications (Issue #22); set true or use --notify / -n flag
 ```
 
 **Auto-Update Configuration:**

--- a/ralph_loop.sh
+++ b/ralph_loop.sh
@@ -71,7 +71,7 @@ CLAUDE_MODEL="${CLAUDE_MODEL:-}"                 # Model override (e.g. claude-s
 CLAUDE_EFFORT="${CLAUDE_EFFORT:-}"               # Effort level override (e.g. high, low); empty = CLI default
 RALPH_SHELL_INIT_FILE="${RALPH_SHELL_INIT_FILE:-}" # Shell init file to source before running claude (e.g. ~/.zshrc)
 DRY_RUN="${DRY_RUN:-false}"                      # Simulate loop without making actual Claude API calls
-ENABLE_NOTIFICATIONS="${ENABLE_NOTIFICATIONS:-false}"  # Enable desktop notifications (requires --notify flag)
+ENABLE_NOTIFICATIONS="${ENABLE_NOTIFICATIONS:-false}"  # Enable desktop notifications; set true or use --notify flag
 
 # Session management configuration (Phase 1.2)
 # Note: SESSION_EXPIRATION_SECONDS is defined in lib/response_analyzer.sh (86400 = 24 hours)
@@ -471,12 +471,16 @@ send_notification() {
 
     [[ "$ENABLE_NOTIFICATIONS" == "true" ]] || return 0
 
+    # Strip double quotes to prevent osascript AppleScript string breakage
+    local safe_title="${title//\"/}"
+    local safe_message="${message//\"/}"
+
     if command -v osascript &>/dev/null; then
-        osascript -e "display notification \"$message\" with title \"$title\"" 2>/dev/null || true
+        osascript -e "display notification \"$safe_message\" with title \"$safe_title\"" 2>/dev/null || true
     elif command -v notify-send &>/dev/null; then
         notify-send "$title" "$message" 2>/dev/null || true
     else
-        echo -e "\a"
+        printf '\a\n'
     fi
 }
 

--- a/tests/unit/test_notifications.bats
+++ b/tests/unit/test_notifications.bats
@@ -32,7 +32,11 @@ teardown() {
 
 # ── Inline send_notification() function under test ───────────────────────────
 # This mirrors the implementation in ralph_loop.sh.
-# Defined here so tests can manipulate PATH and ENABLE_NOTIFICATIONS directly.
+# Defined here so tests can manipulate PATH and ENABLE_NOTIFICATIONS directly
+# without sourcing the full 2300-line script.
+#
+# IMPORTANT: If send_notification() in ralph_loop.sh changes, this copy MUST
+# be updated to match, or these tests will test stale logic.
 
 send_notification() {
     local title="$1"
@@ -40,12 +44,15 @@ send_notification() {
 
     [[ "$ENABLE_NOTIFICATIONS" == "true" ]] || return 0
 
+    local safe_title="${title//\"/}"
+    local safe_message="${message//\"/}"
+
     if command -v osascript &>/dev/null; then
-        osascript -e "display notification \"$message\" with title \"$title\"" 2>/dev/null || true
+        osascript -e "display notification \"$safe_message\" with title \"$safe_title\"" 2>/dev/null || true
     elif command -v notify-send &>/dev/null; then
         notify-send "$title" "$message" 2>/dev/null || true
     else
-        echo -e "\a"
+        printf '\a\n'
     fi
 }
 
@@ -124,12 +131,15 @@ STUB
 @test "send_notification uses osascript on macOS when available" {
     export ENABLE_NOTIFICATIONS=true
 
-    local bin_dir
-    bin_dir=$(make_mock_bin "osascript" "$OSASCRIPT_CALL_FILE")
-    # Ensure notify-send is NOT available
-    make_mock_bin "notify-send" "$NOTIFY_SEND_CALL_FILE" > /dev/null
-    # Only put osascript in PATH
-    export PATH="$bin_dir:$(echo "$PATH" | tr ':' '\n' | grep -v "mock_bin" | tr '\n' ':' | sed 's/:$//')"
+    # Put osascript in its own directory — notify-send is absent from PATH entirely
+    local osx_bin="$TEST_TEMP_DIR/osx_bin"
+    mkdir -p "$osx_bin"
+    cat > "$osx_bin/osascript" << EOF
+#!/bin/bash
+echo "\$@" > "$OSASCRIPT_CALL_FILE"
+EOF
+    chmod +x "$osx_bin/osascript"
+    export PATH="$osx_bin:/usr/bin:/bin"
 
     send_notification "Ralph - Test" "Loop completed"
 


### PR DESCRIPTION
## Summary

- Adds `send_notification()` to `ralph_loop.sh` with cross-platform support: macOS (`osascript`), Linux (`notify-send`), terminal bell fallback
- Disabled by default; enabled with `--notify` / `-n` CLI flag or `ENABLE_NOTIFICATIONS=true` in `.ralphrc`
- Fires on 6 key events: rate limit, API 5-hour limit, circuit breaker open, graceful exit, execution failure, loop completion
- Errors are suppressed so notification failures never break the loop

## Test plan

- [ ] `bats tests/unit/test_notifications.bats` — all 5 tests pass
- [ ] `npm test` — all 638 tests pass (0 regressions)
- [ ] `ralph --notify --help` shows `-n, --notify` in options list
- [ ] Manually verify: `ENABLE_NOTIFICATIONS=true` triggers bell on loop events (no osascript/notify-send in WSL)

Closes #22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Desktop notifications for key loop events (off by default)
  * New CLI flag to enable notifications (-n / --notify)
  * Cross-platform notification handling with fallbacks for macOS, Linux, and terminals

* **Tests**
  * Added unit tests covering notification behavior: disabled state, flag handling, macOS/Linux paths, and fallback behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->