### PR TITLE
feat(loop): backup and rollback system (#23)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,6 +234,7 @@ CLAUDE_AUTO_UPDATE=true               # Auto-update Claude CLI at startup (set f
 CLAUDE_MODEL=""                       # Model override (e.g. claude-sonnet-4-6); empty = CLI default (Issue #228)
 CLAUDE_EFFORT=""                      # Effort level override (e.g. high, low); empty = CLI default (Issue #228)
 ENABLE_NOTIFICATIONS=false            # Desktop notifications (Issue #22); set true or use --notify / -n flag
+ENABLE_BACKUP=false                   # Automatic git backup branches (Issue #23); set true or use --backup / -b flag
 ```
 
 **Auto-Update Configuration:**
@@ -578,7 +579,7 @@ Ralph uses a multi-layered strategy to prevent Claude from accidentally deleting
 
 ## Test Suite
 
-### Test Files (477 unit tests + integration; see `npm test` for current count)
+### Test Files (483 unit tests + integration; see `npm test` for current count)
 
 | File | Tests | Description |
 |------|-------|-------------|
@@ -603,6 +604,7 @@ Ralph uses a multi-layered strategy to prevent Claude from accidentally deleting
 | `test_log_rotation.bats` | 5 | Log rotation (rotate_logs in lib/log_utils.sh): threshold, shift order, content assertions, missing file, stat fallback (Issue #18) |
 | `test_metrics_tracking.bats` | 4 | Metrics tracking: track_metrics() JSON Lines format, per-loop append, ralph-stats output, print_metrics_summary (Issue #21) |
 | `test_notifications.bats` | 5 | Desktop notifications: send_notification() cross-platform (macOS/Linux/bell), disabled by default, --notify flag (Issue #22) |
+| `test_backup_rollback.bats` | 6 | Backup/rollback: create_backup() branch naming, disabled by default, graceful git-less handling, commit message, --backup flag, rollback_to_backup() checkout (Issue #23) |
 
 ### Running Tests
 ```bash

--- a/README.md
+++ b/README.md
@@ -843,6 +843,8 @@ ralph [OPTIONS]
   --circuit-status        Show circuit breaker status
   --auto-reset-circuit    Auto-reset circuit breaker on startup (bypasses cooldown)
   --reset-session         Reset session state manually
+  -b, --backup            Enable automatic git backup branch before each loop (requires git)
+  --rollback [BRANCH]     Roll back to a backup branch (lists available branches if none given)
 ```
 
 ### Project Commands (Per Project)

--- a/ralph_loop.sh
+++ b/ralph_loop.sh
@@ -51,6 +51,7 @@ _env_CLAUDE_MODEL="${CLAUDE_MODEL:-}"
 _env_CLAUDE_EFFORT="${CLAUDE_EFFORT:-}"
 _env_RALPH_SHELL_INIT_FILE="${RALPH_SHELL_INIT_FILE:-}"
 _env_ENABLE_NOTIFICATIONS="${ENABLE_NOTIFICATIONS:-}"
+_env_ENABLE_BACKUP="${ENABLE_BACKUP:-}"
 
 # Now set defaults (only if not already set by environment)
 MAX_CALLS_PER_HOUR="${MAX_CALLS_PER_HOUR:-100}"
@@ -72,6 +73,7 @@ CLAUDE_EFFORT="${CLAUDE_EFFORT:-}"               # Effort level override (e.g. h
 RALPH_SHELL_INIT_FILE="${RALPH_SHELL_INIT_FILE:-}" # Shell init file to source before running claude (e.g. ~/.zshrc)
 DRY_RUN="${DRY_RUN:-false}"                      # Simulate loop without making actual Claude API calls
 ENABLE_NOTIFICATIONS="${ENABLE_NOTIFICATIONS:-false}"  # Enable desktop notifications; set true or use --notify flag
+ENABLE_BACKUP="${ENABLE_BACKUP:-false}"               # Enable automatic git backups before each loop; set true or use --backup flag
 
 # Session management configuration (Phase 1.2)
 # Note: SESSION_EXPIRATION_SECONDS is defined in lib/response_analyzer.sh (86400 = 24 hours)
@@ -177,6 +179,7 @@ load_ralphrc() {
     [[ -n "$_env_CLAUDE_EFFORT" ]] && CLAUDE_EFFORT="$_env_CLAUDE_EFFORT"
     [[ -n "$_env_RALPH_SHELL_INIT_FILE" ]] && RALPH_SHELL_INIT_FILE="$_env_RALPH_SHELL_INIT_FILE"
     [[ -n "$_env_ENABLE_NOTIFICATIONS" ]] && ENABLE_NOTIFICATIONS="$_env_ENABLE_NOTIFICATIONS"
+    [[ -n "$_env_ENABLE_BACKUP" ]] && ENABLE_BACKUP="$_env_ENABLE_BACKUP"
 
     RALPHRC_LOADED=true
     return 0
@@ -1299,6 +1302,86 @@ build_claude_command() {
     CLAUDE_CMD_ARGS+=("-p" "$prompt_content")
 }
 
+# create_backup - Create a git backup branch before a loop iteration (Issue #23)
+#
+# Creates a branch named `ralph-backup-loop-{N}-{timestamp}` and commits the
+# current state with `--allow-empty` so a backup is recorded even when there
+# are no staged changes. The function is a no-op when:
+#   - ENABLE_BACKUP is not "true"
+#   - The working directory is not a git repository
+#
+# Usage: create_backup <loop_count>
+#
+create_backup() {
+    local loop_count="${1:-0}"
+
+    [[ "$ENABLE_BACKUP" == "true" ]] || return 0
+
+    if ! command -v git &>/dev/null || ! git rev-parse --git-dir &>/dev/null 2>&1; then
+        log_status "WARN" "Backup skipped: not a git repository"
+        return 0
+    fi
+
+    local timestamp
+    timestamp=$(date +%s)
+    local branch_name="ralph-backup-loop-${loop_count}-${timestamp}"
+
+    git checkout -b "$branch_name" -q 2>/dev/null || {
+        log_status "WARN" "Backup failed: could not create branch $branch_name"
+        return 0
+    }
+
+    git add -A 2>/dev/null || true
+    git commit --allow-empty -q -m "Ralph backup before loop #${loop_count}" 2>/dev/null || true
+
+    # Return to the branch we were on before creating the backup
+    git checkout - -q 2>/dev/null || true
+
+    log_status "INFO" "Backup created: $branch_name"
+    return 0
+}
+
+# rollback_to_backup - Roll back to a previously created backup branch (Issue #23)
+#
+# With no argument: lists all backup branches (newest first).
+# With a branch name: checks out that branch.
+#
+# Usage: rollback_to_backup [branch_name]
+#
+rollback_to_backup() {
+    local branch="${1:-}"
+
+    if ! command -v git &>/dev/null || ! git rev-parse --git-dir &>/dev/null 2>&1; then
+        log_status "ERROR" "Rollback failed: not a git repository"
+        return 1
+    fi
+
+    if [[ -z "$branch" ]]; then
+        local backups
+        backups=$(git branch --list "ralph-backup-loop-*" 2>/dev/null | sed 's/^[* ]*//' | sort -rV)
+        if [[ -z "$backups" ]]; then
+            log_status "WARN" "No backup branches found"
+            return 1
+        fi
+        echo "Available backups (newest first):"
+        echo "$backups"
+        return 0
+    fi
+
+    if ! git rev-parse --verify "$branch" &>/dev/null 2>&1; then
+        log_status "ERROR" "Rollback failed: branch '$branch' not found"
+        return 1
+    fi
+
+    git checkout "$branch" -q 2>/dev/null || {
+        log_status "ERROR" "Rollback failed: could not checkout $branch"
+        return 1
+    }
+
+    log_status "INFO" "Rolled back to: $branch"
+    return 0
+}
+
 # Main execution function
 execute_claude_code() {
     local timestamp=$(date '+%Y-%m-%d_%H-%M-%S')
@@ -2105,6 +2188,9 @@ main() {
         loop_start_epoch=$(get_epoch_seconds)
         local calls_before_exec="$calls_made"
 
+        # Create backup branch before execution (Issue #23)
+        create_backup "$loop_count"
+
         # Execute Claude Code
         execute_claude_code "$loop_count"
         local exec_result=$?
@@ -2210,6 +2296,8 @@ Options:
     --reset-session         Reset session state and exit (clears session continuity)
     --dry-run               Simulate loop execution without making actual Claude API calls
     -n, --notify            Enable desktop notifications for key events
+    -b, --backup            Enable automatic git backup branch before each loop (requires git)
+    --rollback [BRANCH]     Roll back to a backup branch (lists available backups if no branch given)
 
 Modern CLI Options (Phase 1.1):
     --output-format FORMAT  Set Claude output format: json or text (default: $CLAUDE_OUTPUT_FORMAT)
@@ -2355,6 +2443,16 @@ while [[ $# -gt 0 ]]; do
         -n|--notify)
             ENABLE_NOTIFICATIONS=true
             shift
+            ;;
+        -b|--backup)
+            ENABLE_BACKUP=true
+            shift
+            ;;
+        --rollback)
+            SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
+            source "$SCRIPT_DIR/lib/date_utils.sh"
+            rollback_to_backup "${2:-}"
+            exit $?
             ;;
         *)
             echo "Unknown option: $1"

--- a/tests/unit/test_backup_rollback.bats
+++ b/tests/unit/test_backup_rollback.bats
@@ -1,0 +1,240 @@
+#!/usr/bin/env bats
+# Unit Tests for Backup and Rollback System (Issue #23)
+# Tests create_backup() and rollback_to_backup() functions
+
+load '../helpers/test_helper'
+
+RALPH_SCRIPT="${BATS_TEST_DIRNAME}/../../ralph_loop.sh"
+
+setup() {
+    source "$(dirname "$BATS_TEST_FILENAME")/../helpers/test_helper.bash"
+
+    export TEST_TEMP_DIR="$(mktemp -d)"
+    cd "$TEST_TEMP_DIR"
+
+    export RALPH_DIR=".ralph"
+    mkdir -p "$RALPH_DIR/logs"
+
+    export ENABLE_BACKUP=false
+    export VERBOSE_PROGRESS=false
+
+    # Initialise a real git repo for tests that exercise git behaviour
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "Test User"
+    # Create an initial commit so HEAD is valid
+    echo "initial" > README.md
+    git add README.md
+    git commit -q -m "Initial commit"
+}
+
+teardown() {
+    cd /
+    rm -rf "$TEST_TEMP_DIR"
+}
+
+# ── Inline function under test ────────────────────────────────────────────────
+# These mirror the implementations in ralph_loop.sh.
+# IMPORTANT: Keep in sync if ralph_loop.sh changes.
+
+log_status() {
+    local level="$1"
+    local message="$2"
+    echo "[$level] $message" >&2
+}
+
+create_backup() {
+    local loop_count="${1:-0}"
+
+    [[ "$ENABLE_BACKUP" == "true" ]] || return 0
+
+    if ! command -v git &>/dev/null || ! git rev-parse --git-dir &>/dev/null 2>&1; then
+        log_status "WARN" "Backup skipped: not a git repository"
+        return 0
+    fi
+
+    local timestamp
+    timestamp=$(date +%s)
+    local branch_name="ralph-backup-loop-${loop_count}-${timestamp}"
+
+    git checkout -b "$branch_name" -q 2>/dev/null || {
+        log_status "WARN" "Backup failed: could not create branch $branch_name"
+        return 0
+    }
+
+    git add -A 2>/dev/null || true
+    git commit --allow-empty -q -m "Ralph backup before loop #${loop_count}" 2>/dev/null || true
+
+    # Return to the original branch (the one we were on before the backup)
+    git checkout - -q 2>/dev/null || true
+
+    log_status "INFO" "Backup created: $branch_name"
+    return 0
+}
+
+rollback_to_backup() {
+    local branch="${1:-}"
+
+    if ! command -v git &>/dev/null || ! git rev-parse --git-dir &>/dev/null 2>&1; then
+        log_status "ERROR" "Rollback failed: not a git repository"
+        return 1
+    fi
+
+    if [[ -z "$branch" ]]; then
+        # List available backups newest first
+        local backups
+        backups=$(git branch --list "ralph-backup-loop-*" 2>/dev/null | sed 's/^[* ]*//' | sort -rV)
+        if [[ -z "$backups" ]]; then
+            log_status "WARN" "No backup branches found"
+            return 1
+        fi
+        echo "Available backups:"
+        echo "$backups"
+        return 0
+    fi
+
+    # Verify the branch exists
+    if ! git rev-parse --verify "$branch" &>/dev/null 2>&1; then
+        log_status "ERROR" "Rollback failed: branch '$branch' not found"
+        return 1
+    fi
+
+    git checkout "$branch" -q 2>/dev/null || {
+        log_status "ERROR" "Rollback failed: could not checkout $branch"
+        return 1
+    }
+
+    log_status "INFO" "Rolled back to: $branch"
+    return 0
+}
+
+# =============================================================================
+# TEST 1: create_backup creates branch with correct naming pattern
+# =============================================================================
+
+@test "create_backup creates branch with correct naming pattern" {
+    export ENABLE_BACKUP=true
+
+    create_backup 5
+
+    # Branch matching ralph-backup-loop-5-<timestamp> must exist
+    local found_branch
+    found_branch=$(git branch --list "ralph-backup-loop-5-*" | sed 's/^[* ]*//')
+
+    [[ -n "$found_branch" ]]
+    [[ "$found_branch" == ralph-backup-loop-5-* ]]
+}
+
+# =============================================================================
+# TEST 2: create_backup does nothing when ENABLE_BACKUP=false
+# =============================================================================
+
+@test "create_backup does nothing when ENABLE_BACKUP=false" {
+    export ENABLE_BACKUP=false
+
+    create_backup 3
+
+    # No backup branches should exist
+    local branches
+    branches=$(git branch --list "ralph-backup-loop-*" | sed 's/^[* ]*//')
+    [[ -z "$branches" ]]
+}
+
+# =============================================================================
+# TEST 3: create_backup is graceful when not in git repo
+# =============================================================================
+
+@test "create_backup is graceful when not in git repo" {
+    export ENABLE_BACKUP=true
+
+    # Move to a non-git directory
+    local non_git_dir
+    non_git_dir=$(mktemp -d)
+    cd "$non_git_dir"
+
+    # Must complete without error (return 0)
+    run create_backup 1
+    [ "$status" -eq 0 ]
+
+    cd "$TEST_TEMP_DIR"
+    rm -rf "$non_git_dir"
+}
+
+# =============================================================================
+# TEST 4: create_backup creates commit with correct message
+# =============================================================================
+
+@test "create_backup creates commit with correct message" {
+    export ENABLE_BACKUP=true
+
+    create_backup 7
+
+    # Find the backup branch
+    local branch
+    branch=$(git branch --list "ralph-backup-loop-7-*" | sed 's/^[* ]*//')
+    [[ -n "$branch" ]]
+
+    # Inspect the commit message on that branch
+    local commit_msg
+    commit_msg=$(git log "$branch" -1 --pretty=format:"%s")
+    [[ "$commit_msg" == "Ralph backup before loop #7" ]]
+}
+
+# =============================================================================
+# TEST 5: --backup flag appears in help output
+# =============================================================================
+
+@test "--backup flag appears in help output" {
+    # Stub lib/ so the script parses flags without sourcing real deps
+    mkdir -p lib
+    for stub in circuit_breaker response_analyzer date_utils timeout_utils file_protection log_utils; do
+        cat > "lib/${stub}.sh" << 'STUB'
+reset_circuit_breaker() { :; }
+show_circuit_status() { :; }
+init_circuit_breaker() { :; }
+record_loop_result() { :; }
+analyze_response() { :; }
+detect_output_format() { echo "text"; }
+get_iso_timestamp() { date -Iseconds 2>/dev/null || date '+%Y-%m-%dT%H:%M:%S'; }
+get_epoch_timestamp() { date +%s; }
+get_epoch_seconds() { date +%s; }
+get_next_hour_time() { echo "next-hour"; }
+portable_timeout() { shift; "$@"; }
+detect_timeout_cmd() { :; }
+validate_ralph_integrity() { return 0; }
+get_integrity_report() { echo "OK"; }
+rotate_logs() { :; }
+log_status() { :; }
+STUB
+    done
+    mkdir -p "$RALPH_DIR/logs"
+    echo "# prompt" > "$RALPH_DIR/PROMPT.md"
+
+    run bash "$RALPH_SCRIPT" --help
+    assert_success
+    [[ "$output" == *"--backup"* ]]
+}
+
+# =============================================================================
+# TEST 6: rollback_to_backup checks out specified backup branch
+# =============================================================================
+
+@test "rollback_to_backup checks out specified backup branch" {
+    export ENABLE_BACKUP=true
+
+    # Create a backup branch
+    create_backup 2
+
+    local branch
+    branch=$(git branch --list "ralph-backup-loop-2-*" | sed 's/^[* ]*//')
+    [[ -n "$branch" ]]
+
+    # Roll back to it — should succeed
+    run rollback_to_backup "$branch"
+    [ "$status" -eq 0 ]
+
+    # Confirm we are now on the backup branch
+    local current
+    current=$(git rev-parse --abbrev-ref HEAD)
+    [[ "$current" == "$branch" ]]
+}


### PR DESCRIPTION
## Summary

- Implements `create_backup()` in `ralph_loop.sh` — creates a git branch `ralph-backup-loop-{N}-{timestamp}` with an `--allow-empty` commit before each loop iteration; no-op when not in a git repo or backup is disabled
- Implements `rollback_to_backup()` — checks out a named backup branch; lists available backups (newest first) when no branch is given
- Integrates `create_backup "$loop_count"` into the main loop (called just before `execute_claude_code`)
- Adds `-b`/`--backup` CLI flag (sets `ENABLE_BACKUP=true`) and `--rollback [BRANCH]` command
- Updates `show_help()`, README.md, and CLAUDE.md

## Test plan

- [x] 6 new bats tests in `tests/unit/test_backup_rollback.bats`
  - Branch naming pattern matches `ralph-backup-loop-{N}-{timestamp}`
  - Does nothing when `ENABLE_BACKUP=false`
  - Graceful no-op outside git repositories
  - Commit message is `"Ralph backup before loop #{N}"`
  - `--backup` flag appears in help output
  - `rollback_to_backup` checks out the specified branch
- [x] Full suite: 644 tests, 0 failures

Closes #23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--backup` flag to automatically create git backup branches before each loop iteration.
  * Added `--rollback [BRANCH]` flag to restore to a specific backup branch or list available backups.

* **Documentation**
  * Updated CLI reference documentation with new backup and rollback options.

* **Tests**
  * Added test suite covering backup creation, rollback functionality, and disabled-by-default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->