### PR TITLE
fix(backup): address review feedback from PR #241

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,6 +164,12 @@ ralph --auto-reset-circuit   # Auto-reset OPEN state on startup
 
 # Session management
 ralph --reset-session    # Reset session state manually
+
+# Backup and rollback (requires git; Issue #23)
+ralph --backup           # Enable automatic backup before each loop
+ralph -b                 # Short form of --backup
+ralph --rollback         # List available backup branches
+ralph --rollback ralph-backup-loop-3-1775155286  # Roll back to a specific backup
 ```
 
 ### Monitoring

--- a/README.md
+++ b/README.md
@@ -123,11 +123,6 @@ Ralph is an implementation of the Geoffrey Huntley's technique for Claude Code t
 
 ### In Progress
 - Expanding test coverage
-- Log rotation functionality
-- Dry-run mode
-- Metrics and analytics tracking
-- Desktop notifications
-- Git backup and rollback system
 - [Automated badge updates](#138)
 
 **Timeline to v1.0**: ~4 weeks | [Full roadmap](IMPLEMENTATION_PLAN.md) | **Contributions welcome!**
@@ -913,9 +908,6 @@ Ralph is under active development with a clear path to v1.0.0. See [IMPLEMENTATI
 - Dry-run mode
 
 **Advanced Features & Polish**
-- Metrics and analytics tracking
-- Desktop notifications
-- Git backup and rollback system
 - End-to-end tests
 - Final documentation and release prep
 

--- a/ralph_loop.sh
+++ b/ralph_loop.sh
@@ -357,6 +357,10 @@ setup_tmux_session() {
     if [[ "$CB_AUTO_RESET" == "true" ]]; then
         ralph_cmd="$ralph_cmd --auto-reset-circuit"
     fi
+    # Forward --backup if enabled (Issue #23)
+    if [[ "$ENABLE_BACKUP" == "true" ]]; then
+        ralph_cmd="$ralph_cmd --backup"
+    fi
 
     # Chain tmux kill-session after the loop command so the entire tmux
     # session is torn down when the Ralph loop exits (graceful completion,
@@ -1325,17 +1329,44 @@ create_backup() {
     local timestamp
     timestamp=$(date +%s)
     local branch_name="ralph-backup-loop-${loop_count}-${timestamp}"
+    local stash_msg="Ralph backup before loop #${loop_count}"
 
-    git checkout -b "$branch_name" -q 2>/dev/null || {
-        log_status "WARN" "Backup failed: could not create branch $branch_name"
+    # Stash any staged/unstaged changes so checkout doesn't lose them
+    local stashed=false
+    if ! git stash push -u -m "$stash_msg" 2>/dev/null; then
+        log_status "WARN" "Backup failed: could not stash local changes for loop #${loop_count}"
         return 0
-    }
+    fi
+    stashed=true
 
-    git add -A 2>/dev/null || true
-    git commit --allow-empty -q -m "Ralph backup before loop #${loop_count}" 2>/dev/null || true
+    if ! git checkout -b "$branch_name" -q 2>/dev/null; then
+        log_status "WARN" "Backup failed: could not create branch $branch_name"
+        git stash pop 2>/dev/null || true
+        return 0
+    fi
 
-    # Return to the branch we were on before creating the backup
-    git checkout - -q 2>/dev/null || true
+    if ! git add -A 2>/dev/null; then
+        log_status "WARN" "Backup failed: could not stage files for loop #${loop_count}"
+        git checkout - -q 2>/dev/null || true
+        git stash pop 2>/dev/null || true
+        return 0
+    fi
+
+    if ! git commit --allow-empty -q -m "$stash_msg" 2>/dev/null; then
+        log_status "WARN" "Backup failed: commit failed for loop #${loop_count}"
+        git checkout - -q 2>/dev/null || true
+        git stash pop 2>/dev/null || true
+        return 0
+    fi
+
+    # Return to the original branch and restore the stash
+    if ! git checkout - -q 2>/dev/null; then
+        log_status "WARN" "Backup: could not switch back from $branch_name — manual cleanup may be needed"
+    fi
+
+    if [[ "$stashed" == "true" ]]; then
+        git stash pop 2>/dev/null || log_status "WARN" "Backup: stash pop failed — run 'git stash pop' to restore your changes"
+    fi
 
     log_status "INFO" "Backup created: $branch_name"
     return 0
@@ -1358,7 +1389,7 @@ rollback_to_backup() {
 
     if [[ -z "$branch" ]]; then
         local backups
-        backups=$(git branch --list "ralph-backup-loop-*" 2>/dev/null | sed 's/^[* ]*//' | sort -rV)
+        backups=$(git branch --list "ralph-backup-loop-*" 2>/dev/null | sed 's/^[* ]*//' | sort -t- -k5,5 -rn)
         if [[ -z "$backups" ]]; then
             log_status "WARN" "No backup branches found"
             return 1
@@ -1992,6 +2023,9 @@ main() {
             log_status "INFO" "Loaded configuration from .ralphrc"
         fi
     fi
+    # Re-apply CLI flags that must take priority over .ralphrc (Issue #23)
+    # _cli_ENABLE_BACKUP is set only when --backup / -b was explicitly passed
+    [[ "${_cli_ENABLE_BACKUP:-false}" == "true" ]] && ENABLE_BACKUP=true
 
     # Source user shell init file if configured (e.g. ~/.zshrc for zsh environments)
     # This allows non-bash shells or non-standard setups to export PATH/env vars
@@ -2446,6 +2480,7 @@ while [[ $# -gt 0 ]]; do
             ;;
         -b|--backup)
             ENABLE_BACKUP=true
+            _cli_ENABLE_BACKUP=true
             shift
             ;;
         --rollback)

--- a/tests/unit/test_backup_rollback.bats
+++ b/tests/unit/test_backup_rollback.bats
@@ -2,6 +2,8 @@
 # Unit Tests for Backup and Rollback System (Issue #23)
 # Tests create_backup() and rollback_to_backup() functions
 
+bats_require_minimum_version 1.5.0
+
 load '../helpers/test_helper'
 
 RALPH_SCRIPT="${BATS_TEST_DIRNAME}/../../ralph_loop.sh"
@@ -56,17 +58,42 @@ create_backup() {
     local timestamp
     timestamp=$(date +%s)
     local branch_name="ralph-backup-loop-${loop_count}-${timestamp}"
+    local stash_msg="Ralph backup before loop #${loop_count}"
 
-    git checkout -b "$branch_name" -q 2>/dev/null || {
-        log_status "WARN" "Backup failed: could not create branch $branch_name"
+    local stashed=false
+    if ! git stash push -u -m "$stash_msg" 2>/dev/null; then
+        log_status "WARN" "Backup failed: could not stash local changes for loop #${loop_count}"
         return 0
-    }
+    fi
+    stashed=true
 
-    git add -A 2>/dev/null || true
-    git commit --allow-empty -q -m "Ralph backup before loop #${loop_count}" 2>/dev/null || true
+    if ! git checkout -b "$branch_name" -q 2>/dev/null; then
+        log_status "WARN" "Backup failed: could not create branch $branch_name"
+        git stash pop 2>/dev/null || true
+        return 0
+    fi
 
-    # Return to the original branch (the one we were on before the backup)
-    git checkout - -q 2>/dev/null || true
+    if ! git add -A 2>/dev/null; then
+        log_status "WARN" "Backup failed: could not stage files for loop #${loop_count}"
+        git checkout - -q 2>/dev/null || true
+        git stash pop 2>/dev/null || true
+        return 0
+    fi
+
+    if ! git commit --allow-empty -q -m "$stash_msg" 2>/dev/null; then
+        log_status "WARN" "Backup failed: commit failed for loop #${loop_count}"
+        git checkout - -q 2>/dev/null || true
+        git stash pop 2>/dev/null || true
+        return 0
+    fi
+
+    if ! git checkout - -q 2>/dev/null; then
+        log_status "WARN" "Backup: could not switch back from $branch_name — manual cleanup may be needed"
+    fi
+
+    if [[ "$stashed" == "true" ]]; then
+        git stash pop 2>/dev/null || log_status "WARN" "Backup: stash pop failed — run 'git stash pop' to restore your changes"
+    fi
 
     log_status "INFO" "Backup created: $branch_name"
     return 0
@@ -81,19 +108,17 @@ rollback_to_backup() {
     fi
 
     if [[ -z "$branch" ]]; then
-        # List available backups newest first
         local backups
-        backups=$(git branch --list "ralph-backup-loop-*" 2>/dev/null | sed 's/^[* ]*//' | sort -rV)
+        backups=$(git branch --list "ralph-backup-loop-*" 2>/dev/null | sed 's/^[* ]*//' | sort -t- -k5,5 -rn)
         if [[ -z "$backups" ]]; then
             log_status "WARN" "No backup branches found"
             return 1
         fi
-        echo "Available backups:"
+        echo "Available backups (newest first):"
         echo "$backups"
         return 0
     fi
 
-    # Verify the branch exists
     if ! git rev-parse --verify "$branch" &>/dev/null 2>&1; then
         log_status "ERROR" "Rollback failed: branch '$branch' not found"
         return 1
@@ -237,4 +262,33 @@ STUB
     local current
     current=$(git rev-parse --abbrev-ref HEAD)
     [[ "$current" == "$branch" ]]
+}
+
+# =============================================================================
+# TEST 7: rollback_to_backup with no args lists available backups
+# =============================================================================
+
+@test "rollback_to_backup with no args lists available backup branches" {
+    export ENABLE_BACKUP=true
+
+    # Create two backups at different loop counts
+    create_backup 1
+    sleep 1  # ensure distinct timestamps
+    create_backup 2
+
+    # With no args it should print the list and exit 0
+    run rollback_to_backup
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Available backups"* ]]
+    [[ "$output" == *"ralph-backup-loop-"* ]]
+}
+
+# =============================================================================
+# TEST 8: rollback_to_backup with non-existent branch fails cleanly
+# =============================================================================
+
+@test "rollback_to_backup with non-existent branch fails cleanly" {
+    run --separate-stderr rollback_to_backup "ralph-backup-loop-99-0000000000"
+    [ "$status" -ne 0 ]
+    [[ "$stderr" == *"not found"* ]]
 }


### PR DESCRIPTION
## Summary

Addresses all valid review findings from PR #241 (backup/rollback system).

- **`setup_tmux_session`**: forward `--backup` flag when `ENABLE_BACKUP=true` so tmux-spawned ralph inherits the setting
- **`load_ralphrc` override bug**: add `_cli_ENABLE_BACKUP` tracking variable set when `--backup`/`-b` is parsed; re-apply after `load_ralphrc()` so a `.ralphrc` setting can't silently override the CLI flag
- **`create_backup` data safety**: stash staged/unstaged changes before `git checkout -b`, restore after; replace `|| true` error swallowing with `log_status` warnings so failures surface
- **`sort -rV` portability**: replace with `sort -t- -k5,5 -rn` (timestamp is field 5 of `ralph-backup-loop-{N}-{timestamp}`)
- **CLAUDE.md**: add `--backup`/`--rollback` to Key Commands section
- **README**: remove stale "in-progress" items for already-shipped features (log rotation, dry-run, metrics, notifications, backup/rollback)
- **Tests**: sync inline copies with new stash-based implementation; add tests for no-arg listing (test 7) and non-existent branch error path (test 8); add `bats_require_minimum_version 1.5.0`

## Test plan

- [x] 8 tests in `test_backup_rollback.bats`, all passing
- [x] Full suite: 646 tests, 0 failures

Skipped: suggestion to replace inline function copies with a sourced file — conflicts with established project convention (see `test_notifications.bats` and CLAUDE.md common gotchas).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--backup` (`-b`) and `--rollback` CLI commands for session backup and recovery.
  * Automatic preservation of local changes during backup operations.
  * Improved backup branch sorting for consistent ordering.

* **Documentation**
  * Added CLI documentation for new backup and rollback commands.

* **Tests**
  * Added comprehensive tests for backup and rollback functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->