### PR TITLE
fix: grep -c pattern produces "0\n0" when no matches found

### DIFF
--- a/create_files.sh
+++ b/create_files.sh
@@ -207,8 +207,10 @@ should_exit_gracefully() {
     # Fix #144: Only match valid markdown checkboxes, not date entries like [2026-01-29]
     # Valid patterns: "- [ ]" (uncompleted) and "- [x]" or "- [X]" (completed)
     if [[ -f "$RALPH_DIR/fix_plan.md" ]]; then
-        local uncompleted_items=$(grep -cE "^[[:space:]]*- \[ \]" "$RALPH_DIR/fix_plan.md" 2>/dev/null || echo "0")
-        local completed_items=$(grep -cE "^[[:space:]]*- \[[xX]\]" "$RALPH_DIR/fix_plan.md" 2>/dev/null || echo "0")
+        local uncompleted_items
+        uncompleted_items=$(grep -cE "^[[:space:]]*- \[ \]" "$RALPH_DIR/fix_plan.md" 2>/dev/null) || uncompleted_items=0
+        local completed_items
+        completed_items=$(grep -cE "^[[:space:]]*- \[[xX]\]" "$RALPH_DIR/fix_plan.md" 2>/dev/null) || completed_items=0
         local total_items=$((uncompleted_items + completed_items))
 
         if [[ $total_items -gt 0 ]] && [[ $completed_items -eq $total_items ]]; then

--- a/lib/response_analyzer.sh
+++ b/lib/response_analyzer.sh
@@ -40,7 +40,7 @@ detect_questions() {
     # Count lines matching question patterns (case-insensitive)
     for pattern in "${QUESTION_PATTERNS[@]}"; do
         local matches
-        matches=$(echo "$content" | grep -ciw "$pattern" 2>/dev/null || echo "0")
+        matches=$(echo "$content" | grep -ciw "$pattern" 2>/dev/null) || matches=0
         matches=$(echo "$matches" | tr -d '[:space:]')
         matches=${matches:-0}
         question_count=$((question_count + matches))
@@ -524,8 +524,8 @@ analyze_response() {
     local implementation_count=0
     local error_count=0
 
-    test_command_count=$(grep -c -i "running tests\|npm test\|bats\|pytest\|jest" "$output_file" 2>/dev/null | head -1 || echo "0")
-    implementation_count=$(grep -c -i "implementing\|creating\|writing\|adding\|function\|class" "$output_file" 2>/dev/null | head -1 || echo "0")
+    test_command_count=$(grep -c -i "running tests\|npm test\|bats\|pytest\|jest" "$output_file" 2>/dev/null | head -1) || test_command_count=0
+    implementation_count=$(grep -c -i "implementing\|creating\|writing\|adding\|function\|class" "$output_file" 2>/dev/null | head -1) || implementation_count=0
 
     # Strip whitespace and ensure it's a number
     test_command_count=$(echo "$test_command_count" | tr -d '[:space:]')

--- a/ralph_enable_ci.sh
+++ b/ralph_enable_ci.sh
@@ -326,14 +326,14 @@ main() {
         beads)
             if beads_tasks=$(fetch_beads_tasks 2>/dev/null); then
                 imported_tasks="$beads_tasks"
-                TASKS_IMPORTED=$(echo "$imported_tasks" | grep -c '^\- \[' || echo "0")
+                TASKS_IMPORTED=$(echo "$imported_tasks" | grep -c '^\- \[') || TASKS_IMPORTED=0
                 output_message "Imported $TASKS_IMPORTED tasks from beads"
             fi
             ;;
         github)
             if github_tasks=$(fetch_github_tasks "$GITHUB_LABEL" 2>/dev/null); then
                 imported_tasks="$github_tasks"
-                TASKS_IMPORTED=$(echo "$imported_tasks" | grep -c '^\- \[' || echo "0")
+                TASKS_IMPORTED=$(echo "$imported_tasks" | grep -c '^\- \[') || TASKS_IMPORTED=0
                 output_message "Imported $TASKS_IMPORTED tasks from GitHub"
             fi
             ;;
@@ -341,7 +341,7 @@ main() {
             if [[ -n "$PRD_FILE" && -f "$PRD_FILE" ]]; then
                 if prd_tasks=$(extract_prd_tasks "$PRD_FILE" 2>/dev/null); then
                     imported_tasks="$prd_tasks"
-                    TASKS_IMPORTED=$(echo "$imported_tasks" | grep -c '^\- \[' || echo "0")
+                    TASKS_IMPORTED=$(echo "$imported_tasks" | grep -c '^\- \[') || TASKS_IMPORTED=0
                     output_message "Extracted $TASKS_IMPORTED tasks from PRD"
                 fi
             else

--- a/ralph_loop.sh
+++ b/ralph_loop.sh
@@ -711,8 +711,10 @@ should_exit_gracefully() {
     # Fix #144: Only match valid markdown checkboxes, not date entries like [2026-01-29]
     # Valid patterns: "- [ ]" (uncompleted) and "- [x]" or "- [X]" (completed)
     if [[ -f "$RALPH_DIR/fix_plan.md" ]]; then
-        local uncompleted_items=$(grep -cE "^[[:space:]]*- \[ \]" "$RALPH_DIR/fix_plan.md" 2>/dev/null || echo "0")
-        local completed_items=$(grep -cE "^[[:space:]]*- \[[xX]\]" "$RALPH_DIR/fix_plan.md" 2>/dev/null || echo "0")
+        local uncompleted_items
+        uncompleted_items=$(grep -cE "^[[:space:]]*- \[ \]" "$RALPH_DIR/fix_plan.md" 2>/dev/null) || uncompleted_items=0
+        local completed_items
+        completed_items=$(grep -cE "^[[:space:]]*- \[[xX]\]" "$RALPH_DIR/fix_plan.md" 2>/dev/null) || completed_items=0
         local total_items=$((uncompleted_items + completed_items))
 
         if [[ $total_items -gt 0 ]] && [[ $completed_items -eq $total_items ]]; then
@@ -877,7 +879,8 @@ build_loop_context() {
     # Extract incomplete tasks from fix_plan.md
     # Bug #3 Fix: Support indented markdown checkboxes with [[:space:]]* pattern
     if [[ -f "$RALPH_DIR/fix_plan.md" ]]; then
-        local incomplete_tasks=$(grep -cE "^[[:space:]]*- \[ \]" "$RALPH_DIR/fix_plan.md" 2>/dev/null || echo "0")
+        local incomplete_tasks
+        incomplete_tasks=$(grep -cE "^[[:space:]]*- \[ \]" "$RALPH_DIR/fix_plan.md" 2>/dev/null) || incomplete_tasks=0
         context+="Remaining tasks: ${incomplete_tasks}. "
     fi
 


### PR DESCRIPTION
## Summary

`grep -c` writes `0` to stdout even when it exits non-zero (no matches). The pattern `$(grep -c ... || echo "0")` therefore concatenates both outputs into `"0\n0"`, which breaks any arithmetic or comparison that consumes the result.

This PR replaces that pattern across the codebase with the safe form:

```bash
var=$(grep -c ...) || var=0
```

The fix is applied in:

- `ralph_loop.sh`
- `lib/response_analyzer.sh`
- `create_files.sh`
- `ralph_enable_ci.sh`

## Why it matters

Anywhere a `grep -c` count flowed into `[[ $count -ge N ]]` or arithmetic could silently misbehave when there were zero matches — `"0\n0"` is not a valid integer and triggers shell errors or wrong branches in exit detection, circuit breaker logic, and response analysis.

## Test plan

- [ ] `npm test` passes locally
- [ ] Manually exercise a Ralph loop iteration where grep targets produce zero matches and confirm no `0\n0` integer-expression errors appear in the logs
- [ ] Confirm exit detection / circuit breaker counters still increment correctly when matches do exist


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Counters now reliably default to zero when no matches are found, preventing spurious failures and stray output.
  * Fixed no-match handling across monitoring and analysis flows to stop incorrect status signals.

* **Improvements**
  * Cleaner, quieter runtime behavior for background monitoring and analysis, improving responsiveness and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->