### PR TITLE
feat(enable): add --limit flag to cap issues imported from beads/GitHub

### DIFF
--- a/lib/task_sources.sh
+++ b/lib/task_sources.sh
@@ -31,6 +31,7 @@ check_beads_available() {
 #
 # Parameters:
 #   $1 (filterStatus) - Status filter (optional, default: "open")
+#   $2 (limit) - Max issues to fetch (optional, default: "0" = all)
 #
 # Outputs:
 #   Tasks in markdown checkbox format, one per line
@@ -42,6 +43,7 @@ check_beads_available() {
 #
 fetch_beads_tasks() {
     local filterStatus="${1:-open}"
+    local limit="${2:-0}"
     local tasks=""
 
     # Check if beads is available
@@ -50,7 +52,7 @@ fetch_beads_tasks() {
     fi
 
     # Build bd list command arguments
-    local bdArgs=("list" "--json")
+    local bdArgs=("list" "--json" "--limit" "$limit")
     if [[ "$filterStatus" == "open" ]]; then
         bdArgs+=("--status" "open")
     elif [[ "$filterStatus" == "in_progress" ]]; then
@@ -78,7 +80,7 @@ fetch_beads_tasks() {
     # Fallback: try plain text output if JSON failed or produced no results
     if [[ -z "$tasks" ]]; then
         # Build fallback args (reuse status logic, but without --json)
-        local fallbackArgs=("list")
+        local fallbackArgs=("list" "--limit" "$limit")
         if [[ "$filterStatus" == "open" ]]; then
             fallbackArgs+=("--status" "open")
         elif [[ "$filterStatus" == "in_progress" ]]; then
@@ -109,11 +111,16 @@ fetch_beads_tasks() {
 
 # get_beads_count - Get count of open beads issues
 #
+# Parameters:
+#   $1 (limit) - Max issues to fetch (optional, default: "0" = all)
+#
 # Returns:
 #   0 and echoes the count
 #   1 if beads unavailable
 #
 get_beads_count() {
+    local limit="${1:-0}"
+
     if ! check_beads_available; then
         echo "0"
         return 1
@@ -122,9 +129,9 @@ get_beads_count() {
     local count
     if command -v jq &>/dev/null; then
         # Note: Use 'select(.status == "closed" | not)' to avoid bash escaping issues with '!='
-        count=$(bd list --json 2>/dev/null | jq '[.[] | select(.status == "closed" | not)] | length' 2>/dev/null || echo "0")
+        count=$(bd list --json --limit "$limit" 2>/dev/null | jq '[.[] | select(.status == "closed" | not)] | length' 2>/dev/null || echo "0")
     else
-        count=$(bd list 2>/dev/null | wc -l | tr -d ' ')
+        count=$(bd list --limit "$limit" 2>/dev/null | wc -l | tr -d ' ')
     fi
 
     echo "${count:-0}"
@@ -163,8 +170,8 @@ check_github_available() {
 # fetch_github_tasks - Fetch issues from GitHub
 #
 # Parameters:
-#   $1 (label) - Label to filter by (optional, default: "ralph-task")
-#   $2 (limit) - Maximum number of issues (optional, default: 50)
+#   $1 (label) - Label to filter by (optional)
+#   $2 (limit) - Maximum number of issues (optional, default: "0" = all)
 #
 # Outputs:
 #   Tasks in markdown checkbox format
@@ -174,34 +181,58 @@ check_github_available() {
 #   0 - Success
 #   1 - Error
 #
+# Note:
+#   `gh issue list --limit` enforces a hard cap of 1000 regardless of the
+#   value supplied. When limit=0 ("all"), we fall back to `gh api --paginate`
+#   against the issues endpoint so large repos are not silently truncated.
+#   The issues endpoint returns pull requests as well, so those are filtered
+#   out via `.pull_request | not`.
+#
 fetch_github_tasks() {
     local label="${1:-}"
-    local limit="${2:-50}"
+    local limit="${2:-0}"
     local tasks=""
+    local json_output
 
     # Check if GitHub is available
     if ! check_github_available; then
         return 1
     fi
 
-    # Build gh command
-    local gh_args=("issue" "list" "--state" "open" "--limit" "$limit" "--json" "number,title,labels")
-    if [[ -n "$label" ]]; then
-        gh_args+=("--label" "$label")
-    fi
-
-    # Fetch issues
-    local json_output
-    if ! json_output=$(gh "${gh_args[@]}" 2>/dev/null); then
-        return 1
-    fi
-
-    # Parse JSON and format as markdown tasks
-    if command -v jq &>/dev/null; then
-        tasks=$(echo "$json_output" | jq -r '
-            .[] |
-            "- [ ] [#\(.number)] \(.title)"
-        ' 2>/dev/null)
+    if [[ "$limit" == "0" ]]; then
+        # Fetch all open issues via the REST API with automatic pagination.
+        # `-f` passes URL-encoded string fields so labels with spaces or
+        # special characters are handled correctly.
+        local api_args=("api" "--method" "GET" "repos/{owner}/{repo}/issues"
+                        "-f" "state=open" "-f" "per_page=100" "--paginate")
+        if [[ -n "$label" ]]; then
+            api_args+=("-f" "labels=$label")
+        fi
+        if ! json_output=$(gh "${api_args[@]}" 2>/dev/null); then
+            return 1
+        fi
+        # Parse and format, filtering out pull requests
+        if command -v jq &>/dev/null; then
+            tasks=$(echo "$json_output" | jq -r '
+                .[] | select(.pull_request | not) |
+                "- [ ] [#\(.number)] \(.title)"
+            ' 2>/dev/null)
+        fi
+    else
+        # Bounded fetch via `gh issue list` which already excludes PRs
+        local gh_args=("issue" "list" "--state" "open" "--limit" "$limit" "--json" "number,title,labels")
+        if [[ -n "$label" ]]; then
+            gh_args+=("--label" "$label")
+        fi
+        if ! json_output=$(gh "${gh_args[@]}" 2>/dev/null); then
+            return 1
+        fi
+        if command -v jq &>/dev/null; then
+            tasks=$(echo "$json_output" | jq -r '
+                .[] |
+                "- [ ] [#\(.number)] \(.title)"
+            ' 2>/dev/null)
+        fi
     fi
 
     if [[ -n "$tasks" ]]; then
@@ -490,6 +521,7 @@ prioritize_tasks() {
 #   $1 (sources) - Space-separated list of sources: beads, github, prd
 #   $2 (prd_file) - Path to PRD file (required if prd in sources)
 #   $3 (github_label) - GitHub label filter (optional)
+#   $4 (limit) - Max issues to fetch per source (optional, default: "0" = all)
 #
 # Outputs:
 #   Combined tasks in markdown format
@@ -502,6 +534,7 @@ import_tasks_from_sources() {
     local sources=$1
     local prd_file="${2:-}"
     local github_label="${3:-}"
+    local limit="${4:-0}"
 
     local all_tasks=""
     local source_count=0
@@ -509,7 +542,7 @@ import_tasks_from_sources() {
     # Import from beads
     if echo "$sources" | grep -qw "beads"; then
         local beads_tasks
-        if beads_tasks=$(fetch_beads_tasks); then
+        if beads_tasks=$(fetch_beads_tasks "open" "$limit"); then
             if [[ -n "$beads_tasks" ]]; then
                 all_tasks="${all_tasks}
 # Tasks from beads
@@ -523,7 +556,7 @@ ${beads_tasks}
     # Import from GitHub
     if echo "$sources" | grep -qw "github"; then
         local github_tasks
-        if github_tasks=$(fetch_github_tasks "$github_label"); then
+        if github_tasks=$(fetch_github_tasks "$github_label" "$limit"); then
             if [[ -n "$github_tasks" ]]; then
                 all_tasks="${all_tasks}
 # Tasks from GitHub

--- a/lib/task_sources.sh
+++ b/lib/task_sources.sh
@@ -171,7 +171,7 @@ check_github_available() {
 #
 # Parameters:
 #   $1 (label) - Label to filter by (optional)
-#   $2 (limit) - Maximum number of issues (optional, default: "0" = all)
+#   $2 (limit) - Maximum number of issues (optional, default: 50; pass 0 for all)
 #
 # Outputs:
 #   Tasks in markdown checkbox format
@@ -190,7 +190,7 @@ check_github_available() {
 #
 fetch_github_tasks() {
     local label="${1:-}"
-    local limit="${2:-0}"
+    local limit="${2:-50}"
     local tasks=""
     local json_output
 
@@ -521,7 +521,7 @@ prioritize_tasks() {
 #   $1 (sources) - Space-separated list of sources: beads, github, prd
 #   $2 (prd_file) - Path to PRD file (required if prd in sources)
 #   $3 (github_label) - GitHub label filter (optional)
-#   $4 (limit) - Max issues to fetch per source (optional, default: "0" = all)
+#   $4 (limit) - Max issues to fetch per source (optional, default: 50; pass 0 for all)
 #
 # Outputs:
 #   Combined tasks in markdown format
@@ -534,7 +534,7 @@ import_tasks_from_sources() {
     local sources=$1
     local prd_file="${2:-}"
     local github_label="${3:-}"
-    local limit="${4:-0}"
+    local limit="${4:-50}"
 
     local all_tasks=""
     local source_count=0

--- a/ralph_enable.sh
+++ b/ralph_enable.sh
@@ -43,6 +43,7 @@ SKIP_TASKS=false
 TASK_SOURCE=""
 PRD_FILE=""
 GITHUB_LABEL=""
+IMPORT_LIMIT="0"
 NON_INTERACTIVE=false
 SHOW_HELP=false
 
@@ -63,6 +64,7 @@ Options:
     --from <source>     Import tasks from: beads, github, prd
     --prd <file>        PRD file to convert (when --from prd)
     --label <label>     GitHub label filter (when --from github)
+    --limit <n>         Max issues to import (default: 0 = all)
     --force             Overwrite existing .ralph/ configuration
     --skip-tasks        Skip task import, use default templates
     --non-interactive   Run with defaults (no prompts)
@@ -139,6 +141,15 @@ parse_arguments() {
                     shift 2
                 else
                     echo "Error: --label requires a label name" >&2
+                    exit $ENABLE_INVALID_ARGS
+                fi
+                ;;
+            --limit)
+                if [[ -n "$2" && "$2" =~ ^[0-9]+$ ]]; then
+                    IMPORT_LIMIT="$2"
+                    shift 2
+                else
+                    echo "Error: --limit requires a non-negative integer" >&2
                     exit $ENABLE_INVALID_ARGS
                 fi
                 ;;
@@ -403,7 +414,7 @@ phase_file_generation() {
 
         if echo "$SELECTED_SOURCES" | grep -qw "beads"; then
             local beads_tasks
-            if beads_tasks=$(fetch_beads_tasks); then
+            if beads_tasks=$(fetch_beads_tasks "open" "$IMPORT_LIMIT"); then
                 imported_tasks="${imported_tasks}${beads_tasks}
 "
                 print_success "Imported tasks from beads"
@@ -412,7 +423,7 @@ phase_file_generation() {
 
         if echo "$SELECTED_SOURCES" | grep -qw "github"; then
             local github_tasks
-            if github_tasks=$(fetch_github_tasks "$CONFIG_GITHUB_LABEL"); then
+            if github_tasks=$(fetch_github_tasks "$CONFIG_GITHUB_LABEL" "$IMPORT_LIMIT"); then
                 imported_tasks="${imported_tasks}${github_tasks}
 "
                 print_success "Imported tasks from GitHub"

--- a/ralph_enable.sh
+++ b/ralph_enable.sh
@@ -43,7 +43,7 @@ SKIP_TASKS=false
 TASK_SOURCE=""
 PRD_FILE=""
 GITHUB_LABEL=""
-IMPORT_LIMIT="0"
+IMPORT_LIMIT="50"
 NON_INTERACTIVE=false
 SHOW_HELP=false
 
@@ -64,7 +64,7 @@ Options:
     --from <source>     Import tasks from: beads, github, prd
     --prd <file>        PRD file to convert (when --from prd)
     --label <label>     GitHub label filter (when --from github)
-    --limit <n>         Max issues to import (default: 0 = all)
+    --limit <n>         Max issues to import per source (default: 50; use 0 for all)
     --force             Overwrite existing .ralph/ configuration
     --skip-tasks        Skip task import, use default templates
     --non-interactive   Run with defaults (no prompts)

--- a/ralph_enable_ci.sh
+++ b/ralph_enable_ci.sh
@@ -50,6 +50,7 @@ FORCE_OVERWRITE=false
 TASK_SOURCE=""
 PRD_FILE=""
 GITHUB_LABEL="ralph-task"
+IMPORT_LIMIT="0"
 PROJECT_NAME=""
 PROJECT_TYPE=""
 OUTPUT_JSON=false
@@ -73,6 +74,7 @@ Options:
     --from <source>       Import tasks from: beads, github, prd, none
     --prd <file>          PRD file to convert (when --from prd)
     --label <label>       GitHub label filter (default: ralph-task)
+    --limit <n>           Max issues to import (default: 0 = all)
     --project-name <name> Override detected project name
     --project-type <type> Override detected type (typescript, python, etc.)
     --force               Overwrite existing .ralph/ configuration
@@ -152,6 +154,15 @@ parse_arguments() {
                     shift 2
                 else
                     output_error "--label requires a label name"
+                    exit $ENABLE_INVALID_ARGS
+                fi
+                ;;
+            --limit)
+                if [[ -n "$2" && "$2" =~ ^[0-9]+$ ]]; then
+                    IMPORT_LIMIT="$2"
+                    shift 2
+                else
+                    output_error "--limit requires a non-negative integer"
                     exit $ENABLE_INVALID_ARGS
                 fi
                 ;;
@@ -322,18 +333,21 @@ main() {
 
     # Import tasks
     local imported_tasks=""
+    local beads_tasks=""
+    local github_tasks=""
+    local prd_tasks=""
     case "$TASK_SOURCE" in
         beads)
-            if beads_tasks=$(fetch_beads_tasks 2>/dev/null); then
+            if beads_tasks=$(fetch_beads_tasks "open" "$IMPORT_LIMIT" 2>/dev/null); then
                 imported_tasks="$beads_tasks"
-                TASKS_IMPORTED=$(echo "$imported_tasks" | grep -c '^\- \[' || echo "0")
+                TASKS_IMPORTED=$(echo "$imported_tasks" | grep -c '^\- \[') || TASKS_IMPORTED=0
                 output_message "Imported $TASKS_IMPORTED tasks from beads"
             fi
             ;;
         github)
-            if github_tasks=$(fetch_github_tasks "$GITHUB_LABEL" 2>/dev/null); then
+            if github_tasks=$(fetch_github_tasks "$GITHUB_LABEL" "$IMPORT_LIMIT" 2>/dev/null); then
                 imported_tasks="$github_tasks"
-                TASKS_IMPORTED=$(echo "$imported_tasks" | grep -c '^\- \[' || echo "0")
+                TASKS_IMPORTED=$(echo "$imported_tasks" | grep -c '^\- \[') || TASKS_IMPORTED=0
                 output_message "Imported $TASKS_IMPORTED tasks from GitHub"
             fi
             ;;
@@ -341,7 +355,7 @@ main() {
             if [[ -n "$PRD_FILE" && -f "$PRD_FILE" ]]; then
                 if prd_tasks=$(extract_prd_tasks "$PRD_FILE" 2>/dev/null); then
                     imported_tasks="$prd_tasks"
-                    TASKS_IMPORTED=$(echo "$imported_tasks" | grep -c '^\- \[' || echo "0")
+                    TASKS_IMPORTED=$(echo "$imported_tasks" | grep -c '^\- \[') || TASKS_IMPORTED=0
                     output_message "Extracted $TASKS_IMPORTED tasks from PRD"
                 fi
             else

--- a/ralph_enable_ci.sh
+++ b/ralph_enable_ci.sh
@@ -50,7 +50,7 @@ FORCE_OVERWRITE=false
 TASK_SOURCE=""
 PRD_FILE=""
 GITHUB_LABEL="ralph-task"
-IMPORT_LIMIT="0"
+IMPORT_LIMIT="50"
 PROJECT_NAME=""
 PROJECT_TYPE=""
 OUTPUT_JSON=false
@@ -74,7 +74,7 @@ Options:
     --from <source>       Import tasks from: beads, github, prd, none
     --prd <file>          PRD file to convert (when --from prd)
     --label <label>       GitHub label filter (default: ralph-task)
-    --limit <n>           Max issues to import (default: 0 = all)
+    --limit <n>           Max issues to import per source (default: 50; use 0 for all)
     --project-name <name> Override detected project name
     --project-type <type> Override detected type (typescript, python, etc.)
     --force               Overwrite existing .ralph/ configuration

--- a/tests/unit/test_task_sources.bats
+++ b/tests/unit/test_task_sources.bats
@@ -267,3 +267,118 @@ EOF
     # 'none' doesn't import anything, so fails
     assert_failure
 }
+
+# =============================================================================
+# GITHUB FETCH — limit and pagination (4 tests)
+# =============================================================================
+#
+# These tests mock the `gh` CLI with a fake binary on PATH that records its
+# args to a file and writes fixture JSON based on subcommand. They also set
+# up a minimal git repo with a github.com remote so check_github_available
+# returns success.
+
+# Helper: build a mock gh binary that records args and emits fixture JSON
+_mock_gh_with_fixture() {
+    local api_fixture="$1"
+    local list_fixture="$2"
+    local args_file="$TEST_DIR/gh_args"
+
+    mkdir -p "$TEST_DIR/mock_bin"
+    cat > "$TEST_DIR/mock_bin/gh" << EOF
+#!/bin/bash
+# Record each invocation's args on its own line (append)
+printf '%s\n' "\$*" >> "$args_file"
+case "\$1" in
+    api)
+        cat <<'JSON'
+$api_fixture
+JSON
+        ;;
+    issue)
+        cat <<'JSON'
+$list_fixture
+JSON
+        ;;
+esac
+exit 0
+EOF
+    chmod +x "$TEST_DIR/mock_bin/gh"
+    export PATH="$TEST_DIR/mock_bin:$PATH"
+}
+
+# Helper: fake a git repo with github.com remote so check_github_available passes
+_fake_github_repo() {
+    git init -q . >/dev/null 2>&1
+    git remote add origin https://github.com/fake/repo.git >/dev/null 2>&1
+}
+
+@test "fetch_github_tasks with limit=0 uses gh api with --paginate" {
+    _fake_github_repo
+    _mock_gh_with_fixture \
+        '[{"number":1,"title":"issue one"},{"number":2,"title":"issue two"}]' \
+        '[]'
+
+    run fetch_github_tasks "" "0"
+    assert_success
+
+    # Verify gh api was invoked with --paginate and expected form fields
+    local args
+    args=$(cat "$TEST_DIR/gh_args")
+    [[ "$args" == *"api"* ]]
+    [[ "$args" == *"--paginate"* ]]
+    [[ "$args" == *"repos/{owner}/{repo}/issues"* ]]
+    [[ "$args" == *"state=open"* ]]
+    [[ "$args" == *"per_page=100"* ]]
+    # Must NOT fall back to the bounded `issue list` path
+    [[ "$args" != *"issue list"* ]]
+}
+
+@test "fetch_github_tasks with limit=0 filters out pull requests" {
+    _fake_github_repo
+    # Mixed response: two issues and one PR (PRs have a .pull_request field)
+    _mock_gh_with_fixture \
+        '[{"number":1,"title":"real issue"},{"number":2,"title":"a pull request","pull_request":{"url":"x"}},{"number":3,"title":"another issue"}]' \
+        '[]'
+
+    run fetch_github_tasks "" "0"
+    assert_success
+
+    [[ "$output" == *"#1"* ]]
+    [[ "$output" == *"real issue"* ]]
+    [[ "$output" == *"#3"* ]]
+    [[ "$output" == *"another issue"* ]]
+    # The PR must be filtered out
+    [[ "$output" != *"#2"* ]]
+    [[ "$output" != *"pull request"* ]]
+}
+
+@test "fetch_github_tasks with positive limit uses gh issue list" {
+    _fake_github_repo
+    _mock_gh_with_fixture \
+        '[]' \
+        '[{"number":42,"title":"bounded fetch"}]'
+
+    run fetch_github_tasks "" "5"
+    assert_success
+
+    local args
+    args=$(cat "$TEST_DIR/gh_args")
+    # Must use the bounded list path, not the paginated api path
+    [[ "$args" == *"issue list"* ]]
+    [[ "$args" == *"--limit 5"* ]]
+    [[ "$args" != *"--paginate"* ]]
+    [[ "$output" == *"#42"* ]]
+}
+
+@test "fetch_github_tasks with limit=0 plumbs label as URL-encoded field" {
+    _fake_github_repo
+    _mock_gh_with_fixture '[]' '[]'
+
+    run fetch_github_tasks "needs-triage" "0"
+    assert_success
+
+    local args
+    args=$(cat "$TEST_DIR/gh_args")
+    # -f labels=needs-triage ensures gh URL-encodes values with spaces/specials
+    [[ "$args" == *"labels=needs-triage"* ]]
+}


### PR DESCRIPTION
## Summary

Adds a `--limit <n>` flag to `ralph-enable` and `ralph-enable-ci` that bounds the number of issues imported from each task source (beads, GitHub) during project enablement. Default is `0`, meaning "import all" — preserving today's behavior.

Motivation: on repos with large beads or GitHub issue backlogs, the enable wizard currently dumps every open issue into `fix_plan.md`, producing an unwieldy initial task list. `--limit 25` lets the user bring in just the top of the queue and grow from there.

## Changes

- **`lib/task_sources.sh`**
  - `fetch_beads_tasks` now takes a second `limit` argument and forwards `--limit` to `bd list` (both JSON and text fallback paths).
  - `get_beads_count` accepts a `limit` argument symmetrically.
  - `fetch_github_tasks` honors the `limit` argument, mapping `0` → `1000` since `gh issue list` treats `0` differently from "all".
  - `import_tasks_from_sources` plumbs the limit through to both source fetchers.
- **`ralph_enable.sh`** — adds `--limit <n>` CLI parsing with non-negative-integer validation, default `0`, plumbed into `fetch_beads_tasks` / `fetch_github_tasks`.
- **`ralph_enable_ci.sh`** — same `--limit <n>` flag for the non-interactive path, with `output_error` validation.

## Why it's safe

- Default of `0` is a no-op for existing users.
- Validation rejects non-numeric / negative values before any side effects.
- The change is purely additive at the CLI surface — no existing flags or argument positions move.

## Test plan

- [ ] `ralph-enable --from beads --limit 5` imports at most 5 beads issues into `fix_plan.md`
- [ ] `ralph-enable --from github --limit 10` imports at most 10 GitHub issues
- [ ] `ralph-enable --from beads` (no `--limit`) still imports the full backlog
- [ ] `ralph-enable --limit -3` and `ralph-enable --limit foo` exit with the validation error
- [ ] `ralph-enable-ci --from beads --limit 5 --json` produces the limited list and a clean JSON envelope
- [ ] `npm test` passes locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --limit <n> option (default 50; 0 = import all) to cap imports from GitHub and Beads; fetches now accept and forward limit.

* **Behavior**
  * GitHub import uses paginated API when limit=0 and bounded listing when limit>0; Beads listing/counting honor limit.
  * Import counters explicitly set to 0 when no results.

* **Documentation**
  * Help updated to document --limit semantics.

* **Tests**
  * Added unit tests for GitHub pagination selection, label passing, PR filtering, and limit handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->