### PR TITLE
fix: prevent arithmetic error when fix_plan.md has no matching checkboxes

### DIFF
--- a/ralph_loop.sh
+++ b/ralph_loop.sh
@@ -711,8 +711,17 @@ should_exit_gracefully() {
     # Fix #144: Only match valid markdown checkboxes, not date entries like [2026-01-29]
     # Valid patterns: "- [ ]" (uncompleted) and "- [x]" or "- [X]" (completed)
     if [[ -f "$RALPH_DIR/fix_plan.md" ]]; then
-        local uncompleted_items=$(grep -cE "^[[:space:]]*- \[ \]" "$RALPH_DIR/fix_plan.md" 2>/dev/null || echo "0")
-        local completed_items=$(grep -cE "^[[:space:]]*- \[[xX]\]" "$RALPH_DIR/fix_plan.md" 2>/dev/null || echo "0")
+        # BSD grep (macOS) prints "0" to stdout AND exits 1 when no matches,
+        # so the previous `grep -c ... || echo "0"` fallback appended a second
+        # "0", producing a multi-line "0\n0" value that broke the $((...))
+        # arithmetic with: "syntax error in expression (error token is "0")".
+        # Pipe through `head -n1` to mask the non-zero exit and keep one line.
+        local uncompleted_items
+        uncompleted_items=$(grep -cE "^[[:space:]]*- \[ \]" "$RALPH_DIR/fix_plan.md" 2>/dev/null | head -n1)
+        local completed_items
+        completed_items=$(grep -cE "^[[:space:]]*- \[[xX]\]" "$RALPH_DIR/fix_plan.md" 2>/dev/null | head -n1)
+        uncompleted_items=${uncompleted_items:-0}
+        completed_items=${completed_items:-0}
         local total_items=$((uncompleted_items + completed_items))
 
         if [[ $total_items -gt 0 ]] && [[ $completed_items -eq $total_items ]]; then


### PR DESCRIPTION
## Summary

`should_exit_gracefully` in `ralph_loop.sh` counts checkbox items in `fix_plan.md` to decide whether all tasks are done. The current form fails on macOS:

```bash
local uncompleted_items=$(grep -cE "..." "$file" 2>/dev/null || echo "0")
local completed_items=$(grep -cE "..." "$file" 2>/dev/null || echo "0")
local total_items=$((uncompleted_items + completed_items))
```

### Root cause

BSD grep (macOS default) **both prints `"0"` to stdout *and* exits 1** when there are no matches. The `|| echo "0"` fallback therefore appends a second `"0"`, and the variable becomes a multi-line `"0\n0"` string. The next line:

```bash
local total_items=$((uncompleted_items + completed_items))
```

then crashes with:

```
ralph_loop.sh: line 716: 0
0: syntax error in expression (error token is "0")
```

### Impact

- Silently disables the *"all fix_plan.md items completed"* graceful-exit branch — the function falls through and the loop never auto-stops on a fully checked plan.
- Spams the loop log with the `syntax error in expression` message every iteration.
- Reproduces consistently on macOS (BSD grep). GNU grep may not hit it because GNU `grep -c` exits 0 on zero matches, so the `||` fallback never runs.

### Fix

Pipe `grep -c` through `head -n1`. The pipeline's exit code becomes `head`'s (always 0), so the brittle `||` fallback is no longer needed. BSD grep already prints `"0"` on no match, so the count line is always available. A defensive `${var:-0}` covers the edge case of grep producing no output at all.

## Test plan

- [x] `bash -n ralph_loop.sh` — syntax OK
- [x] Smoke test on macOS BSD grep:
  - empty `fix_plan.md` → `u=0 c=0 total=0` (no error)
  - all-done plan (2 `[x]`, 0 `[ ]`) → `u=0 c=2 total=2` and triggers the `plan_complete` branch
  - mixed plan → counts correctly
- [ ] Re-run a real ralph loop on macOS and confirm the `syntax error in expression` line no longer appears in `.ralph/logs/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed checkbox completion counting to work reliably on macOS and BSD systems, ensuring proper script execution and completion tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->