### PR TITLE
fix(loop): trust agent RALPH_STATUS before halting on permission denials

### DIFF
--- a/lib/circuit_breaker.sh
+++ b/lib/circuit_breaker.sh
@@ -195,15 +195,25 @@ record_loop_result() {
         ralph_files_modified=$((ralph_files_modified + 0))
     fi
 
-    # Track permission denials (Issue #101)
+    # Track permission denials (Issue #101, refined for Issue #243)
+    # Defer to the agent's RALPH_STATUS self-report, mirroring the fix in
+    # ralph_loop.sh's should_exit_gracefully (PR #264) and the producer-side
+    # analysis.status fix in lib/response_analyzer.sh. A denial paired with
+    # STATUS: COMPLETE or IN_PROGRESS means the agent recovered — treat it as
+    # no denial so the circuit doesn't open on benign single-denial sessions.
+    # Only BLOCKED or missing/UNKNOWN status counts toward the trip threshold,
+    # preserving the silent-loop safety guarantee from #101.
     local has_permission_denials="false"
+    local agent_status="UNKNOWN"
     if [[ -f "$response_analysis_file" ]]; then
         has_permission_denials=$(jq -r '.analysis.has_permission_denials // false' "$response_analysis_file" 2>/dev/null || echo "false")
+        agent_status=$(jq -r '.analysis.status // "UNKNOWN"' "$response_analysis_file" 2>/dev/null || echo "UNKNOWN")
     fi
 
-    if [[ "$has_permission_denials" == "true" ]]; then
+    if [[ "$has_permission_denials" == "true" ]] && [[ "$agent_status" == "BLOCKED" || "$agent_status" == "UNKNOWN" || -z "$agent_status" ]]; then
         consecutive_permission_denials=$((consecutive_permission_denials + 1))
     else
+        # Either no denial, or agent recovered — reset counter
         consecutive_permission_denials=0
     fi
 

--- a/lib/response_analyzer.sh
+++ b/lib/response_analyzer.sh
@@ -175,12 +175,35 @@ parse_json_response() {
             fi
             # Also check STATUS field as fallback ONLY when EXIT_SIGNAL was not specified
             # This respects explicit EXIT_SIGNAL: false which means "task complete, continue working"
+            #
+            # Use anchored grep so "TESTS_STATUS:" doesn't match alongside "STATUS:" — a naive
+            # `grep STATUS:` would join values across both lines and produce e.g. "COMPLETE PASSING".
             local embedded_status
-            embedded_status=$(echo "$result_text" | grep "STATUS:" | cut -d: -f2 | xargs)
+            embedded_status=$(echo "$result_text" | grep -E "^STATUS:" | head -1 | cut -d: -f2 | xargs)
             if [[ "$embedded_status" == "COMPLETE" && "$explicit_exit_signal_found" != "true" ]]; then
                 # STATUS: COMPLETE without any EXIT_SIGNAL field implies completion
                 exit_signal="true"
                 [[ "${VERBOSE_PROGRESS:-}" == "true" ]] && echo "DEBUG: Inferred EXIT_SIGNAL=true from .result STATUS=COMPLETE (no explicit EXIT_SIGNAL found)" >&2
+            fi
+        fi
+    fi
+
+    # Issue #243 (second half): always promote embedded STATUS into `status` so
+    # downstream consumers (analyze_response → .analysis.status → ralph_loop.sh
+    # permission-denial handler from PR #264) can defer to the agent's own
+    # RALPH_STATUS self-report. The block above only uses STATUS to derive
+    # exit_signal; it never updates `status` itself, so .analysis.status would
+    # always be "UNKNOWN" and the loop would halt on every denial regardless of
+    # whether the agent recovered.
+    if [[ "$status" == "UNKNOWN" && "$has_result_field" == "true" ]]; then
+        local status_promotion_text
+        status_promotion_text=$(jq -r '.result // ""' "$output_file" 2>/dev/null)
+        if [[ -n "$status_promotion_text" ]] && echo "$status_promotion_text" | grep -q -- "---RALPH_STATUS---"; then
+            local promoted_status
+            promoted_status=$(echo "$status_promotion_text" | grep -E "^STATUS:" | head -1 | cut -d: -f2 | xargs)
+            if [[ -n "$promoted_status" ]]; then
+                status="$promoted_status"
+                [[ "${VERBOSE_PROGRESS:-}" == "true" ]] && echo "DEBUG: Promoted STATUS=$status from RALPH_STATUS block (Issue #243)" >&2
             fi
         fi
     fi
@@ -373,6 +396,11 @@ analyze_response() {
             local permission_denial_count=$(jq -r '.permission_denial_count' $RALPH_DIR/.json_parse_result 2>/dev/null || echo "0")
             local denied_commands_json=$(jq -r '.denied_commands' $RALPH_DIR/.json_parse_result 2>/dev/null || echo "[]")
 
+            # Agent status from RALPH_STATUS block (Issue #243). Surfaced into
+            # analysis.status so ralph_loop.sh's permission-denial handler can
+            # decide whether to halt (BLOCKED/UNKNOWN) or continue (COMPLETE/IN_PROGRESS).
+            local agent_status=$(jq -r '.status // "UNKNOWN"' $RALPH_DIR/.json_parse_result 2>/dev/null || echo "UNKNOWN")
+
             # Persist session ID if present (for session continuity across loop iterations)
             if [[ -n "$session_id" && "$session_id" != "null" ]]; then
                 store_session_id "$session_id"
@@ -437,6 +465,7 @@ analyze_response() {
                 --arg timestamp "$(get_iso_timestamp)" \
                 --arg output_file "$output_file" \
                 --arg output_format "json" \
+                --arg status "$agent_status" \
                 --argjson has_completion_signal "$has_completion_signal" \
                 --argjson is_test_only "$is_test_only" \
                 --argjson is_stuck "$is_stuck" \
@@ -457,6 +486,7 @@ analyze_response() {
                     output_file: $output_file,
                     output_format: $output_format,
                     analysis: {
+                        status: $status,
                         has_completion_signal: $has_completion_signal,
                         is_test_only: $is_test_only,
                         is_stuck: $is_stuck,
@@ -485,10 +515,17 @@ analyze_response() {
     # If explicit signal found, heuristics should NOT override Claude's intent
     local explicit_exit_signal_found=false
 
+    # Agent status from RALPH_STATUS block (Issue #243). Default UNKNOWN — set
+    # below when the block is present. Surfaced into analysis.status downstream.
+    local status="UNKNOWN"
+
     # 1. Check for explicit structured output (if Claude follows schema)
     if grep -q -- "---RALPH_STATUS---" "$output_file"; then
         # Parse structured output
-        local status=$(grep "STATUS:" "$output_file" | cut -d: -f2 | xargs)
+        # Anchored "^STATUS:" so "TESTS_STATUS:" doesn't co-match — naive grep
+        # would join values across both lines into e.g. "COMPLETE PASSING".
+        status=$(grep -E "^STATUS:" "$output_file" | head -1 | cut -d: -f2 | xargs)
+        [[ -z "$status" ]] && status="UNKNOWN"
         local exit_sig=$(grep "EXIT_SIGNAL:" "$output_file" | cut -d: -f2 | xargs)
 
         # If EXIT_SIGNAL is explicitly provided, respect it
@@ -658,6 +695,7 @@ analyze_response() {
         --arg timestamp "$(get_iso_timestamp)" \
         --arg output_file "$output_file" \
         --arg output_format "text" \
+        --arg status "$status" \
         --argjson has_completion_signal "$has_completion_signal" \
         --argjson is_test_only "$is_test_only" \
         --argjson is_stuck "$is_stuck" \
@@ -675,6 +713,7 @@ analyze_response() {
             output_file: $output_file,
             output_format: $output_format,
             analysis: {
+                status: $status,
                 has_completion_signal: $has_completion_signal,
                 is_test_only: $is_test_only,
                 is_stuck: $is_stuck,

--- a/ralph_loop.sh
+++ b/ralph_loop.sh
@@ -651,18 +651,32 @@ should_exit_gracefully() {
 
     # Check for exit conditions
 
-    # 0. Permission denials (highest priority - Issue #101)
-    # When Claude Code is denied permission to run commands, halt immediately
-    # to allow user to update .ralphrc ALLOWED_TOOLS configuration
+    # 0. Permission denials (Issue #101, refined for Issue #243)
+    # When Claude Code is denied permission to run commands, defer to the agent's
+    # own RALPH_STATUS self-report to decide whether to halt:
+    #   - STATUS: BLOCKED      → halt (agent says it is stuck)
+    #   - STATUS missing/UNKNOWN → halt (preserves #101 safety against silent loops)
+    #   - STATUS: COMPLETE | IN_PROGRESS → warn and continue (agent recovered)
+    # The agent is instructed (in its prompt) to create a GitHub Issue and route
+    # around peripheral denials, so a single denial inside an otherwise successful
+    # loop should not kill productive sessions (Issue #243).
     if [[ -f "$RESPONSE_ANALYSIS_FILE" ]]; then
         local has_permission_denials=$(jq -r '.analysis.has_permission_denials // false' "$RESPONSE_ANALYSIS_FILE" 2>/dev/null || echo "false")
         if [[ "$has_permission_denials" == "true" ]]; then
             local denied_count=$(jq -r '.analysis.permission_denial_count // 0' "$RESPONSE_ANALYSIS_FILE" 2>/dev/null || echo "0")
             local denied_cmds=$(jq -r '.analysis.denied_commands | join(", ")' "$RESPONSE_ANALYSIS_FILE" 2>/dev/null || echo "unknown")
-            log_status "WARN" "🚫 Permission denied for $denied_count command(s): $denied_cmds"
-            log_status "WARN" "Update ALLOWED_TOOLS in .ralphrc to include the required tools"
-            echo "permission_denied"
-            return 0
+            local agent_status=$(jq -r '.analysis.status // "UNKNOWN"' "$RESPONSE_ANALYSIS_FILE" 2>/dev/null || echo "UNKNOWN")
+            if [[ "$agent_status" == "BLOCKED" || "$agent_status" == "UNKNOWN" || -z "$agent_status" ]]; then
+                log_status "WARN" "🚫 Permission denied for $denied_count command(s): $denied_cmds"
+                log_status "WARN" "Agent status: $agent_status — halting"
+                log_status "WARN" "Update ALLOWED_TOOLS in .ralphrc to include the required tools"
+                echo "permission_denied"
+                return 0
+            else
+                log_status "WARN" "⚠️  Permission denied for $denied_count command(s): $denied_cmds"
+                log_status "WARN" "Agent status: $agent_status — agent reports it recovered; continuing"
+                log_status "WARN" "Consider adding the denied tool(s) to ALLOWED_TOOLS in .ralphrc"
+            fi
         fi
     fi
 

--- a/tests/unit/test_circuit_breaker_permission_denial.bats
+++ b/tests/unit/test_circuit_breaker_permission_denial.bats
@@ -1,0 +1,162 @@
+#!/usr/bin/env bats
+# Unit Tests for Circuit Breaker permission-denial counter (Issue #243 follow-up)
+#
+# record_loop_result tracks `consecutive_permission_denials` independently
+# of should_exit_gracefully. Without status-aware counting, the wrapper trips
+# even after PR #264 — a productive loop with a benign denial still increments
+# the counter, and two such loops in a row open the circuit.
+#
+# Verified against game-one production: 2026-05-13 14:39 UTC, loop 4 merged
+# PR #464 successfully (status IN_PROGRESS) but had 4 denied compound-bash
+# calls. Combined with loop 3's 2 denials (status IN_PROGRESS), the counter
+# went 0→0→1→2 and the circuit opened.
+
+load '../helpers/test_helper'
+
+SCRIPT_DIR="${BATS_TEST_DIRNAME}/../../lib"
+
+setup() {
+    export TEST_TEMP_DIR="$(mktemp -d)"
+    cd "$TEST_TEMP_DIR"
+
+    export RALPH_DIR=".ralph"
+    export CB_STATE_FILE="$RALPH_DIR/.circuit_breaker_state"
+    export CB_HISTORY_FILE="$RALPH_DIR/.circuit_breaker_history"
+    export RESPONSE_ANALYSIS_FILE="$RALPH_DIR/.response_analysis"
+    export CB_PERMISSION_DENIAL_THRESHOLD=2
+
+    mkdir -p "$RALPH_DIR"
+
+    source "$SCRIPT_DIR/date_utils.sh"
+    source "$SCRIPT_DIR/circuit_breaker.sh"
+}
+
+teardown() {
+    cd /
+    rm -rf "$TEST_TEMP_DIR"
+}
+
+# Helper: write a .response_analysis with given agent status and denial flag.
+# Default `files_modified` is 1 to mirror real productive loops (game-one
+# loop 4 reported FILES_MODIFIED: 8) — without it the no-progress counter
+# would trip on its own, masking the denial-counter behavior we're testing.
+write_analysis() {
+    local agent_status="$1"
+    local has_denials="$2"
+    local files_modified="${3:-1}"
+    cat > "$RESPONSE_ANALYSIS_FILE" << EOF
+{
+    "loop_number": 1,
+    "analysis": {
+        "status": "$agent_status",
+        "has_permission_denials": $has_denials,
+        "permission_denial_count": $([[ "$has_denials" == "true" ]] && echo 1 || echo 0),
+        "denied_commands": $([[ "$has_denials" == "true" ]] && echo '["Bash(some compound)"]' || echo '[]'),
+        "exit_signal": false,
+        "has_completion_signal": false,
+        "is_test_only": false,
+        "is_stuck": false,
+        "has_progress": false,
+        "files_modified": $files_modified,
+        "asking_questions": false
+    }
+}
+EOF
+}
+
+# Helper: read the current denial counter from state file.
+get_counter() {
+    jq -r '.consecutive_permission_denials' "$CB_STATE_FILE"
+}
+
+get_state() {
+    jq -r '.state' "$CB_STATE_FILE"
+}
+
+@test "denial with STATUS=COMPLETE does not increment counter" {
+    write_analysis "COMPLETE" "true"
+    record_loop_result 1 0 "false" 1000
+    assert_equal "$(get_counter)" "0"
+    assert_equal "$(get_state)" "CLOSED"
+}
+
+@test "denial with STATUS=IN_PROGRESS does not increment counter" {
+    write_analysis "IN_PROGRESS" "true"
+    record_loop_result 1 0 "false" 1000
+    assert_equal "$(get_counter)" "0"
+    assert_equal "$(get_state)" "CLOSED"
+}
+
+@test "denial with STATUS=BLOCKED increments counter" {
+    write_analysis "BLOCKED" "true"
+    record_loop_result 1 0 "false" 1000
+    assert_equal "$(get_counter)" "1"
+}
+
+@test "denial with STATUS=UNKNOWN increments counter (preserves #101 safety)" {
+    write_analysis "UNKNOWN" "true"
+    record_loop_result 1 0 "false" 1000
+    assert_equal "$(get_counter)" "1"
+}
+
+@test "denial with no .response_analysis still increments (preserves #101 safety)" {
+    rm -f "$RESPONSE_ANALYSIS_FILE"
+    # Create a minimal stub the existing code expects, with denial flag but no status
+    cat > "$RESPONSE_ANALYSIS_FILE" << 'EOF'
+{
+    "loop_number": 1,
+    "analysis": {
+        "has_permission_denials": true
+    }
+}
+EOF
+    record_loop_result 1 0 "false" 1000
+    assert_equal "$(get_counter)" "1"
+}
+
+@test "two consecutive IN_PROGRESS denials do NOT open circuit (game-one repro)" {
+    # This is the exact production failure mode: loops 3+4 both had denials,
+    # both IN_PROGRESS, and the circuit opened at threshold=2 even though the
+    # agent merged a PR in loop 4. The fix must keep this scenario closed.
+    write_analysis "IN_PROGRESS" "true"
+    record_loop_result 3 0 "false" 1000
+    write_analysis "IN_PROGRESS" "true"
+    record_loop_result 4 0 "false" 1000
+
+    assert_equal "$(get_counter)" "0"
+    assert_equal "$(get_state)" "CLOSED"
+}
+
+@test "two consecutive BLOCKED denials open the circuit" {
+    write_analysis "BLOCKED" "true"
+    record_loop_result 1 0 "false" 1000
+    write_analysis "BLOCKED" "true"
+    # record_loop_result returns non-zero when it opens the circuit; that's
+    # signalling, not an error — use `|| true` so the state-check below runs.
+    record_loop_result 2 0 "false" 1000 || true
+
+    assert_equal "$(get_counter)" "2"
+    assert_equal "$(get_state)" "OPEN"
+}
+
+@test "BLOCKED denial then IN_PROGRESS denial resets counter (recovery)" {
+    write_analysis "BLOCKED" "true"
+    record_loop_result 1 0 "false" 1000
+    assert_equal "$(get_counter)" "1"
+
+    # Next loop: still a denial, but agent recovered — counter resets
+    write_analysis "IN_PROGRESS" "true"
+    record_loop_result 2 0 "false" 1000
+    assert_equal "$(get_counter)" "0"
+    assert_equal "$(get_state)" "CLOSED"
+}
+
+@test "no denial resets counter regardless of status" {
+    write_analysis "BLOCKED" "true"
+    record_loop_result 1 0 "false" 1000
+    assert_equal "$(get_counter)" "1"
+
+    write_analysis "IN_PROGRESS" "false"
+    record_loop_result 2 0 "false" 1000
+    assert_equal "$(get_counter)" "0"
+}

--- a/tests/unit/test_exit_detection.bats
+++ b/tests/unit/test_exit_detection.bats
@@ -1403,3 +1403,87 @@ EOF
     # Must call reset_session before break
     echo "$exit_block" | grep -q 'reset_session'
 }
+
+# =============================================================================
+# END-TO-END: analyze_response → should_exit_gracefully on permission denials
+#
+# These tests pipe a realistic Claude CLI JSON file (matching the shape of an
+# actual production halt) through the *real* analyze_response, then through
+# should_exit_gracefully_with_denials. They are the integration tests that
+# would have caught the "analysis.status never written" defect when PR #264
+# was first opened.
+# =============================================================================
+
+@test "end-to-end: COMPLETE status from real analyze_response output continues past denial" {
+    # Reproduces the exact shape of the production halt at game-one
+    # 2026-05-13 07:24 UTC: agent merged 6 PRs successfully, hit one denied
+    # `echo "..." >> file` redirect, recovered using the Edit tool, reported
+    # COMPLETE. Wrapper must continue, not halt.
+    source "${BATS_TEST_DIRNAME}/../../lib/response_analyzer.sh"
+
+    local output_file="$RALPH_DIR/claude_output.log"
+    cat > "$output_file" << 'EOF'
+{
+    "result": "Merged 6 PRs.\n\n---RALPH_STATUS---\nSTATUS: COMPLETE\nTASKS_COMPLETED_THIS_LOOP: 6\nFILES_MODIFIED: 8\nTESTS_STATUS: PASSING\nWORK_TYPE: IMPLEMENTATION\nEXIT_SIGNAL: false\nPERMISSION_DENIALS: none\n---END_RALPH_STATUS---",
+    "sessionId": "session-e2e-complete",
+    "permission_denials": [
+        {"tool_name": "Bash", "tool_input": {"command": "echo \"line\" >> file.log"}}
+    ]
+}
+EOF
+
+    # Drive the real analyzer — no hand-crafted .response_analysis fixture
+    analyze_response "$output_file" 1 "$RESPONSE_ANALYSIS_FILE"
+
+    echo '{"test_only_loops": [], "done_signals": [], "completion_indicators": []}' > "$EXIT_SIGNALS_FILE"
+
+    result=$(should_exit_gracefully_with_denials || true)
+    assert_equal "$result" ""
+}
+
+@test "end-to-end: missing RALPH_STATUS from real analyze_response halts on denial" {
+    # Safety preservation (#101): if the agent fails to emit a RALPH_STATUS
+    # block at all and there are denials, the loop must still halt — we cannot
+    # tell whether the agent recovered.
+    source "${BATS_TEST_DIRNAME}/../../lib/response_analyzer.sh"
+
+    local output_file="$RALPH_DIR/claude_output.log"
+    cat > "$output_file" << 'EOF'
+{
+    "result": "Did stuff but never wrote a status block.",
+    "sessionId": "session-e2e-missing",
+    "permission_denials": [
+        {"tool_name": "Bash", "tool_input": {"command": "rm -rf /"}}
+    ]
+}
+EOF
+
+    analyze_response "$output_file" 1 "$RESPONSE_ANALYSIS_FILE"
+
+    echo '{"test_only_loops": [], "done_signals": [], "completion_indicators": []}' > "$EXIT_SIGNALS_FILE"
+
+    result=$(should_exit_gracefully_with_denials)
+    assert_equal "$result" "permission_denied"
+}
+
+@test "end-to-end: BLOCKED status from real analyze_response halts on denial" {
+    source "${BATS_TEST_DIRNAME}/../../lib/response_analyzer.sh"
+
+    local output_file="$RALPH_DIR/claude_output.log"
+    cat > "$output_file" << 'EOF'
+{
+    "result": "Cannot proceed.\n\n---RALPH_STATUS---\nSTATUS: BLOCKED\nTESTS_STATUS: NOT_RUN\nEXIT_SIGNAL: true\n---END_RALPH_STATUS---",
+    "sessionId": "session-e2e-blocked",
+    "permission_denials": [
+        {"tool_name": "Bash", "tool_input": {"command": "critical-tool"}}
+    ]
+}
+EOF
+
+    analyze_response "$output_file" 1 "$RESPONSE_ANALYSIS_FILE"
+
+    echo '{"test_only_loops": [], "done_signals": [], "completion_indicators": []}' > "$EXIT_SIGNALS_FILE"
+
+    result=$(should_exit_gracefully_with_denials)
+    assert_equal "$result" "permission_denied"
+}

--- a/tests/unit/test_exit_detection.bats
+++ b/tests/unit/test_exit_detection.bats
@@ -683,12 +683,18 @@ should_exit_gracefully_with_denials() {
     recent_done_signals=$(echo "$signals" | jq '.done_signals | length' 2>/dev/null || echo "0")
     recent_completion_indicators=$(echo "$signals" | jq '.completion_indicators | length' 2>/dev/null || echo "0")
 
-    # Check for permission denials first (highest priority - Issue #101)
+    # Check for permission denials first (Issue #101, refined for Issue #243)
+    # Halt only when the agent itself reports BLOCKED or no status; trust the agent
+    # when it reports COMPLETE or IN_PROGRESS.
     if [[ -f "$RESPONSE_ANALYSIS_FILE" ]]; then
         local has_permission_denials=$(jq -r '.analysis.has_permission_denials // false' "$RESPONSE_ANALYSIS_FILE" 2>/dev/null || echo "false")
         if [[ "$has_permission_denials" == "true" ]]; then
-            echo "permission_denied"
-            return 0
+            local agent_status=$(jq -r '.analysis.status // "UNKNOWN"' "$RESPONSE_ANALYSIS_FILE" 2>/dev/null || echo "UNKNOWN")
+            if [[ "$agent_status" == "BLOCKED" || "$agent_status" == "UNKNOWN" || -z "$agent_status" ]]; then
+                echo "permission_denied"
+                return 0
+            fi
+            # Agent reports COMPLETE or IN_PROGRESS — recovered; fall through
         fi
     fi
 
@@ -837,6 +843,90 @@ EOF
 
     result=$(should_exit_gracefully_with_denials || true)
     assert_equal "$result" ""
+}
+
+# Test 40a: Denial with STATUS: COMPLETE — agent recovered, do NOT halt (Issue #243)
+@test "should_exit_gracefully continues on permission denial when agent reports COMPLETE" {
+    echo '{"test_only_loops": [], "done_signals": [], "completion_indicators": []}' > "$EXIT_SIGNALS_FILE"
+
+    # Denial occurred but agent reports task finished successfully
+    cat > "$RESPONSE_ANALYSIS_FILE" << 'EOF'
+{
+    "loop_number": 1,
+    "analysis": {
+        "status": "COMPLETE",
+        "has_permission_denials": true,
+        "permission_denial_count": 1,
+        "denied_commands": ["mcp__some_peripheral_tool"],
+        "exit_signal": false
+    }
+}
+EOF
+
+    result=$(should_exit_gracefully_with_denials || true)
+    assert_equal "$result" ""
+}
+
+# Test 40b: Denial with STATUS: IN_PROGRESS — agent recovered, do NOT halt (Issue #243)
+@test "should_exit_gracefully continues on permission denial when agent reports IN_PROGRESS" {
+    echo '{"test_only_loops": [], "done_signals": [], "completion_indicators": []}' > "$EXIT_SIGNALS_FILE"
+
+    cat > "$RESPONSE_ANALYSIS_FILE" << 'EOF'
+{
+    "loop_number": 1,
+    "analysis": {
+        "status": "IN_PROGRESS",
+        "has_permission_denials": true,
+        "permission_denial_count": 1,
+        "denied_commands": ["Bash(awk ...)"],
+        "exit_signal": false
+    }
+}
+EOF
+
+    result=$(should_exit_gracefully_with_denials || true)
+    assert_equal "$result" ""
+}
+
+# Test 40c: Denial with STATUS: BLOCKED — agent stuck, DO halt (Issue #243)
+@test "should_exit_gracefully halts on permission denial when agent reports BLOCKED" {
+    echo '{"test_only_loops": [], "done_signals": [], "completion_indicators": []}' > "$EXIT_SIGNALS_FILE"
+
+    cat > "$RESPONSE_ANALYSIS_FILE" << 'EOF'
+{
+    "loop_number": 1,
+    "analysis": {
+        "status": "BLOCKED",
+        "has_permission_denials": true,
+        "permission_denial_count": 1,
+        "denied_commands": ["Bash(critical-command)"],
+        "exit_signal": true
+    }
+}
+EOF
+
+    result=$(should_exit_gracefully_with_denials)
+    assert_equal "$result" "permission_denied"
+}
+
+# Test 40d: Denial with missing status — preserve #101 safety, DO halt
+@test "should_exit_gracefully halts on permission denial when agent status is missing" {
+    echo '{"test_only_loops": [], "done_signals": [], "completion_indicators": []}' > "$EXIT_SIGNALS_FILE"
+
+    # No status field at all — agent may have failed to emit RALPH_STATUS
+    cat > "$RESPONSE_ANALYSIS_FILE" << 'EOF'
+{
+    "loop_number": 1,
+    "analysis": {
+        "has_permission_denials": true,
+        "permission_denial_count": 1,
+        "denied_commands": ["Bash(npm install)"]
+    }
+}
+EOF
+
+    result=$(should_exit_gracefully_with_denials)
+    assert_equal "$result" "permission_denied"
 }
 
 # =============================================================================

--- a/tests/unit/test_json_parsing.bats
+++ b/tests/unit/test_json_parsing.bats
@@ -1155,3 +1155,161 @@ EOF
     exit_signal=$(jq -r '.analysis.exit_signal' "$RALPH_DIR/.response_analysis")
     assert_equal "$exit_signal" "false"
 }
+
+# =============================================================================
+# RALPH_STATUS STATUS PROPAGATION TESTS (Issue #243 — second half)
+#
+# PR #264 makes ralph_loop.sh defer to .analysis.status when handling permission
+# denials. For that to work, parse_json_response must extract the STATUS value
+# from the embedded RALPH_STATUS block and propagate it through analyze_response
+# into the .analysis.status field of .response_analysis.
+#
+# Without these tests, the upstream PR shipped a feature that read a field the
+# producer never wrote — denial recovery silently never worked in production.
+# =============================================================================
+
+@test "parse_json_response promotes embedded STATUS=COMPLETE from RALPH_STATUS block" {
+    local output_file="$LOG_DIR/test_output.log"
+    cat > "$output_file" << 'EOF'
+{
+    "result": "Did the work.\n\n---RALPH_STATUS---\nSTATUS: COMPLETE\nTASKS_COMPLETED_THIS_LOOP: 1\nTESTS_STATUS: PASSING\nEXIT_SIGNAL: false\n---END_RALPH_STATUS---",
+    "sessionId": "session-status-complete"
+}
+EOF
+
+    run parse_json_response "$output_file"
+    assert_equal "$status" "0"
+
+    local result_file="$RALPH_DIR/.json_parse_result"
+    [[ -f "$result_file" ]]
+
+    local parsed_status
+    parsed_status=$(jq -r '.status' "$result_file")
+    assert_equal "$parsed_status" "COMPLETE"
+}
+
+@test "parse_json_response promotes embedded STATUS=IN_PROGRESS from RALPH_STATUS block" {
+    local output_file="$LOG_DIR/test_output.log"
+    cat > "$output_file" << 'EOF'
+{
+    "result": "Still working.\n\n---RALPH_STATUS---\nSTATUS: IN_PROGRESS\nTESTS_STATUS: NOT_RUN\nEXIT_SIGNAL: false\n---END_RALPH_STATUS---",
+    "sessionId": "session-status-in-progress"
+}
+EOF
+
+    run parse_json_response "$output_file"
+    assert_equal "$status" "0"
+
+    local parsed_status
+    parsed_status=$(jq -r '.status' "$RALPH_DIR/.json_parse_result")
+    assert_equal "$parsed_status" "IN_PROGRESS"
+}
+
+@test "parse_json_response promotes embedded STATUS=BLOCKED from RALPH_STATUS block" {
+    local output_file="$LOG_DIR/test_output.log"
+    cat > "$output_file" << 'EOF'
+{
+    "result": "Cannot proceed.\n\n---RALPH_STATUS---\nSTATUS: BLOCKED\nTESTS_STATUS: NOT_RUN\nEXIT_SIGNAL: true\n---END_RALPH_STATUS---",
+    "sessionId": "session-status-blocked"
+}
+EOF
+
+    run parse_json_response "$output_file"
+    assert_equal "$status" "0"
+
+    local parsed_status
+    parsed_status=$(jq -r '.status' "$RALPH_DIR/.json_parse_result")
+    assert_equal "$parsed_status" "BLOCKED"
+}
+
+@test "parse_json_response disambiguates STATUS from TESTS_STATUS in RALPH_STATUS block" {
+    # Regression guard: a naive `grep STATUS:` matches both "STATUS:" and
+    # "TESTS_STATUS:", joining their values. Anchor extraction must take only
+    # the STATUS line, not concatenate "COMPLETE FAILING".
+    local output_file="$LOG_DIR/test_output.log"
+    cat > "$output_file" << 'EOF'
+{
+    "result": "Done.\n\n---RALPH_STATUS---\nSTATUS: COMPLETE\nTESTS_STATUS: FAILING\nEXIT_SIGNAL: false\n---END_RALPH_STATUS---",
+    "sessionId": "session-status-disambig"
+}
+EOF
+
+    run parse_json_response "$output_file"
+    assert_equal "$status" "0"
+
+    local parsed_status
+    parsed_status=$(jq -r '.status' "$RALPH_DIR/.json_parse_result")
+    assert_equal "$parsed_status" "COMPLETE"
+}
+
+@test "analyze_response surfaces analysis.status from embedded RALPH_STATUS (JSON path)" {
+    # Contract test: PR #264's ralph_loop.sh patch reads .analysis.status —
+    # this asserts analyze_response actually writes it for Claude CLI JSON
+    # output. Mirrors the exact shape from a real production halt
+    # (game-one repo, 2026-05-13 07:24 UTC) where the agent reported COMPLETE
+    # after recovering from a single denied tool call.
+    local output_file="$LOG_DIR/test_output.log"
+    cat > "$output_file" << 'EOF'
+{
+    "result": "Merged 6 PRs.\n\n---RALPH_STATUS---\nSTATUS: COMPLETE\nTASKS_COMPLETED_THIS_LOOP: 6\nFILES_MODIFIED: 8\nTESTS_STATUS: PASSING\nWORK_TYPE: IMPLEMENTATION\nEXIT_SIGNAL: false\nPERMISSION_DENIALS: none\n---END_RALPH_STATUS---",
+    "sessionId": "session-real-shape",
+    "permission_denials": [
+        {"tool_name": "Bash", "tool_input": {"command": "echo \"line\" >> file.log"}}
+    ]
+}
+EOF
+
+    run analyze_response "$output_file" 1 "$RALPH_DIR/.response_analysis"
+    assert_success
+
+    local analysis_status
+    analysis_status=$(jq -r '.analysis.status' "$RALPH_DIR/.response_analysis")
+    assert_equal "$analysis_status" "COMPLETE"
+
+    # Sanity: the denial is still surfaced (we want the recovery path, not
+    # to hide that a denial happened).
+    local has_denials
+    has_denials=$(jq -r '.analysis.has_permission_denials' "$RALPH_DIR/.response_analysis")
+    assert_equal "$has_denials" "true"
+}
+
+@test "analyze_response surfaces analysis.status from RALPH_STATUS (text path)" {
+    # Text-fallback path must populate analysis.status the same way the JSON
+    # path does — both feed the same downstream check in ralph_loop.sh.
+    local output_file="$LOG_DIR/test_output.log"
+    cat > "$output_file" << 'EOF'
+Did the work and finished cleanly.
+
+---RALPH_STATUS---
+STATUS: COMPLETE
+TASKS_COMPLETED_THIS_LOOP: 2
+TESTS_STATUS: PASSING
+EXIT_SIGNAL: false
+---END_RALPH_STATUS---
+EOF
+
+    run analyze_response "$output_file" 1 "$RALPH_DIR/.response_analysis"
+    assert_success
+
+    local analysis_status
+    analysis_status=$(jq -r '.analysis.status' "$RALPH_DIR/.response_analysis")
+    assert_equal "$analysis_status" "COMPLETE"
+}
+
+@test "analyze_response defaults analysis.status to UNKNOWN when no RALPH_STATUS block" {
+    # Preserves #101 safety: missing/UNKNOWN status with denials still halts.
+    local output_file="$LOG_DIR/test_output.log"
+    cat > "$output_file" << 'EOF'
+{
+    "result": "Did stuff but never wrote a RALPH_STATUS block.",
+    "sessionId": "session-no-block"
+}
+EOF
+
+    run analyze_response "$output_file" 1 "$RALPH_DIR/.response_analysis"
+    assert_success
+
+    local analysis_status
+    analysis_status=$(jq -r '.analysis.status' "$RALPH_DIR/.response_analysis")
+    assert_equal "$analysis_status" "UNKNOWN"
+}


### PR DESCRIPTION
## Summary

Closes #243. Refines #101.

The current "halt on any permission denial" rule (introduced by #142 to fix #101) is too aggressive: it kills the loop even when the agent already recovered from the denial. A single denied peripheral tool call — an MCP docs lookup, a `Bash(awk ...)` text extraction, a `Bash(mvn ... | tail -40)` whose pipe operator breaks pattern matching (#243) — terminates otherwise productive sessions. In the session that triggered this fix, the agent shipped 6 PRs in 6 loops, then loop 7 halted on a single denied `Context7` docs lookup that the agent itself didn't need and worked around.

## Approach

Defer the halt decision to the agent's own `RALPH_STATUS` self-report:

| Agent `STATUS:` | Behavior on denial |
|---|---|
| `BLOCKED` | halt (agent reports it is stuck) |
| missing / `UNKNOWN` | halt (preserves #101 safety against silent loops) |
| `COMPLETE` | warn and continue (agent recovered) |
| `IN_PROGRESS` | warn and continue (agent recovered) |

The warning surface is preserved either way, so users still see the suggestion to expand `ALLOWED_TOOLS`. The original #101 silent-loop concern remains addressed: agents that fail to emit a `RALPH_STATUS` block still trigger a halt.

## Why this is safe

- **Old #101 behavior preserved as fallback.** If the agent doesn't emit a recognized status (missing or `UNKNOWN`), the loop still halts. The only behavior change is when the agent *explicitly* declares it recovered.
- **Other safety mechanisms remain intact.** The circuit breaker (`consecutive_no_progress`, `consecutive_same_error`), the `completion_signals` exit, and the test-saturation guard all still apply.
- **The agent prompt has standing instructions** to create a GitHub Issue for any denial that materially impacts work and to set `STATUS: BLOCKED` when truly stuck. This change makes the wrapper respect that contract.

## Tests

- All 5 existing permission-denial tests (`Test 36`–`Test 40`) continue to pass — none of them set `status`, so they fall through the `UNKNOWN → halt` path.
- 4 new tests cover the new behavior:
  - `Test 40a`: denial + `STATUS: COMPLETE` → no halt
  - `Test 40b`: denial + `STATUS: IN_PROGRESS` → no halt
  - `Test 40c`: denial + `STATUS: BLOCKED` → halt
  - `Test 40d`: denial + missing status → halt (backward compat)

Full suite: **681 pass, 0 fail** (`npm test`).

## Test plan

- [x] Existing `test_exit_detection.bats` tests pass (35/35 unchanged)
- [x] New `test_exit_detection.bats` tests pass (4/4)
- [x] Full `npm test` suite passes (681/681)
- [ ] Tested in a real Ralph loop on the project that surfaced #243 (will report back)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Permission-denial handling now halts only when the agent reports BLOCKED or unknown/missing status; execution continues for COMPLETE/IN_PROGRESS.

* **Analysis Improvements**
  * Analysis output now captures embedded agent status and promotes it into the normalized analysis so recoveries are detected.

* **Tests**
  * Added unit, integration, and end-to-end tests covering status propagation, permission-denial scenarios, and circuit-breaker behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/frankbria/ralph-claude-code/pull/264)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->