### PR TITLE
fix(analyzer): treat compound-command denials as non-fatal advisory (#243)

### DIFF
--- a/lib/response_analyzer.sh
+++ b/lib/response_analyzer.sh
@@ -71,6 +71,82 @@ _file_size_bytes() {
     printf '%d' "${size:-0}"
 }
 
+# =============================================================================
+# Compound-command permission-denial detection (issue #243)
+# =============================================================================
+#
+# Claude Code's --allowedTools matcher does not match compound shell commands
+# (those containing pipes, redirects, &&, ||, ;) against patterns like
+# `Bash(mvn *)`. So `mvn clean compile 2>&1 | tail -40` is denied even when
+# `Bash(mvn *)` is configured.
+#
+# This is a Claude CLI limitation, not a real permission gap — halting the
+# loop in that case is wrong. The helpers below extract the base command from
+# a denied invocation and check whether the user's ALLOWED_TOOLS already
+# permits arbitrary arguments to it.
+
+# _extract_base_command — first whitespace/redirect/pipe-delimited token.
+# Args: $1 = full shell command (e.g., "mvn clean compile 2>&1 | tail -40")
+# Stdout: base command (e.g., "mvn"), empty if input is empty.
+_extract_base_command() {
+    local cmd="$1"
+    # Strip leading whitespace
+    cmd="${cmd#"${cmd%%[![:space:]]*}"}"
+    [[ -z "$cmd" ]] && return 0
+    # Take everything up to the first whitespace, pipe, redirect, semicolon,
+    # or ampersand. Uses a character class in a `%%` pattern.
+    printf '%s' "${cmd%%[ $'\t'|;\&\<\>]*}"
+}
+
+# _base_command_in_allowed_tools — does CLAUDE_ALLOWED_TOOLS permit ARBITRARY
+# arguments to $base_cmd? Returns 0 if yes.
+#
+# A pattern is considered to permit arbitrary args if its inside-of-`Bash(...)`:
+#   * is literal `*`                                — universal allow
+#   * starts with `$base_cmd` followed by `*`        — e.g., `Bash(git*)`
+#   * starts with `$base_cmd ` and contains a `*`    — e.g., `Bash(git *)` or
+#                                                      `Bash(git diff *)`
+#
+# Exact-only patterns like `Bash(npm install)` are NOT considered covering,
+# because they don't permit `npm test` either — a denial there is a real gap.
+_base_command_in_allowed_tools() {
+    local base_cmd="$1"
+    local allowed_tools="$2"
+
+    [[ -z "$base_cmd" || -z "$allowed_tools" ]] && return 1
+
+    local IFS=','
+    local entry
+    for entry in $allowed_tools; do
+        # Trim whitespace
+        entry="${entry#"${entry%%[![:space:]]*}"}"
+        entry="${entry%"${entry##*[![:space:]]}"}"
+
+        # Universal allow
+        [[ "$entry" == "Bash(*)" || "$entry" == "*" ]] && return 0
+
+        # Must be Bash(...) form to match a shell command
+        [[ "$entry" != "Bash("*")" ]] && continue
+
+        local inside="${entry#Bash(}"
+        inside="${inside%)}"
+
+        # Inside must start with the base command
+        [[ "$inside" == "$base_cmd"* ]] || continue
+        local rest="${inside#"$base_cmd"}"
+
+        # Pattern is e.g. `mvn*`
+        if [[ "$rest" == "*"* ]]; then
+            return 0
+        fi
+        # Pattern is e.g. `mvn *` or `mvn clean *`
+        if [[ "$rest" == " "* && "$rest" == *"*"* ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
 # Detect output format (json or text)
 # Returns: "json" if valid JSON, "text" otherwise
 detect_output_format() {
@@ -270,6 +346,43 @@ parse_json_response() {
         denied_commands_json=$(jq -r '[.permission_denials[] | if .tool_name == "Bash" then "Bash(\(.tool_input.command // "?" | split("\n")[0] | .[0:60]))" else .tool_name // "unknown" end]' "$output_file" 2>/dev/null || echo "[]")
     fi
 
+    # Compound-command detection (issue #243).
+    # Claude CLI does not match compound shell commands (with pipes/redirects)
+    # against `Bash(<cmd> *)` patterns, so a denial here may be a false positive.
+    # If EVERY denial is a Bash command whose base is already covered by
+    # CLAUDE_ALLOWED_TOOLS, treat it as a compound-command limitation instead
+    # of a real permission gap — the loop should continue with an advisory.
+    local has_compound_command_limitation="false"
+    local compound_command_count=0
+    if [[ $permission_denial_count -gt 0 && -n "${CLAUDE_ALLOWED_TOOLS:-}" ]]; then
+        # Count Bash denials. Anything else (e.g., AskUserQuestion) is a real gap.
+        local bash_denial_count
+        bash_denial_count=$(jq -r '[.permission_denials[] | select(.tool_name == "Bash")] | length' "$output_file" 2>/dev/null || echo "0")
+        bash_denial_count=$((bash_denial_count + 0))
+
+        if [[ $bash_denial_count -gt 0 && $bash_denial_count -eq $permission_denial_count ]]; then
+            # All denials are Bash — check coverage of each base command
+            local covered=0
+            local denied_full_commands
+            denied_full_commands=$(jq -r '.permission_denials[] | select(.tool_name == "Bash") | .tool_input.command // ""' "$output_file" 2>/dev/null)
+            while IFS= read -r full_cmd; do
+                [[ -z "$full_cmd" ]] && continue
+                local base
+                base=$(_extract_base_command "$full_cmd")
+                if [[ -n "$base" ]] && _base_command_in_allowed_tools "$base" "$CLAUDE_ALLOWED_TOOLS"; then
+                    covered=$((covered + 1))
+                fi
+            done <<< "$denied_full_commands"
+
+            if [[ $covered -eq $bash_denial_count ]]; then
+                has_compound_command_limitation="true"
+                compound_command_count=$bash_denial_count
+                # Downgrade has_permission_denials — the loop should continue
+                has_permission_denials="false"
+            fi
+        fi
+    fi
+
     # Normalize values
     # Convert exit_signal to boolean string
     # Only infer from status/completion_status if no explicit EXIT_SIGNAL was provided
@@ -332,6 +445,8 @@ parse_json_response() {
         --argjson has_permission_denials "$has_permission_denials" \
         --argjson permission_denial_count "$permission_denial_count" \
         --argjson denied_commands "$denied_commands_json" \
+        --argjson has_compound_command_limitation "$has_compound_command_limitation" \
+        --argjson compound_command_count "$compound_command_count" \
         '{
             status: $status,
             exit_signal: $exit_signal,
@@ -347,6 +462,8 @@ parse_json_response() {
             has_permission_denials: $has_permission_denials,
             permission_denial_count: $permission_denial_count,
             denied_commands: $denied_commands,
+            has_compound_command_limitation: $has_compound_command_limitation,
+            compound_command_count: $compound_command_count,
             metadata: {
                 loop_number: $loop_number,
                 session_id: $session_id
@@ -406,6 +523,9 @@ analyze_response() {
             local has_permission_denials=$(jq -r '.has_permission_denials' $RALPH_DIR/.json_parse_result 2>/dev/null || echo "false")
             local permission_denial_count=$(jq -r '.permission_denial_count' $RALPH_DIR/.json_parse_result 2>/dev/null || echo "0")
             local denied_commands_json=$(jq -r '.denied_commands' $RALPH_DIR/.json_parse_result 2>/dev/null || echo "[]")
+            # Compound-command limitation flag (Issue #243)
+            local has_compound_command_limitation=$(jq -r '.has_compound_command_limitation // false' $RALPH_DIR/.json_parse_result 2>/dev/null || echo "false")
+            local compound_command_count=$(jq -r '.compound_command_count // 0' $RALPH_DIR/.json_parse_result 2>/dev/null || echo "0")
 
             # Persist session ID if present (for session continuity across loop iterations)
             if [[ -n "$session_id" && "$session_id" != "null" ]]; then
@@ -483,6 +603,8 @@ analyze_response() {
                 --argjson has_permission_denials "$has_permission_denials" \
                 --argjson permission_denial_count "$permission_denial_count" \
                 --argjson denied_commands "$denied_commands_json" \
+                --argjson has_compound_command_limitation "$has_compound_command_limitation" \
+                --argjson compound_command_count "$compound_command_count" \
                 --argjson asking_questions "$asking_questions" \
                 --argjson question_count "$question_count" \
                 '{
@@ -503,6 +625,8 @@ analyze_response() {
                         has_permission_denials: $has_permission_denials,
                         permission_denial_count: $permission_denial_count,
                         denied_commands: $denied_commands,
+                        has_compound_command_limitation: $has_compound_command_limitation,
+                        compound_command_count: $compound_command_count,
                         asking_questions: $asking_questions,
                         question_count: $question_count
                     }

--- a/ralph_loop.sh
+++ b/ralph_loop.sh
@@ -674,10 +674,21 @@ should_exit_gracefully() {
 
     # 0. Permission denials (highest priority - Issue #101)
     # When Claude Code is denied permission to run commands, halt immediately
-    # to allow user to update .ralphrc ALLOWED_TOOLS configuration
+    # to allow user to update .ralphrc ALLOWED_TOOLS configuration.
+    # Exception (Issue #243): if every denial is a Bash compound command whose
+    # base is already covered by ALLOWED_TOOLS, the denial is a Claude CLI
+    # limitation rather than a real permission gap — log an advisory and continue.
     if [[ -f "$RESPONSE_ANALYSIS_FILE" ]]; then
         local has_permission_denials=$(jq -r '.analysis.has_permission_denials // false' "$RESPONSE_ANALYSIS_FILE" 2>/dev/null || echo "false")
-        if [[ "$has_permission_denials" == "true" ]]; then
+        local has_compound_limitation=$(jq -r '.analysis.has_compound_command_limitation // false' "$RESPONSE_ANALYSIS_FILE" 2>/dev/null || echo "false")
+
+        if [[ "$has_compound_limitation" == "true" ]]; then
+            local compound_count=$(jq -r '.analysis.compound_command_count // 0' "$RESPONSE_ANALYSIS_FILE" 2>/dev/null || echo "0")
+            local denied_cmds=$(jq -r '.analysis.denied_commands | join(", ")' "$RESPONSE_ANALYSIS_FILE" 2>/dev/null || echo "unknown")
+            log_status "WARN" "⚠️  Claude CLI denied $compound_count compound command(s) but the base command is already in ALLOWED_TOOLS: $denied_cmds"
+            log_status "WARN" "This is a Claude CLI matching limitation (pipes/redirects bypass Bash(cmd *) patterns). Loop continues."
+            # Fall through — do not halt
+        elif [[ "$has_permission_denials" == "true" ]]; then
             local denied_count=$(jq -r '.analysis.permission_denial_count // 0' "$RESPONSE_ANALYSIS_FILE" 2>/dev/null || echo "0")
             local denied_cmds=$(jq -r '.analysis.denied_commands | join(", ")' "$RESPONSE_ANALYSIS_FILE" 2>/dev/null || echo "unknown")
             log_status "WARN" "🚫 Permission denied for $denied_count command(s): $denied_cmds"

--- a/templates/ralphrc.template
+++ b/templates/ralphrc.template
@@ -40,6 +40,10 @@ CLAUDE_OUTPUT_FORMAT="json"
 # NOTE: Default uses specific git subcommands for safety. To allow ALL git commands: Bash(git *)
 # Dangerous commands excluded by default: git clean, git rm, git reset (can delete .ralph/)
 # Safe git subcommands only - broad Bash(git *) allows destructive commands like git clean/git rm (Issue #149)
+# Compound commands (with pipes |, redirects 2>&1, ; or && chains) may not match
+# `Bash(cmd *)` patterns due to a Claude CLI limitation (Issue #243). Ralph detects
+# this case automatically and continues the loop with a warning instead of halting,
+# but you can also restructure commands or use Bash(*) to bypass the issue.
 ALLOWED_TOOLS="Write,Read,Edit,Bash(git add *),Bash(git commit *),Bash(git diff *),Bash(git log *),Bash(git status),Bash(git status *),Bash(git push *),Bash(git pull *),Bash(git fetch *),Bash(git checkout *),Bash(git branch *),Bash(git stash *),Bash(git merge *),Bash(git tag *),Bash(npm *),Bash(pytest)"
 
 # =============================================================================

--- a/tests/unit/test_compound_command_detection.bats
+++ b/tests/unit/test_compound_command_detection.bats
@@ -1,0 +1,246 @@
+#!/usr/bin/env bats
+# Unit tests for compound-command permission-denial detection helpers
+# (lib/response_analyzer.sh, issue #243).
+#
+# Covers _extract_base_command and _base_command_in_allowed_tools.
+
+load '../helpers/test_helper'
+
+RESPONSE_ANALYZER="${BATS_TEST_DIRNAME}/../../lib/response_analyzer.sh"
+
+setup() {
+    TEST_DIR="$(mktemp -d)"
+    cd "$TEST_DIR"
+    source "$RESPONSE_ANALYZER"
+}
+
+teardown() {
+    cd /
+    [[ -n "$TEST_DIR" && -d "$TEST_DIR" ]] && rm -rf "$TEST_DIR"
+}
+
+# -----------------------------------------------------------------------------
+# _extract_base_command
+# -----------------------------------------------------------------------------
+
+@test "_extract_base_command: single command" {
+    result="$(_extract_base_command "mvn")"
+    assert_equal "$result" "mvn"
+}
+
+@test "_extract_base_command: command with arguments" {
+    result="$(_extract_base_command "mvn clean compile")"
+    assert_equal "$result" "mvn"
+}
+
+@test "_extract_base_command: command with pipe (the #243 case)" {
+    result="$(_extract_base_command "mvn clean compile 2>&1 | tail -40")"
+    assert_equal "$result" "mvn"
+}
+
+@test "_extract_base_command: command with leading whitespace" {
+    result="$(_extract_base_command "   git status")"
+    assert_equal "$result" "git"
+}
+
+@test "_extract_base_command: command with redirect immediately after" {
+    result="$(_extract_base_command "mvn>output.log")"
+    assert_equal "$result" "mvn"
+}
+
+@test "_extract_base_command: empty input returns empty" {
+    result="$(_extract_base_command "")"
+    assert_equal "$result" ""
+}
+
+@test "_extract_base_command: pipe-only input returns empty" {
+    result="$(_extract_base_command "| tail")"
+    assert_equal "$result" ""
+}
+
+# -----------------------------------------------------------------------------
+# _base_command_in_allowed_tools — positive matches
+# -----------------------------------------------------------------------------
+
+@test "_base_command_in_allowed_tools: Bash(mvn *) covers mvn" {
+    run _base_command_in_allowed_tools "mvn" "Write,Read,Bash(mvn *)"
+    assert_success
+}
+
+@test "_base_command_in_allowed_tools: Bash(git *) covers git" {
+    run _base_command_in_allowed_tools "git" "Bash(git *),Bash(npm *)"
+    assert_success
+}
+
+@test "_base_command_in_allowed_tools: Bash(*) covers anything" {
+    run _base_command_in_allowed_tools "rm" "Bash(*)"
+    assert_success
+}
+
+@test "_base_command_in_allowed_tools: literal '*' wildcard entry" {
+    run _base_command_in_allowed_tools "ls" "*"
+    assert_success
+}
+
+@test "_base_command_in_allowed_tools: Bash(npm*) (no space) covers npm" {
+    run _base_command_in_allowed_tools "npm" "Bash(npm*)"
+    assert_success
+}
+
+@test "_base_command_in_allowed_tools: Bash(git diff *) covers git" {
+    # Multi-word patterns ending in * also cover the base
+    run _base_command_in_allowed_tools "git" "Bash(git diff *)"
+    assert_success
+}
+
+@test "_base_command_in_allowed_tools: tolerates whitespace around commas" {
+    run _base_command_in_allowed_tools "mvn" "Write, Read , Bash(mvn *) , Bash(npm *)"
+    assert_success
+}
+
+# -----------------------------------------------------------------------------
+# _base_command_in_allowed_tools — negative matches (no false positives)
+# -----------------------------------------------------------------------------
+
+@test "_base_command_in_allowed_tools: exact Bash(npm install) does NOT cover npm" {
+    # Exact-only pattern doesn't grant arbitrary args
+    run _base_command_in_allowed_tools "npm" "Bash(npm install)"
+    assert_failure
+}
+
+@test "_base_command_in_allowed_tools: exact Bash(git status) does NOT cover git" {
+    run _base_command_in_allowed_tools "git" "Bash(git status)"
+    assert_failure
+}
+
+@test "_base_command_in_allowed_tools: pattern for different command does not cover" {
+    run _base_command_in_allowed_tools "mvn" "Bash(npm *),Bash(git *)"
+    assert_failure
+}
+
+@test "_base_command_in_allowed_tools: empty allowed_tools returns failure" {
+    run _base_command_in_allowed_tools "mvn" ""
+    assert_failure
+}
+
+@test "_base_command_in_allowed_tools: empty base_cmd returns failure" {
+    run _base_command_in_allowed_tools "" "Bash(*)"
+    assert_failure
+}
+
+@test "_base_command_in_allowed_tools: non-Bash entries are ignored" {
+    run _base_command_in_allowed_tools "mvn" "Write,Read,Edit"
+    assert_failure
+}
+
+@test "_base_command_in_allowed_tools: prefix collisions don't match (git ≠ gitlab)" {
+    # Bash(gitlab *) should NOT cover base "git"
+    run _base_command_in_allowed_tools "git" "Bash(gitlab *)"
+    assert_failure
+}
+
+# -----------------------------------------------------------------------------
+# parse_json_response — end-to-end behavior for compound-command denials
+# -----------------------------------------------------------------------------
+
+# Helper: minimal Claude Code output JSON with a permission_denials array
+_write_denial_output() {
+    local file="$1"
+    local tool_name="$2"
+    local denied_command="$3"
+    cat > "$file" <<EOF
+{
+  "status": "IN_PROGRESS",
+  "session_id": "test-session",
+  "permission_denials": [
+    {"tool_name": "$tool_name", "tool_input": {"command": "$denied_command"}}
+  ]
+}
+EOF
+}
+
+@test "parse_json_response: marks compound-command limitation when base is allowed (#243)" {
+    local output_file="$TEST_DIR/output.json"
+    local result_file="$TEST_DIR/result.json"
+    _write_denial_output "$output_file" "Bash" "mvn clean compile 2>&1 | tail -40"
+
+    export CLAUDE_ALLOWED_TOOLS="Write,Read,Edit,Bash(mvn *),Bash(git *)"
+    parse_json_response "$output_file" "$result_file"
+
+    assert_equal "$(jq -r '.has_compound_command_limitation' "$result_file")" "true"
+    assert_equal "$(jq -r '.has_permission_denials' "$result_file")" "false"
+    assert_equal "$(jq -r '.compound_command_count' "$result_file")" "1"
+}
+
+@test "parse_json_response: keeps real denial when base is NOT allowed" {
+    local output_file="$TEST_DIR/output.json"
+    local result_file="$TEST_DIR/result.json"
+    _write_denial_output "$output_file" "Bash" "curl http://example.com"
+
+    export CLAUDE_ALLOWED_TOOLS="Write,Read,Bash(mvn *),Bash(git *)"
+    parse_json_response "$output_file" "$result_file"
+
+    assert_equal "$(jq -r '.has_compound_command_limitation' "$result_file")" "false"
+    assert_equal "$(jq -r '.has_permission_denials' "$result_file")" "true"
+}
+
+@test "parse_json_response: non-Bash denial keeps halt behavior" {
+    # AskUserQuestion denial is never a compound-command issue
+    local output_file="$TEST_DIR/output.json"
+    local result_file="$TEST_DIR/result.json"
+    _write_denial_output "$output_file" "AskUserQuestion" ""
+
+    export CLAUDE_ALLOWED_TOOLS="Write,Read,Bash(*)"
+    parse_json_response "$output_file" "$result_file"
+
+    assert_equal "$(jq -r '.has_compound_command_limitation' "$result_file")" "false"
+    assert_equal "$(jq -r '.has_permission_denials' "$result_file")" "true"
+}
+
+@test "parse_json_response: mixed Bash + non-Bash denials keep halt behavior" {
+    local output_file="$TEST_DIR/output.json"
+    local result_file="$TEST_DIR/result.json"
+    cat > "$output_file" <<'EOF'
+{
+  "status": "IN_PROGRESS",
+  "session_id": "test-session",
+  "permission_denials": [
+    {"tool_name": "Bash", "tool_input": {"command": "mvn clean | tail"}},
+    {"tool_name": "AskUserQuestion", "tool_input": {}}
+  ]
+}
+EOF
+    export CLAUDE_ALLOWED_TOOLS="Bash(mvn *)"
+    parse_json_response "$output_file" "$result_file"
+
+    # Compound limitation only applies when ALL denials are Bash-and-covered
+    assert_equal "$(jq -r '.has_compound_command_limitation' "$result_file")" "false"
+    assert_equal "$(jq -r '.has_permission_denials' "$result_file")" "true"
+}
+
+@test "parse_json_response: empty CLAUDE_ALLOWED_TOOLS does not break detection" {
+    local output_file="$TEST_DIR/output.json"
+    local result_file="$TEST_DIR/result.json"
+    _write_denial_output "$output_file" "Bash" "mvn install"
+
+    unset CLAUDE_ALLOWED_TOOLS
+    parse_json_response "$output_file" "$result_file"
+
+    # No allowed_tools to compare against → cannot mark as compound limitation
+    assert_equal "$(jq -r '.has_compound_command_limitation' "$result_file")" "false"
+    assert_equal "$(jq -r '.has_permission_denials' "$result_file")" "true"
+}
+
+@test "parse_json_response: no denials → both flags false" {
+    local output_file="$TEST_DIR/output.json"
+    local result_file="$TEST_DIR/result.json"
+    cat > "$output_file" <<'EOF'
+{"status": "COMPLETE", "session_id": "test-session"}
+EOF
+    export CLAUDE_ALLOWED_TOOLS="Bash(*)"
+    parse_json_response "$output_file" "$result_file"
+
+    assert_equal "$(jq -r '.has_compound_command_limitation' "$result_file")" "false"
+    assert_equal "$(jq -r '.has_permission_denials' "$result_file")" "false"
+    assert_equal "$(jq -r '.compound_command_count' "$result_file")" "0"
+}


### PR DESCRIPTION
## Summary

Closes #243.

When `ALLOWED_TOOLS` contains `Bash(mvn *)` and Claude runs `mvn clean compile 2>&1 | tail -40`, Claude CLI's `--allowedTools` matcher fails to recognise the compound expression (with pipe / redirect) as matching the base pattern. The denial bubbles up to `should_exit_gracefully()` and halts the whole loop on a false positive.

This change keeps the halt behavior for **real** permission gaps but treats this specific case as an advisory.

## Approach

`parse_json_response()` in `lib/response_analyzer.sh` now checks each Bash denial's base command against `CLAUDE_ALLOWED_TOOLS`. When **every** denial is a Bash command whose base is already permitted by a sufficiently liberal pattern, a new `has_compound_command_limitation` flag is raised and `has_permission_denials` is downgraded to `false`. `ralph_loop.sh`'s exit logic then logs a `WARN` advisory and the loop continues.

Two pure helpers:

- `_extract_base_command` — strips leading whitespace and returns the first token before any whitespace, pipe, redirect, semicolon, or ampersand
- `_base_command_in_allowed_tools` — splits `CLAUDE_ALLOWED_TOOLS` on commas, ignores non-Bash entries, requires `Bash(...)` to start with the base command and end with (or contain) a wildcard

The coverage check is intentionally conservative:

- `Bash(mvn *)` covers base `mvn` → false positive suppressed ✅
- `Bash(npm install)` does **NOT** cover base `npm` for an `npm test` denial → real gap, still halts ✅
- Non-Bash denials (e.g., `AskUserQuestion`) → still halt ✅
- Mixed Bash + non-Bash denials → still halt ✅
- Empty `CLAUDE_ALLOWED_TOOLS` → no detection, defaults to existing behavior ✅

The new flag is forwarded through `parse_json_response` → `analyze_response` → `.response_analysis` (both `json_parse_result` and `analysis` blocks). The `.ralphrc` template now documents the limitation.

## Test plan

`tests/unit/test_compound_command_detection.bats` (27 tests, all passing):

- **`_extract_base_command`** (7) — single command, multi-arg, the #243 pipe case, leading whitespace, immediate redirect, empty input, pipe-only input
- **`_base_command_in_allowed_tools`** (14) — `Bash(mvn *)` / `Bash(git *)` / `Bash(*)` / literal `*` / `Bash(npm*)` (no space) / `Bash(git diff *)` multi-word, comma-whitespace tolerance; negative: exact-only patterns, wrong command, empty inputs, non-Bash entries, prefix collisions (git ≠ gitlab)
- **`parse_json_response`** end-to-end (6) — compound denial with covered base flags limitation, uncovered base keeps real denial, AskUserQuestion denial keeps halt, mixed Bash + non-Bash denials keep halt, empty `CLAUDE_ALLOWED_TOOLS` is graceful, no-denial case has both flags false

No regressions in:

- [x] `tests/unit/test_json_parsing.bats`
- [x] `tests/unit/test_exit_detection.bats`
- [x] `tests/unit/test_jsonl_guard.bats`
- [x] `tests/unit/test_safe_count.bats`

(The single pre-existing failure in `tests/unit/test_log_rotation.bats:13` is also present on `main` — unrelated to this change.)

## Out of scope

The traycerai plan on the issue also suggested restructuring `denied_commands` to expose `{full, base}` objects and rewriting the `PERMISSION DENIED` banner. I kept those out of this PR — they are larger schema/UX changes that can be done separately once this functional fix lands. The current change is the minimum needed to unblock users hitting the loop-halt false positive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Mitigated false-positive "permission denied" errors for compound shell commands (pipes, redirects, etc.) by distinguishing them from actual permission failures.

* **Documentation**
  * Clarified Claude CLI limitations with compound commands and provided recommended workarounds in configuration guidance.

* **Tests**
  * Added comprehensive test suite for compound command detection logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->