### PR TITLE
feat(diag): tooling to inspect --allowedTools argv (refs #154)

### DIFF
--- a/docs/CLI_OPTIONS.md
+++ b/docs/CLI_OPTIONS.md
@@ -201,6 +201,8 @@ ralph --allowed-tools "Write,Read,Edit,Bash(git *),Bash(npm *)"
 
 > **Why specific git subcommands?** The default intentionally omits `Bash(git *)` to prevent `git clean`, `git rm`, and `git reset`, which could delete `.ralph/` configuration files. See [File Protection](../CLAUDE.md#file-protection-issue-149).
 
+> **Debugging denied commands.** If a command is denied even though your `ALLOWED_TOOLS` looks correct, run `RALPH_VERBOSE=true ralph` to log the exact argv passed to Claude, or `tools/inspect-allowed-tools.sh` to inspect parsing without invoking Claude. For compound commands with pipes/redirects (e.g., `mvn clean | tail`), ralph automatically downgrades the denial to a warning when the base command is already allowed — see issue #243. The broader `Bash(git *)` wildcard limitation is tracked in issue #154.
+
 ---
 
 ### `--no-continue`

--- a/ralph_loop.sh
+++ b/ralph_loop.sh
@@ -1341,6 +1341,29 @@ build_claude_command() {
     local prompt_content
     prompt_content=$(cat "$prompt_file")
     CLAUDE_CMD_ARGS+=("-p" "$prompt_content")
+
+    # Diagnostic logging (Issue #154): when RALPH_VERBOSE=true, dump the exact
+    # argv that will be passed to Claude CLI — minus the prompt body, which is
+    # noisy and may contain secrets. Lets users verify --allowedTools entries
+    # actually reach Claude (e.g., when investigating Bash(git *) denials).
+    if [[ "${RALPH_VERBOSE:-false}" == "true" ]]; then
+        local -a redacted_args=()
+        local skip_prompt=false
+        for arg in "${CLAUDE_CMD_ARGS[@]}"; do
+            if [[ "$skip_prompt" == "true" ]]; then
+                redacted_args+=("<prompt:${#arg} chars>")
+                skip_prompt=false
+                continue
+            fi
+            if [[ "$arg" == "-p" ]]; then
+                redacted_args+=("$arg")
+                skip_prompt=true
+                continue
+            fi
+            redacted_args+=("$arg")
+        done
+        log_status "DEBUG" "Claude argv (${#CLAUDE_CMD_ARGS[@]} args): ${redacted_args[*]}"
+    fi
 }
 
 # create_backup - Create a git backup branch before a loop iteration (Issue #23)

--- a/tests/unit/test_inspect_allowed_tools.bats
+++ b/tests/unit/test_inspect_allowed_tools.bats
@@ -1,0 +1,99 @@
+#!/usr/bin/env bats
+# Tests for tools/inspect-allowed-tools.sh — the diagnostic helper that
+# prints the exact argv ralph_loop.sh would pass to Claude CLI for a
+# given ALLOWED_TOOLS config.
+#
+# Refs issue #154. The point of these tests is to lock in that:
+#   * shell metacharacters in patterns (parens, spaces, asterisks)
+#     survive the comma-split intact;
+#   * empty / missing inputs are handled cleanly.
+
+load '../helpers/test_helper'
+
+INSPECT="${BATS_TEST_DIRNAME}/../../tools/inspect-allowed-tools.sh"
+
+setup() {
+    TEST_DIR="$(mktemp -d)"
+    cd "$TEST_DIR"
+}
+
+teardown() {
+    cd /
+    [[ -n "$TEST_DIR" && -d "$TEST_DIR" ]] && rm -rf "$TEST_DIR"
+}
+
+@test "inspect: env var overrides .ralphrc" {
+    cat > .ralphrc <<'EOF'
+ALLOWED_TOOLS="ShouldNotAppear"
+EOF
+    run env ALLOWED_TOOLS="FromEnv,Read" "$INSPECT"
+    assert_success
+    [[ "$output" == *"env var"* ]]
+    [[ "$output" == *"FromEnv"* ]]
+    [[ "$output" != *"ShouldNotAppear"* ]]
+}
+
+@test "inspect: reads ALLOWED_TOOLS from .ralphrc when no env var set" {
+    cat > .ralphrc <<'EOF'
+ALLOWED_TOOLS="Write,Read,Bash(git *)"
+EOF
+    run "$INSPECT"
+    assert_success
+    [[ "$output" == *".ralphrc"* ]]
+    [[ "$output" == *"Write"* ]]
+    [[ "$output" == *"Read"* ]]
+    [[ "$output" == *"git"* ]]
+}
+
+@test "inspect: preserves Bash(git *) pattern literally" {
+    run env ALLOWED_TOOLS="Bash(git *)" "$INSPECT"
+    assert_success
+    # printf %q escapes parens and asterisks for visibility, but the literal
+    # base string must be present
+    [[ "$output" == *"Bash"* ]]
+    [[ "$output" == *"git"* ]]
+    [[ "$output" == *"*"* ]]
+}
+
+@test "inspect: preserves Bash(*) literal asterisk (no glob expansion)" {
+    # Create some files in cwd that would match * if glob expansion fired
+    touch sentinel-a sentinel-b
+    run env ALLOWED_TOOLS="Bash(*)" "$INSPECT"
+    assert_success
+    # Output must mention the literal pattern, not the matched files
+    [[ "$output" == *"Bash"* ]]
+    [[ "$output" != *"sentinel-a"* ]]
+    [[ "$output" != *"sentinel-b"* ]]
+}
+
+@test "inspect: trims whitespace around comma-separated entries" {
+    run env ALLOWED_TOOLS="  Write , Read , Bash(npm *)  " "$INSPECT"
+    assert_success
+    # Each entry should be present without leading/trailing whitespace
+    [[ "$output" =~ \[0\][[:space:]]+Write ]]
+    [[ "$output" =~ \[1\][[:space:]]+Read ]]
+}
+
+@test "inspect: empty ALLOWED_TOOLS reports the empty case" {
+    run env ALLOWED_TOOLS="" "$INSPECT"
+    # No .ralphrc + empty env → fall through to missing-file message
+    [[ $status -eq 0 || $status -eq 2 ]]
+}
+
+@test "inspect: missing .ralphrc with no env var exits non-zero" {
+    # No env var, no .ralphrc in cwd
+    run env -u ALLOWED_TOOLS -u CLAUDE_ALLOWED_TOOLS "$INSPECT"
+    assert_failure
+    [[ "$output" == *"not found"* || "$output" == *"Usage"* ]]
+}
+
+@test "inspect: accepts custom .ralphrc path as argument" {
+    cat > custom.ralphrc <<'EOF'
+ALLOWED_TOOLS="Custom,Tools"
+EOF
+    run env -u ALLOWED_TOOLS -u CLAUDE_ALLOWED_TOOLS "$INSPECT" "custom.ralphrc"
+    assert_success
+    [[ "$output" == *"custom.ralphrc"* ]]
+    [[ "$output" == *"Custom"* ]]
+    [[ "$output" == *"Tools"* ]]
+}

--- a/tools/inspect-allowed-tools.sh
+++ b/tools/inspect-allowed-tools.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# inspect-allowed-tools.sh — prints the exact `--allowedTools` argv that
+# ralph_loop.sh would pass to Claude CLI for a given .ralphrc.
+#
+# Diagnostic helper for issue #154 (Bash wildcard patterns in ALLOWED_TOOLS
+# not matching). Lets users verify that their pattern reaches Claude with
+# the bytes they expect, ruling out shell-quoting or comma-split bugs in
+# ralph before opening a Claude CLI ticket.
+#
+# Usage:
+#   tools/inspect-allowed-tools.sh                  # uses ./.ralphrc
+#   tools/inspect-allowed-tools.sh path/to/.ralphrc
+#   ALLOWED_TOOLS='Bash(git *)' tools/inspect-allowed-tools.sh   # ad-hoc
+#
+# Exit 0 always — this is a read-only inspection tool.
+
+set -euo pipefail
+
+rcfile="${1:-.ralphrc}"
+allowed_from_env="${ALLOWED_TOOLS:-${CLAUDE_ALLOWED_TOOLS:-}}"
+
+if [[ -n "$allowed_from_env" ]]; then
+    echo "Source: \$ALLOWED_TOOLS env var"
+    allowed="$allowed_from_env"
+elif [[ -f "$rcfile" ]]; then
+    echo "Source: $rcfile"
+    # Source in a subshell-style block to avoid leaking other .ralphrc vars
+    # into this script, but still pick up ALLOWED_TOOLS.
+    allowed=$(
+        # shellcheck disable=SC1090
+        source "$rcfile"
+        printf '%s' "${ALLOWED_TOOLS:-${CLAUDE_ALLOWED_TOOLS:-}}"
+    )
+else
+    echo "ERROR: $rcfile not found and no ALLOWED_TOOLS env var set" >&2
+    echo "Usage: $0 [path/to/.ralphrc]" >&2
+    exit 2
+fi
+
+if [[ -z "$allowed" ]]; then
+    echo "(empty — no --allowedTools flag would be passed)"
+    exit 0
+fi
+
+echo "Raw value:"
+echo "  $allowed"
+echo
+
+# Replicate the parsing from ralph_loop.sh:build_claude_command
+declare -a tools_array=()
+IFS=','
+read -ra raw_tokens <<< "$allowed"
+unset IFS
+for tool in "${raw_tokens[@]}"; do
+    # Trim whitespace (matches the sed in ralph_loop.sh)
+    tool="${tool#"${tool%%[![:space:]]*}"}"
+    tool="${tool%"${tool##*[![:space:]]}"}"
+    [[ -n "$tool" ]] && tools_array+=("$tool")
+done
+
+echo "Parsed argv (${#tools_array[@]} tools):"
+echo "  --allowedTools"
+for i in "${!tools_array[@]}"; do
+    printf '  [%d] %q\n' "$i" "${tools_array[$i]}"
+done
+
+echo
+echo "Notes:"
+echo "  * Each tool is passed as a separate positional argument."
+echo "  * Patterns like 'Bash(git *)' that contain shell metacharacters"
+echo "    should appear LITERALLY in the printf %q output above."
+echo "  * If a literal '*' got expanded to filenames, that's a quoting bug —"
+echo "    please file a ralph issue."
+echo "  * If the printf output looks correct but Claude still denies a"
+echo "    command, the issue is likely in Claude CLI's matcher itself."
+echo "    Reference issue #243 (compound-command false positives) for one"
+echo "    documented case ralph already works around."


### PR DESCRIPTION
## Summary

Refs #154 (does not close — see [Scope](#scope) below).

When a Bash command is denied even though `ALLOWED_TOOLS` looks correct, users currently have no way to tell whether ralph mangled the value before passing it to Claude CLI, or whether Claude's matcher is the culprit. This PR adds two diagnostic affordances; it does **not** modify ralph's actual permission behavior.

## What changes

1. **`ralph_loop.sh`** — `build_claude_command()` now logs the full Claude CLI argv (with the `-p` prompt body redacted as `<prompt:N chars>`) when `RALPH_VERBOSE=true`. Lets users confirm that `--allowedTools` and each pattern entry land exactly as configured.

2. **`tools/inspect-allowed-tools.sh`** — standalone read-only helper that sources a `.ralphrc` (or reads `ALLOWED_TOOLS` from the env) and prints the comma-split argv ralph would build. Uses `printf %q` so shell metacharacters (parens, spaces, asterisks) are visible.

   ```
   $ ALLOWED_TOOLS="Write,Read,Bash(git *),Bash(*)" tools/inspect-allowed-tools.sh
   Source: $ALLOWED_TOOLS env var
   Raw value:
     Write,Read,Bash(git *),Bash(*)

   Parsed argv (4 tools):
     --allowedTools
     [0] Write
     [1] Read
     [2] Bash\(git\ \*\)
     [3] Bash\(\*\)
   ```

3. **`docs/CLI_OPTIONS.md`** — adds a debugging note pointing at both tools and at the #243 compound-command workaround so users can self-serve before opening tickets.

## Scope

This PR intentionally does **not** claim to fix the underlying behavior reported in #154 (broad `Bash(git *)` patterns sometimes denying simple `git commit` invocations). Running the new inspect tool on the reported config confirms ralph passes patterns literally to Claude CLI — the matcher's rejection appears to happen upstream. Giving maintainers and reporters the visibility to verify that on their own setups is the prerequisite for a clean upstream ticket or a documented workaround in ralph; closing the issue prematurely would obscure that distinction.

The related, narrower compound-command false-positive case (`mvn ... 2>&1 | tail`) is being handled in #268.

## Test plan

`tests/unit/test_inspect_allowed_tools.bats` (8 tests, all passing):

- env var overrides `.ralphrc`
- `.ralphrc`-only mode reads `ALLOWED_TOOLS`
- `Bash(git *)` survives intact through the parser
- `Bash(*)` does **not** glob-expand against cwd files (regression guard against shell quoting bugs)
- whitespace trimming around comma-separated entries
- empty `ALLOWED_TOOLS` handled cleanly
- missing `.ralphrc` + no env var exits non-zero
- custom `.ralphrc` path argument works

No regressions in:
- [x] `tests/unit/test_cli_parsing.bats`
- [x] `tests/unit/test_cli_modern.bats`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added verbose logging mode (`RALPH_VERBOSE=true`) to debug tool allowance issues by displaying arguments passed to Claude
  * New tool inspection script to verify allowed tools configuration without invoking Claude

* **Documentation**
  * Enhanced `--allowed-tools` documentation with debugging instructions and guidance for denied commands

* **Tests**
  * Added comprehensive test coverage for tool allowance configuration parsing and precedence

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/frankbria/ralph-claude-code/pull/269?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->