### PR TITLE
fix(ci): allow claude-review to run for known fork contributors

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -20,6 +20,14 @@ concurrency:
 
 jobs:
   claude-review:
+    # Only review PRs from known/trusted authors. author_association is maintained
+    # automatically by GitHub: anyone who has had a PR merged becomes CONTRIBUTOR,
+    # so the trust list grows on its own with no manual upkeep. First-time/unknown
+    # authors are skipped (safe default) until their first PR lands. This gate is
+    # what makes the per-author `allowed_non_write_users` below safe — only authors
+    # who pass this association check ever reach the action.
+    if: |
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.pull_request.author_association)
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -57,6 +65,15 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # Explicit github_token needed for pull_request_target (OIDC doesn't work)
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          # By default the action only runs for users with write access, which blocks
+          # external fork contributors (they only have read). Rather than a blanket '*'
+          # bypass, allow exactly one user: the author of THIS PR. Because the job-level
+          # `if:` above has already confirmed that author is a trusted association
+          # (CONTRIBUTOR and up), this permits only an already-vetted individual per run —
+          # never a wildcard. Combined with minimal permissions + read-only allowed-tools,
+          # this lets Claude review fork PRs from known contributors without opening the
+          # door to arbitrary actors. See docs/security.md in the action repo.
+          allowed_non_write_users: ${{ github.event.pull_request.user.login }}
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

`claude-review` has been failing in ~10s on **every external fork PR** with:

```
Action failed with error: Actor does not have write permissions to the repository
```

`anthropics/claude-code-action@v1` runs a built-in **write-permission gate** on the triggering actor (anti-prompt-injection safeguard). External fork contributors only have read access, so all their PRs are blocked — that is the red X seen across the recently-handled PR queue (#252 #253 #259 #262 #264 #267 #268 #269).

**Auth was never the problem** — the workflow already uses OAuth via `CLAUDE_CODE_OAUTH_TOKEN` (secret present since 2026-03-16). No API key is or was involved.

## Fix — auto-maintained "known contributors", no wildcard

Two scoped layers:

1. **Gate the job on GitHub's own `author_association`:**
   ```yaml
   if: |
     contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.pull_request.author_association)
   ```
   Anyone who has had a PR **merged** is `CONTRIBUTOR` automatically → the trust list grows on its own, **zero manual upkeep**. First-time / unknown authors are **skipped** (safe default) until their first PR lands.

2. **Allowlist only the current PR's author** (not `'*'`):
   ```yaml
   allowed_non_write_users: ${{ github.event.pull_request.user.login }}
   ```
   Because the gate above already confirmed that author is trusted, this bypasses the action's write-check for exactly **one already-vetted individual per run** — never a blanket wildcard.

The four fork authors merged today (gacabartosz, visigoth, edlsh, justanotherguyme) are `CONTRIBUTOR` going forward, so their future PRs get reviewed.

## Why the bypass is low-risk
Existing safeguards (unchanged) satisfy the action's [security.md](https://github.com/anthropics/claude-code-action/blob/main/docs/security.md):
- explicit `github_token: ${{ secrets.GITHUB_TOKEN }}`
- minimal `permissions` (contents: read, issues: read, pull-requests: write only)
- read-only `--allowed-tools` (gh view/list/diff + pr comment)
- default subprocess env scrubbing

Worst case is bounded to PR-comment content; no code execution, repo writes, or secret access.

## Activation note
`pull_request_target` uses the workflow file from the **base branch**, so this only takes effect once merged to `main`. This PR won't trigger the review itself (`.github/**` is in `paths-ignore`).

## Test plan
- [x] YAML validates (`yaml.safe_load`)
- [ ] After merge: a fresh fork PR from a known contributor triggers a successful review run