### PR TITLE
test(compat): add backward-compatibility integration tests (#41)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -611,7 +611,7 @@ Ralph uses a multi-layered strategy to prevent Claude from accidentally deleting
 | `test_metrics_tracking.bats` | 4 | Metrics tracking: track_metrics() JSON Lines format, per-loop append, ralph-stats output, print_metrics_summary (Issue #21) |
 | `test_notifications.bats` | 5 | Desktop notifications: send_notification() cross-platform (macOS/Linux/bell), disabled by default, --notify flag (Issue #22) |
 | `test_backup_rollback.bats` | 6 | Backup/rollback: create_backup() branch naming, disabled by default, graceful git-less handling, commit message, --backup flag, rollback_to_backup() checkout (Issue #23) |
-| `test_backward_compat.bats` | 7 | Integration-level backward compatibility: old flat-structure migration message, .ralphrc with missing/legacy fields, missing optional state files (status.json, circuit breaker state), bare-CLI defaults, old-style prompt paths (Issue #41) |
+| `test_backward_compat.bats` | 9 | Integration-level backward compatibility: old flat-structure migration message (PROMPT.md + legacy @-prefixed markers via shared `is_legacy_flat_structure`), generic dirs not misflagged, .ralphrc with missing/legacy fields, missing optional state files (status.json, circuit breaker state), bare-CLI defaults, old-style prompt paths (Issue #41) |
 
 ### Running Tests
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -611,6 +611,7 @@ Ralph uses a multi-layered strategy to prevent Claude from accidentally deleting
 | `test_metrics_tracking.bats` | 4 | Metrics tracking: track_metrics() JSON Lines format, per-loop append, ralph-stats output, print_metrics_summary (Issue #21) |
 | `test_notifications.bats` | 5 | Desktop notifications: send_notification() cross-platform (macOS/Linux/bell), disabled by default, --notify flag (Issue #22) |
 | `test_backup_rollback.bats` | 6 | Backup/rollback: create_backup() branch naming, disabled by default, graceful git-less handling, commit message, --backup flag, rollback_to_backup() checkout (Issue #23) |
+| `test_backward_compat.bats` | 7 | Integration-level backward compatibility: old flat-structure migration message, .ralphrc with missing/legacy fields, missing optional state files (status.json, circuit breaker state), bare-CLI defaults, old-style prompt paths (Issue #41) |
 
 ### Running Tests
 ```bash

--- a/ralph_loop.sh
+++ b/ralph_loop.sh
@@ -274,15 +274,10 @@ BLUE='\033[0;34m'
 PURPLE='\033[0;35m'
 NC='\033[0m' # No Color
 
-# Detect an un-migrated pre-v0.10 flat-structure project: no .ralph/ subfolder
-# yet, but an unambiguous Ralph control file still sits at the project root.
-# Only Ralph-specific markers are used — PROMPT.md and the legacy @-prefixed
-# fix_plan/AGENT files. Generic names (fix_plan.md, AGENT.md, logs/, specs/) are
-# deliberately excluded so a modern or non-Ralph project that merely contains one
-# of those is never halted by mistake. The migrator (migrate_to_ralph_folder.sh)
-# keeps broader, advisory semantics suited to its manual context (Issue #41).
-# Shared by the directory-init guard below and main()'s migration gate so the two
-# checks cannot diverge.
+# Un-migrated pre-v0.10 flat structure: no .ralph/ yet, but an unambiguous Ralph
+# control file (PROMPT.md or legacy @fix_plan.md/@AGENT.md) sits at the root.
+# Generic names (logs/, AGENT.md, ...) are excluded to avoid false-positive halts
+# on non-Ralph projects. Shared by the init guard and main()'s gate (Issue #41).
 is_legacy_flat_structure() {
     [[ -d ".ralph" ]] && return 1
     [[ -f "PROMPT.md" ]] || [[ -f "@fix_plan.md" ]] || [[ -f "@AGENT.md" ]]

--- a/ralph_loop.sh
+++ b/ralph_loop.sh
@@ -274,12 +274,23 @@ BLUE='\033[0;34m'
 PURPLE='\033[0;35m'
 NC='\033[0m' # No Color
 
-# Initialize directories
-# Skip when an un-migrated flat-structure project is detected (root PROMPT.md and
-# no .ralph/). Creating .ralph/ here would mask the old layout and turn main()'s
-# migration gate into dead code (Issue #41); main() surfaces the migration message.
-# Condition is the De Morgan inverse of the flat-structure check in main().
-if [[ ! -f "PROMPT.md" ]] || [[ -d ".ralph" ]]; then
+# Detect an un-migrated pre-v0.10 flat-structure project: no .ralph/ subfolder
+# yet, but an unambiguous Ralph control file still sits at the project root.
+# Only Ralph-specific markers are used — PROMPT.md and the legacy @-prefixed
+# fix_plan/AGENT files. Generic names (fix_plan.md, AGENT.md, logs/, specs/) are
+# deliberately excluded so a modern or non-Ralph project that merely contains one
+# of those is never halted by mistake. The migrator (migrate_to_ralph_folder.sh)
+# keeps broader, advisory semantics suited to its manual context (Issue #41).
+# Shared by the directory-init guard below and main()'s migration gate so the two
+# checks cannot diverge.
+is_legacy_flat_structure() {
+    [[ -d ".ralph" ]] && return 1
+    [[ -f "PROMPT.md" ]] || [[ -f "@fix_plan.md" ]] || [[ -f "@AGENT.md" ]]
+}
+
+# Initialize directories. Skip for an un-migrated flat structure so main() can
+# surface the migration message instead of masking the old layout (Issue #41).
+if ! is_legacy_flat_structure; then
     mkdir -p "$LOG_DIR" "$DOCS_DIR"
 fi
 
@@ -2163,10 +2174,11 @@ loop_count=0
 
 # Main loop
 main() {
-    # Check for an un-migrated old flat structure (root PROMPT.md, no .ralph/)
-    # BEFORE anything else — including Claude CLI validation — so the migration
-    # guidance fires regardless of whether the CLI is installed (Issue #41).
-    if [[ -f "PROMPT.md" ]] && [[ ! -d ".ralph" ]]; then
+    # Check for an un-migrated old flat structure BEFORE anything else — including
+    # Claude CLI validation — so the migration guidance fires regardless of whether
+    # the CLI is installed. Uses the shared is_legacy_flat_structure helper so this
+    # gate stays in lock-step with the directory-init guard (Issue #41).
+    if is_legacy_flat_structure; then
         log_status "ERROR" "This project uses the old flat structure."
         echo ""
         echo "Ralph v0.10.0+ uses a .ralph/ subfolder to keep your project root clean."

--- a/ralph_loop.sh
+++ b/ralph_loop.sh
@@ -275,7 +275,12 @@ PURPLE='\033[0;35m'
 NC='\033[0m' # No Color
 
 # Initialize directories
-mkdir -p "$LOG_DIR" "$DOCS_DIR"
+# Skip when an un-migrated flat-structure project is detected (root PROMPT.md and
+# no .ralph/). Creating .ralph/ here would mask the old layout and turn main()'s
+# migration gate into dead code (Issue #41); main() surfaces the migration message.
+if ! { [[ -f "PROMPT.md" ]] && [[ ! -d ".ralph" ]]; }; then
+    mkdir -p "$LOG_DIR" "$DOCS_DIR"
+fi
 
 # Check if tmux is available
 check_tmux_available() {
@@ -481,7 +486,11 @@ log_status() {
     # Write to stderr so log messages don't interfere with function return values
     # 2>/dev/null suppresses "Input/output error" when tmux pty is broken (Issue #188)
     echo -e "${color}[$timestamp] [$level] $message${NC}" >&2 2>/dev/null
-    echo "[$timestamp] [$level] $message" >> "$LOG_DIR/ralph.log" 2>/dev/null
+    # Only append to the log file when its directory exists. Redirection-open
+    # failures are emitted by the shell before `2>/dev/null` takes effect, so a
+    # missing $LOG_DIR (e.g. the pre-migration flat-structure exit) would leak a
+    # "No such file or directory" line without this guard (Issue #41).
+    [[ -d "$LOG_DIR" ]] && echo "[$timestamp] [$level] $message" >> "$LOG_DIR/ralph.log" 2>/dev/null
 }
 
 # Update status JSON for external monitoring
@@ -2153,6 +2162,22 @@ loop_count=0
 
 # Main loop
 main() {
+    # Check for an un-migrated old flat structure (root PROMPT.md, no .ralph/)
+    # BEFORE anything else — including Claude CLI validation — so the migration
+    # guidance fires regardless of whether the CLI is installed (Issue #41).
+    if [[ -f "PROMPT.md" ]] && [[ ! -d ".ralph" ]]; then
+        log_status "ERROR" "This project uses the old flat structure."
+        echo ""
+        echo "Ralph v0.10.0+ uses a .ralph/ subfolder to keep your project root clean."
+        echo ""
+        echo "To upgrade your project, run:"
+        echo "  ralph-migrate"
+        echo ""
+        echo "This will move Ralph-specific files to .ralph/ while preserving src/ at root."
+        echo "A backup will be created before migration."
+        exit 1
+    fi
+
     # Load project-specific configuration from .ralphrc
     if load_ralphrc; then
         if [[ "$RALPHRC_LOADED" == "true" ]]; then
@@ -2190,20 +2215,6 @@ main() {
     log_status "SUCCESS" "🚀 Ralph loop starting with Claude Code"
     log_status "INFO" "Max calls per hour: $MAX_CALLS_PER_HOUR"
     log_status "INFO" "Logs: $LOG_DIR/ | Docs: $DOCS_DIR/ | Status: $STATUS_FILE"
-
-    # Check if project uses old flat structure and needs migration
-    if [[ -f "PROMPT.md" ]] && [[ ! -d ".ralph" ]]; then
-        log_status "ERROR" "This project uses the old flat structure."
-        echo ""
-        echo "Ralph v0.10.0+ uses a .ralph/ subfolder to keep your project root clean."
-        echo ""
-        echo "To upgrade your project, run:"
-        echo "  ralph-migrate"
-        echo ""
-        echo "This will move Ralph-specific files to .ralph/ while preserving src/ at root."
-        echo "A backup will be created before migration."
-        exit 1
-    fi
 
     # Check if this is a Ralph project directory
     if [[ ! -f "$PROMPT_FILE" ]]; then

--- a/ralph_loop.sh
+++ b/ralph_loop.sh
@@ -278,7 +278,8 @@ NC='\033[0m' # No Color
 # Skip when an un-migrated flat-structure project is detected (root PROMPT.md and
 # no .ralph/). Creating .ralph/ here would mask the old layout and turn main()'s
 # migration gate into dead code (Issue #41); main() surfaces the migration message.
-if ! { [[ -f "PROMPT.md" ]] && [[ ! -d ".ralph" ]]; }; then
+# Condition is the De Morgan inverse of the flat-structure check in main().
+if [[ ! -f "PROMPT.md" ]] || [[ -d ".ralph" ]]; then
     mkdir -p "$LOG_DIR" "$DOCS_DIR"
 fi
 

--- a/tests/integration/test_backward_compat.bats
+++ b/tests/integration/test_backward_compat.bats
@@ -61,6 +61,13 @@ teardown() {
 
     # The migration gate must not have silently initialised the new structure.
     assert_file_not_exists ".ralph"
+
+    # Regression guard: the migration exit path runs without $LOG_DIR, so
+    # log_status must not leak a shell redirection error to stderr (Issue #41).
+    local err
+    # `|| true`: the script exits 1 (migration gate); we only care about stderr.
+    err=$(bash "$RALPH_SCRIPT" 2>&1 >/dev/null) || true
+    [[ "$err" != *"No such file or directory"* ]]
 }
 
 @test ".ralphrc missing optional fields still loads with safe defaults" {

--- a/tests/integration/test_backward_compat.bats
+++ b/tests/integration/test_backward_compat.bats
@@ -70,6 +70,34 @@ teardown() {
     [[ "$err" != *"No such file or directory"* ]]
 }
 
+@test "legacy @-prefixed control file (no .ralph/) also triggers migration message" {
+    # Pre-v0.10 projects used @-prefixed control files (e.g. @fix_plan.md). One at
+    # the root with no .ralph/ must also be recognised as a flat structure needing
+    # migration — the detection is not limited to PROMPT.md.
+    echo "- [ ] legacy task" > @fix_plan.md
+
+    run bash "$RALPH_SCRIPT"
+
+    assert_failure
+    [[ "$output" == *"old flat structure"* ]]
+    [[ "$output" == *"ralph-migrate"* ]]
+    assert_file_not_exists ".ralph"
+}
+
+@test "modern non-Ralph project with a root logs/ dir is NOT flagged as legacy" {
+    # Generic directory names must not trigger the migration halt: a project that
+    # merely has a root logs/ folder (and no Ralph control files) is not a legacy
+    # Ralph layout and must not be told to run ralph-migrate.
+    source "$RALPH_SCRIPT"
+    # Sourcing initialises .ralph/ via the directory-init guard; clear it so we
+    # evaluate the marker logic in a true "no .ralph/" state.
+    rm -rf .ralph
+    mkdir -p logs
+
+    run is_legacy_flat_structure
+    assert_failure
+}
+
 @test ".ralphrc missing optional fields still loads with safe defaults" {
     # A user-authored .ralphrc that only sets a couple of values must not break;
     # everything it omits falls back to the documented defaults.

--- a/tests/integration/test_backward_compat.bats
+++ b/tests/integration/test_backward_compat.bats
@@ -1,0 +1,175 @@
+#!/usr/bin/env bats
+# Integration tests for backward compatibility (GitHub Issue #41)
+#
+# Ensures Phase 1-4 enhancements don't break existing Ralph installations or
+# upgrade paths. Unit-level CLI flag compatibility is already covered by
+# test_cli_modern.bats / test_cli_parsing.bats; this file focuses on
+# INTEGRATION-level concerns those unit tests don't catch:
+#   - old flat-structure projects (pre-.ralph/ subfolder)
+#   - .ralphrc files missing optional / Phase-3 fields
+#   - missing optional state files (status.json, circuit breaker state)
+#   - the bare CLI surface staying backward compatible
+#
+# Pattern note: most tests `source ralph_loop.sh` (the BASH_SOURCE guard keeps
+# main() from running) and exercise individual functions, mirroring
+# test_dry_run.bats / test_loop_execution.bats. The migration-message test runs
+# the script as a subprocess because it asserts main()'s startup gate.
+
+load '../helpers/test_helper'
+load '../helpers/fixtures'
+
+RALPH_SCRIPT="${BATS_TEST_DIRNAME}/../../ralph_loop.sh"
+CB_LIB="${BATS_TEST_DIRNAME}/../../lib/circuit_breaker.sh"
+
+setup() {
+    TEST_DIR="$(mktemp -d)"
+    cd "$TEST_DIR"
+
+    git init > /dev/null 2>&1
+    git config user.email "test@example.com"
+    git config user.name "Test User"
+
+    # Clear any ambient config so sourcing ralph_loop.sh exercises the real
+    # default-resolution logic instead of values inherited from the outer shell
+    # (e.g. CLAUDE_EFFORT may be set by the surrounding environment).
+    unset CLAUDE_EFFORT CLAUDE_MODEL CLAUDE_ALLOWED_TOOLS CLAUDE_OUTPUT_FORMAT \
+          CLAUDE_USE_CONTINUE VERBOSE_PROGRESS MAX_CALLS_PER_HOUR MAX_TOKENS_PER_HOUR
+}
+
+teardown() {
+    if [[ -n "$TEST_DIR" ]] && [[ -d "$TEST_DIR" ]]; then
+        cd /
+        rm -rf "$TEST_DIR"
+    fi
+}
+
+# =============================================================================
+# Existing project compatibility (5 tests)
+# =============================================================================
+
+@test "old flat structure (root PROMPT.md, no .ralph/) reports migration message" {
+    # Pre-v0.10 projects kept PROMPT.md at the project root. Running current ralph
+    # there must surface clear migration guidance and exit non-zero WITHOUT silently
+    # creating a .ralph/ directory (which would mask the old layout).
+    echo "# Legacy prompt" > PROMPT.md
+
+    run bash "$RALPH_SCRIPT"
+
+    assert_failure
+    [[ "$output" == *"old flat structure"* ]]
+    [[ "$output" == *"ralph-migrate"* ]]
+
+    # The migration gate must not have silently initialised the new structure.
+    assert_file_not_exists ".ralph"
+}
+
+@test ".ralphrc missing optional fields still loads with safe defaults" {
+    # A user-authored .ralphrc that only sets a couple of values must not break;
+    # everything it omits falls back to the documented defaults.
+    cat > .ralphrc <<'EOF'
+MAX_CALLS_PER_HOUR=50
+EOF
+
+    source "$RALPH_SCRIPT"
+    load_ralphrc
+
+    # Explicitly-set field is honoured.
+    assert_equal "$MAX_CALLS_PER_HOUR" "50"
+    # Omitted fields fall back to defaults.
+    assert_equal "$CLAUDE_OUTPUT_FORMAT" "json"
+    assert_equal "$CLAUDE_USE_CONTINUE" "true"
+    # Optional overrides remain empty (use CLI default) when not specified.
+    assert_equal "$CLAUDE_MODEL" ""
+    assert_equal "$CLAUDE_EFFORT" ""
+    # The hardened tool allowlist must still be populated from defaults.
+    [[ -n "$CLAUDE_ALLOWED_TOOLS" ]]
+    [[ "$CLAUDE_ALLOWED_TOOLS" == *"Bash(git commit *)"* ]]
+}
+
+@test "v0.9-style .ralphrc (legacy var names) loads without errors" {
+    # v0.9 .ralphrc files predate Phase-3 fields and used the legacy ALLOWED_TOOLS
+    # / RALPH_VERBOSE names. They must load cleanly and map to internal names.
+    cat > .ralphrc <<'EOF'
+MAX_CALLS_PER_HOUR=75
+ALLOWED_TOOLS="Write,Read,Bash(git commit)"
+RALPH_VERBOSE=true
+EOF
+
+    source "$RALPH_SCRIPT"
+    load_ralphrc
+
+    assert_equal "$MAX_CALLS_PER_HOUR" "75"
+    # Legacy ALLOWED_TOOLS maps onto the internal CLAUDE_ALLOWED_TOOLS name.
+    assert_equal "$CLAUDE_ALLOWED_TOOLS" "Write,Read,Bash(git commit)"
+    # Legacy RALPH_VERBOSE maps onto VERBOSE_PROGRESS.
+    assert_equal "$VERBOSE_PROGRESS" "true"
+}
+
+@test "loop still functions when status.json is absent" {
+    # status.json is an optional output file; update_status must create it on demand.
+    source "$RALPH_SCRIPT"
+    export RALPH_DIR=".ralph"
+    export STATUS_FILE="$RALPH_DIR/status.json"
+    export TOKEN_COUNT_FILE="$RALPH_DIR/.token_count"
+    mkdir -p "$RALPH_DIR"
+
+    assert_file_not_exists "$STATUS_FILE"
+
+    update_status 1 0 "executing" "running"
+
+    assert_file_exists "$STATUS_FILE"
+    assert_valid_json "$STATUS_FILE"
+    assert_equal "$(get_json_field "$STATUS_FILE" 'loop_count')" "1"
+    assert_equal "$(get_json_field "$STATUS_FILE" 'status')" "running"
+}
+
+@test "loop still functions when .circuit_breaker_state is absent" {
+    # The circuit breaker state file is optional; init must create a CLOSED state.
+    export RALPH_DIR=".ralph"
+    export CB_STATE_FILE="$RALPH_DIR/.circuit_breaker_state"
+    mkdir -p "$RALPH_DIR"
+
+    source "${BATS_TEST_DIRNAME}/../../lib/date_utils.sh"
+    source "$CB_LIB"
+
+    assert_file_not_exists "$CB_STATE_FILE"
+
+    init_circuit_breaker
+
+    assert_file_exists "$CB_STATE_FILE"
+    assert_valid_json "$CB_STATE_FILE"
+    assert_equal "$(get_json_field "$CB_STATE_FILE" 'state')" "CLOSED"
+}
+
+# =============================================================================
+# CLI upgrade path (2 tests)
+# =============================================================================
+
+@test "bare ralph (no new flags) keeps pre-Phase-3 defaults" {
+    # Sourcing with a clean environment must yield the long-standing defaults so
+    # existing invocations behave identically after upgrading.
+    source "$RALPH_SCRIPT"
+
+    assert_equal "$MAX_CALLS_PER_HOUR" "100"
+    assert_equal "$PROMPT_FILE" ".ralph/PROMPT.md"
+    assert_equal "$SLEEP_DURATION" "3600"
+
+    # Legacy flags remain documented in --help.
+    run bash "$RALPH_SCRIPT" --help
+    assert_success
+    [[ "$output" == *"--calls"* ]]
+    [[ "$output" == *"--prompt"* ]]
+    [[ "$output" == *"--status"* ]]
+}
+
+@test "old-style prompt file path via --prompt / -p is still accepted" {
+    # Pre-Phase-3 users passed a custom prompt path. Both the long and short flags
+    # must still parse alongside other options without error.
+    run bash "$RALPH_SCRIPT" --prompt custom_prompt.md --help
+    assert_success
+    [[ "$output" == *"Usage:"* ]]
+
+    run bash "$RALPH_SCRIPT" -p custom_prompt.md --help
+    assert_success
+    [[ "$output" == *"Usage:"* ]]
+}


### PR DESCRIPTION
## Summary
Implements **Issue #41** — integration-level backward-compatibility tests ensuring Phase 1–4 enhancements don't break existing Ralph installations or upgrade paths.

New file: `tests/integration/test_backward_compat.bats` (7 tests):

**Existing project compatibility**
- Old flat structure (root `PROMPT.md`, no `.ralph/`) → clear migration message, exit 1, **does not** create `.ralph/`
- `.ralphrc` missing optional fields → `load_ralphrc` applies documented defaults (`CLAUDE_MODEL`/`CLAUDE_EFFORT` stay empty, tool allowlist populated)
- v0.9-style `.ralphrc` (legacy `ALLOWED_TOOLS`, `RALPH_VERBOSE`) loads cleanly and maps to internal names
- Missing `status.json` → `update_status` creates valid JSON on demand
- Missing `.ralph/.circuit_breaker_state` → `init_circuit_breaker` creates a CLOSED state

**CLI upgrade path**
- Bare `ralph` keeps pre-Phase-3 defaults (`MAX_CALLS_PER_HOUR=100`, `PROMPT_FILE=.ralph/PROMPT.md`, `SLEEP_DURATION=3600`); legacy flags still documented in `--help`
- Old-style prompt paths via `--prompt` / `-p` still parse

## Bug fix included (required for acceptance criterion #1)
Writing the migration test exposed that the migration message was **dead code**:
- The top-level `mkdir -p "$LOG_DIR"` created `.ralph/` *before* `main()`'s `[[ ! -d ".ralph" ]]` check, so the gate never fired when the script actually ran.
- The check also sat *after* `validate_claude_command`, so it couldn't fire without the Claude CLI installed.

Fix (minimal, low-risk):
1. Guard the top-level `mkdir` to skip when an un-migrated flat structure is detected.
2. Move the migration check to the top of `main()`, before CLI validation. Existing structural ordering tests (validate → version → updates before the loop) still hold.
3. Guard `log_status`'s log-file append so a missing `$LOG_DIR` on the pre-migration exit path doesn't leak a shell redirection error to stderr.

## Testing
- New suite: 9/9 passing
- Full suite: **771 passing, 0 failing, 11 skipped** — no regressions
- Manual demo: running current `ralph` in an old flat-structure project now prints the migration guidance, exits 1, and leaves the directory untouched (no stray `.ralph/`)

## Known limitations
- The two CLI-upgrade-path tests assert the backward-compatible **CLI surface** (flags parse, defaults unchanged) via `--help`; deeper `--prompt` path-resolution is already covered by `test_cli_parsing.bats` / `test_cli_modern.bats`, so it's not duplicated here.

Closes #41

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Migration detection now runs earlier at startup and avoids creating project directories when a legacy layout is detected
  * Logging refined to avoid spurious startup errors when project metadata or state files are missing

* **Tests**
  * Added an integration suite validating backward-compatibility for legacy layouts, older config formats, optional runtime state creation, and CLI upgrade-path behavior

* **Documentation**
  * Test matrix updated to include the new backward-compatibility coverage entry
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
