### PR TITLE
test(e2e): full-loop E2E suite running ralph_loop.sh as a subprocess (#17)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,7 @@ jobs:
 
     - name: Run E2E tests
       run: npm run test:e2e
+      timeout-minutes: 15
 
     - name: Generate test report
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [ main ]
 
+# Least-privilege token: this workflow only reads the repo (tests + coverage
+# artifact upload need no write scopes)
+permissions:
+  contents: read
+
 env:
   # Coverage threshold - configurable, not hardcoded
   # Set to 0 to disable threshold enforcement
@@ -47,9 +52,11 @@ jobs:
 
     - name: Generate test report
       run: |
-        echo "## Test Results" >> $GITHUB_STEP_SUMMARY
-        echo "✅ Unit tests passed" >> $GITHUB_STEP_SUMMARY
-        echo "✅ E2E tests passed" >> $GITHUB_STEP_SUMMARY
+        {
+          echo "## Test Results"
+          echo "✅ Unit tests passed"
+          echo "✅ E2E tests passed"
+        } >> "$GITHUB_STEP_SUMMARY"
 
   coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,12 +42,13 @@ jobs:
       run: npm run test:integration || true
 
     - name: Run E2E tests
-      run: npm run test:e2e || true
+      run: npm run test:e2e
 
     - name: Generate test report
       run: |
         echo "## Test Results" >> $GITHUB_STEP_SUMMARY
         echo "✅ Unit tests passed" >> $GITHUB_STEP_SUMMARY
+        echo "✅ E2E tests passed" >> $GITHUB_STEP_SUMMARY
 
   coverage:
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,7 @@ The system uses a modular architecture with reusable components in the `lib/` di
    - Automatic session persistence to `.ralph/.claude_session_id` file with 24-hour expiration
    - Session lifecycle: `get_session_id()`, `reset_session()`, `log_session_transition()`, `init_session_tracking()`
    - Session history tracked in `.ralph/.ralph_session_history` (last 50 transitions)
+   - Session lifecycle state tracked in `.ralph/.ralph_session` (JSON: `session_id`, `created_at`, `last_used`, `reset_at`, `reset_reason`) — written by `reset_session()` and `init_session_tracking()` in ralph_loop.sh
    - Session auto-reset on: circuit breaker open, manual interrupt, project completion
    - Detects test-only loops, stuck error patterns, and question-only loops
    - Two-stage error filtering to eliminate false positives

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,6 +193,7 @@ npm test
 # Run specific test suites
 npm run test:unit
 npm run test:integration
+npm run test:e2e
 
 # Run individual test files
 bats tests/unit/test_cli_parsing.bats
@@ -325,6 +326,8 @@ Ralph uses GitHub Actions for continuous integration:
    - Executes unit, integration, and E2E tests
    - Coverage reporting with kcov (informational only)
    - Uploads coverage artifacts
+
+   - Unit and E2E suites are blocking; the integration suite is currently advisory (`|| true`)
 
 2. **claude.yml** - Claude Code GitHub Actions integration
    - Automated code review capabilities
@@ -612,6 +615,7 @@ Ralph uses a multi-layered strategy to prevent Claude from accidentally deleting
 | `test_notifications.bats` | 5 | Desktop notifications: send_notification() cross-platform (macOS/Linux/bell), disabled by default, --notify flag (Issue #22) |
 | `test_backup_rollback.bats` | 6 | Backup/rollback: create_backup() branch naming, disabled by default, graceful git-less handling, commit message, --backup flag, rollback_to_backup() checkout (Issue #23) |
 | `test_backward_compat.bats` | 9 | Integration-level backward compatibility: old flat-structure migration message (PROMPT.md + legacy @-prefixed markers via shared `is_legacy_flat_structure`), generic dirs not misflagged, .ralphrc with missing/legacy fields, missing optional state files (status.json, circuit breaker state), bare-CLI defaults, old-style prompt paths (Issue #41) |
+| `test_full_loop.bats` (e2e) | 13 | True E2E: runs ralph_loop.sh as a subprocess with an executable mock `claude` CLI on disk (`tests/e2e/helpers/e2e_helper.bash`). Covers startup validation failures, plan_complete with zero API calls, multi-loop fix_plan progression, completion-signal exit, test saturation, circuit-breaker halt, stale exit-signal reset (#194), session continuity via `--resume` argv, hourly counter reset, CLI flags in a real run, API-limit exit, and signal-interrupt cleanup (Issue #17). Mock must take >1s per call — ralph's early-failure detection treats sub-second exits as startup failures |
 
 ### Running Tests
 ```bash

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Ralph is an implementation of the Geoffrey Huntley's technique for Claude Code t
 
 **Version**: v0.11.5 - Active Development
 **Core Features**: Working and tested
-**Test Coverage**: 566 tests, 100% pass rate
+**Test Coverage**: 784 tests, 100% pass rate
 
 ### What's Working Now
 - Autonomous development loops with intelligent exit detection
@@ -646,8 +646,11 @@ If you want to run the test suite:
 # Install BATS testing framework
 npm install -g bats bats-support bats-assert
 
-# Run all tests (566 tests)
+# Run unit + integration tests (771 tests)
 npm test
+
+# Run end-to-end tests (13 tests; full ralph_loop.sh subprocess runs)
+npm run test:e2e
 
 # Run specific test suites
 bats tests/unit/test_rate_limiting.bats
@@ -672,10 +675,11 @@ bats tests/integration/test_installation.bats
 ```
 
 Current test status:
-- **566 tests** across 18 test files
-- **100% pass rate** (556/556 passing)
-- Comprehensive unit and integration tests
+- **784 tests** across 34 test files
+- **100% pass rate** (784/784 passing)
+- Comprehensive unit, integration, and end-to-end tests
 - Specialized tests for JSON parsing, CLI flags, circuit breaker, EXIT_SIGNAL behavior, enable wizard, and installation workflows
+- True E2E suite running ralph_loop.sh as a subprocess against a mock Claude CLI (`tests/e2e/`)
 
 > **Note on Coverage**: Bash code coverage measurement with kcov has fundamental limitations when tracing subprocess executions. Test pass rate (100%) is the quality gate. See [bats-core#15](https://github.com/bats-core/bats-core/issues/15) for details.
 
@@ -780,7 +784,7 @@ cd ralph-claude-code
 
 # Install dependencies and run tests
 npm install
-npm test  # All 566 tests must pass
+npm test && npm run test:e2e  # All 784 tests must pass
 ```
 
 ### Priority Contribution Areas

--- a/TESTING.md
+++ b/TESTING.md
@@ -133,7 +133,7 @@ tests/
 
 - **Test files**: `test_<component_name>.bats`
 - **Test functions**: Descriptive sentences: `@test "can_make_call returns success when under limit"`
-- **Location**: Place tests in `unit/` or `integration/` based on scope
+- **Location**: Place tests in `unit/`, `integration/`, or `e2e/` based on scope
 
 ---
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -110,7 +110,10 @@ tests/
 │   ├── test_project_setup.bats     # Project setup (setup.sh) (36 tests)
 │   └── test_prd_import.bats        # PRD import workflow (33 tests)
 │
-├── e2e/                            # End-to-end tests (planned)
+├── e2e/                            # End-to-end tests
+│   ├── test_full_loop.bats         # Full ralph_loop.sh subprocess runs (13 tests)
+│   └── helpers/
+│       └── e2e_helper.bash         # Mock claude CLI + temp project harness
 │
 └── helpers/                        # Shared test utilities
     ├── test_helper.bash            # Assertions and setup functions
@@ -629,7 +632,7 @@ test:
     - run: npm install && sudo apt-get install -y jq
     - run: npm run test:unit          # Must pass
     - run: npm run test:integration   # Allowed to fail (|| true)
-    - run: npm run test:e2e          # Allowed to fail (|| true)
+    - run: npm run test:e2e          # Must pass
 ```
 
 #### 2. Coverage Job (Informational)

--- a/tests/e2e/helpers/e2e_helper.bash
+++ b/tests/e2e/helpers/e2e_helper.bash
@@ -21,6 +21,18 @@
 
 RALPH_SCRIPT="${BATS_TEST_DIRNAME}/../../ralph_loop.sh"
 
+# Cross-platform GNU timeout: Linux ships `timeout`; macOS gets `gtimeout`
+# from Homebrew coreutils (same GNU binary, so --foreground/-k work on both).
+# Mirrors the detection in lib/timeout_utils.sh.
+if command -v timeout >/dev/null 2>&1; then
+    E2E_TIMEOUT_CMD="timeout"
+elif command -v gtimeout >/dev/null 2>&1; then
+    E2E_TIMEOUT_CMD="gtimeout"
+else
+    echo "FATAL: E2E tests require GNU timeout (brew install coreutils on macOS)" >&2
+    exit 1
+fi
+
 # Create a complete temp Ralph project + mock claude CLI, and cd into it.
 # Sets: E2E_DIR, MOCK_DIR, PROJECT_DIR
 setup_e2e_project() {
@@ -197,12 +209,15 @@ queue_effect() {
 
 # Standard "productive work" effect: create + stage a src file (git progress
 # for the circuit breaker) and check off the first open fix_plan item.
+# Uses awk (not GNU `sed -i '0,...'`) so the effect runs on BSD/macOS too.
 queue_productive_effect() {
     local n=$1
     queue_effect "$n" << EOF
 echo "work from loop $n" > "src/work_${n}.txt"
 git add "src/work_${n}.txt"
-sed -i '0,/^- \[ \]/s//- [x]/' .ralph/fix_plan.md
+awk 'done != 1 && /^- \[ \]/ { sub(/^- \[ \]/, "- [x]"); done = 1 } { print }' \
+    .ralph/fix_plan.md > .ralph/fix_plan.md.tmp \
+    && mv .ralph/fix_plan.md.tmp .ralph/fix_plan.md
 EOF
 }
 
@@ -228,7 +243,7 @@ e2e_fix_plan() {
 # a plain `timeout` would deliver TERM and then wait forever.
 # Usage: run_ralph [args...]   — use with bats `run`
 run_ralph() {
-    timeout --foreground -k 5 120 bash "$RALPH_SCRIPT" "$@" < /dev/null
+    "$E2E_TIMEOUT_CMD" --foreground -k 5 120 bash "$RALPH_SCRIPT" "$@" < /dev/null
 }
 
 # Number of times the mock claude was invoked.

--- a/tests/e2e/helpers/e2e_helper.bash
+++ b/tests/e2e/helpers/e2e_helper.bash
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+# E2E Test Harness for Full Ralph Loop Execution (Issue #17)
+#
+# Unlike unit/integration tests (which source functions), this harness runs
+# ralph_loop.sh as a TRUE SUBPROCESS with a real executable mock `claude` CLI.
+# The mock lives on disk (not a bash function) so it survives the subprocess
+# boundary, logs the argv of every invocation, and replays scripted JSON
+# responses with optional side effects (file creation, fix_plan edits).
+#
+# Layout created by setup_e2e_project:
+#   $E2E_DIR/
+#   ├── bin/claude            # executable mock CLI
+#   ├── mock/
+#   │   ├── calls/.count      # mock invocation counter
+#   │   ├── calls/argv_N.log  # argv of call N (one arg per line)
+#   │   ├── responses/N.out   # stdout for call N (default.out as fallback)
+#   │   ├── responses/N.exit  # exit code for call N (default 0)
+#   │   ├── responses/N.sleep # seconds to sleep before responding
+#   │   └── effects/N.sh      # side-effect script run (in project cwd) on call N
+#   └── project/              # full Ralph project (git repo, .ralph/, .ralphrc)
+
+RALPH_SCRIPT="${BATS_TEST_DIRNAME}/../../ralph_loop.sh"
+
+# Create a complete temp Ralph project + mock claude CLI, and cd into it.
+# Sets: E2E_DIR, MOCK_DIR, PROJECT_DIR
+setup_e2e_project() {
+    E2E_DIR="$(mktemp -d)"
+    MOCK_DIR="$E2E_DIR/mock"
+    PROJECT_DIR="$E2E_DIR/project"
+    mkdir -p "$MOCK_DIR"/{responses,effects,calls} "$E2E_DIR/bin" "$PROJECT_DIR"
+
+    install_mock_claude
+
+    cd "$PROJECT_DIR" || return 1
+    git init -q
+    git config user.email "e2e@test.local"
+    git config user.name "E2E Test"
+
+    # .ralph/ is gitignored so per-loop state writes (status.json, logs, analysis
+    # files) never count as git progress — only deliberate src/ changes made by
+    # mock side effects feed the circuit breaker's progress detection.
+    printf '.ralph/\n' > .gitignore
+
+    mkdir -p .ralph/logs src
+    cat > .ralph/PROMPT.md << 'EOF'
+# E2E Test Prompt
+Work through .ralph/fix_plan.md one item at a time.
+EOF
+    e2e_fix_plan 3 0
+    cat > .ralph/AGENT.md << 'EOF'
+# Agent Instructions
+Build: none. Test: none. This is an E2E fixture project.
+EOF
+    # Minimal .ralphrc: must exist for the integrity check; intentionally empty
+    # of overrides so env vars and CLI flags drive each test's configuration.
+    cat > .ralphrc << 'EOF'
+# E2E test project configuration
+EOF
+    echo "fixture" > src/seed.txt
+    git add -A
+    git commit -qm "e2e: initial fixture project"
+
+    # Subprocess configuration (env vars win over .ralphrc; defaults use :-)
+    export CLAUDE_CODE_CMD="$E2E_DIR/bin/claude"
+    export CLAUDE_AUTO_UPDATE=false          # never touch the npm registry
+    export ENABLE_NOTIFICATIONS=false
+    export ENABLE_BACKUP=false
+    export CLAUDE_TIMEOUT_MINUTES=1
+    export CLAUDE_USE_CONTINUE=false         # tests opt in to session continuity
+}
+
+teardown_e2e_project() {
+    # Kill any stray subprocesses anchored in the temp dir (background ralph,
+    # sleeping mock claude), then remove the tree.
+    if [[ -n "$E2E_DIR" && -d "$E2E_DIR" ]]; then
+        pkill -9 -f "$E2E_DIR" 2>/dev/null || true
+        cd /
+        rm -rf "$E2E_DIR"
+    fi
+}
+
+# Write the mock claude executable. Behavior per invocation:
+#   --version            → prints a modern version and exits
+#   anything else        → bumps call counter, logs argv, runs effects/N.sh
+#                          (cwd = project dir), sleeps responses/N.sleep if
+#                          present, cats responses/N.out (or default.out),
+#                          exits with responses/N.exit (default 0)
+install_mock_claude() {
+    cat > "$E2E_DIR/bin/claude" << EOF
+#!/usr/bin/env bash
+MOCK_DIR="$MOCK_DIR"
+EOF
+    cat >> "$E2E_DIR/bin/claude" << 'EOF'
+if [[ "$1" == "--version" ]]; then
+    echo "2.99.0 (Claude Code)"
+    exit 0
+fi
+
+n=$(( $(cat "$MOCK_DIR/calls/.count" 2>/dev/null || echo 0) + 1 ))
+echo "$n" > "$MOCK_DIR/calls/.count"
+printf '%s\n' "$@" > "$MOCK_DIR/calls/argv_${n}.log"
+
+if [[ -f "$MOCK_DIR/effects/${n}.sh" ]]; then
+    bash "$MOCK_DIR/effects/${n}.sh" >/dev/null 2>&1
+fi
+
+# ralph_loop.sh treats any process that exits within ~1s as an immediate
+# startup failure (Issue #97 early-failure detection), so the mock must take
+# realistically long. Override per call with responses/N.sleep.
+if [[ -f "$MOCK_DIR/responses/${n}.sleep" ]]; then
+    sleep "$(cat "$MOCK_DIR/responses/${n}.sleep")"
+else
+    sleep 1.5
+fi
+
+exit_code=0
+if [[ -f "$MOCK_DIR/responses/${n}.exit" ]]; then
+    exit_code=$(cat "$MOCK_DIR/responses/${n}.exit")
+fi
+
+if [[ -f "$MOCK_DIR/responses/${n}.out" ]]; then
+    cat "$MOCK_DIR/responses/${n}.out"
+elif [[ -f "$MOCK_DIR/responses/default.out" ]]; then
+    cat "$MOCK_DIR/responses/default.out"
+fi
+
+exit "$exit_code"
+EOF
+    chmod +x "$E2E_DIR/bin/claude"
+
+    # Default response: benign no-progress JSON. If a runaway loop makes more
+    # calls than a test scripted, the circuit breaker halts it (and the outer
+    # `timeout` wrapper is the final backstop).
+    e2e_response_json "IN_PROGRESS" "false" "Analyzing the codebase structure." \
+        > "$MOCK_DIR/responses/default.out"
+}
+
+# Build a flat Claude-CLI-format JSON response with an embedded RALPH_STATUS
+# block (the format parse_json_response extracts EXIT_SIGNAL from).
+# Usage: e2e_response_json STATUS EXIT_SIGNAL TEXT [SESSION_ID] [EXTRA_JQ_FIELDS]
+#   EXTRA_JQ_FIELDS: optional jq object suffix, e.g. '+ {work_type: "TEST_ONLY"}'
+e2e_response_json() {
+    local status=$1
+    local exit_signal=$2
+    local text=$3
+    local session_id=${4:-}
+    local extra=${5:-}
+
+    local result_text="$text
+
+---RALPH_STATUS---
+STATUS: $status
+TASKS_COMPLETED_THIS_LOOP: 1
+FILES_MODIFIED: 1
+TESTS_STATUS: PASSING
+WORK_TYPE: IMPLEMENTATION
+EXIT_SIGNAL: $exit_signal
+RECOMMENDATION: none
+---END_RALPH_STATUS---"
+
+    jq -cn \
+        --arg result "$result_text" \
+        --arg sid "$session_id" \
+        '{
+            type: "result",
+            subtype: "success",
+            is_error: false,
+            duration_ms: 1200,
+            result: $result,
+            usage: {input_tokens: 100, output_tokens: 50}
+        }
+        + (if $sid != "" then {session_id: $sid} else {} end)'"${extra:+ $extra}"
+}
+
+# Queue a response for mock call N.
+# Usage: queue_response N STATUS EXIT_SIGNAL TEXT [SESSION_ID] [EXTRA_JQ_FIELDS]
+queue_response() {
+    local n=$1; shift
+    e2e_response_json "$@" > "$MOCK_DIR/responses/${n}.out"
+}
+
+# Queue raw stdout + exit code for mock call N (for non-JSON failure scenarios).
+# Usage: queue_raw_response N EXIT_CODE <<< "output text"
+queue_raw_response() {
+    local n=$1
+    local exit_code=$2
+    cat > "$MOCK_DIR/responses/${n}.out"
+    echo "$exit_code" > "$MOCK_DIR/responses/${n}.exit"
+}
+
+# Queue a side-effect script for mock call N (runs with cwd = project dir).
+# Usage: queue_effect N <<'EOF' ... EOF
+queue_effect() {
+    local n=$1
+    cat > "$MOCK_DIR/effects/${n}.sh"
+}
+
+# Standard "productive work" effect: create + stage a src file (git progress
+# for the circuit breaker) and check off the first open fix_plan item.
+queue_productive_effect() {
+    local n=$1
+    queue_effect "$n" << EOF
+echo "work from loop $n" > "src/work_${n}.txt"
+git add "src/work_${n}.txt"
+sed -i '0,/^- \[ \]/s//- [x]/' .ralph/fix_plan.md
+EOF
+}
+
+# Write .ralph/fix_plan.md with N unchecked and M checked items.
+e2e_fix_plan() {
+    local unchecked=${1:-3}
+    local checked=${2:-0}
+    {
+        echo "# E2E Fix Plan"
+        echo ""
+        local i
+        for ((i = 1; i <= checked; i++)); do
+            echo "- [x] Completed task $i"
+        done
+        for ((i = 1; i <= unchecked; i++)); do
+            echo "- [ ] Open task $i"
+        done
+    } > .ralph/fix_plan.md
+}
+
+# Run ralph_loop.sh as a subprocess under a hard timeout (never hang CI).
+# -k is required: ralph traps SIGTERM (cleanup handler) without exiting, so
+# a plain `timeout` would deliver TERM and then wait forever.
+# Usage: run_ralph [args...]   — use with bats `run`
+run_ralph() {
+    timeout --foreground -k 5 120 bash "$RALPH_SCRIPT" "$@" < /dev/null
+}
+
+# Number of times the mock claude was invoked.
+mock_call_count() {
+    cat "$MOCK_DIR/calls/.count" 2>/dev/null || echo 0
+}
+
+# Read a field from .ralph/status.json.
+status_field() {
+    jq -r ".$1" .ralph/status.json
+}
+
+# Poll a jq condition against status.json until true or timeout (seconds).
+# Usage: wait_for_status '.status == "interrupted"' 25
+wait_for_status() {
+    local condition=$1
+    local timeout_s=${2:-20}
+    local waited=0
+    while (( waited < timeout_s * 10 )); do
+        if [[ -f .ralph/status.json ]] \
+           && jq -e "$condition" .ralph/status.json >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep 0.1
+        waited=$((waited + 1))
+    done
+    return 1
+}

--- a/tests/e2e/helpers/e2e_helper.bash
+++ b/tests/e2e/helpers/e2e_helper.bash
@@ -21,14 +21,12 @@
 
 RALPH_SCRIPT="${BATS_TEST_DIRNAME}/../../ralph_loop.sh"
 
-# Cross-platform GNU timeout: Linux ships `timeout`; macOS gets `gtimeout`
-# from Homebrew coreutils (same GNU binary, so --foreground/-k work on both).
-# Mirrors the detection in lib/timeout_utils.sh.
-if command -v timeout >/dev/null 2>&1; then
-    E2E_TIMEOUT_CMD="timeout"
-elif command -v gtimeout >/dev/null 2>&1; then
-    E2E_TIMEOUT_CMD="gtimeout"
-else
+# Cross-platform GNU timeout via the shared detection in lib/timeout_utils.sh
+# (Linux: `timeout`; macOS: `gtimeout` from Homebrew coreutils). The harness
+# invokes the binary directly rather than through portable_timeout() because
+# it needs the --foreground/-k flags, which that wrapper does not pass through.
+source "${BATS_TEST_DIRNAME}/../../lib/timeout_utils.sh"
+if ! E2E_TIMEOUT_CMD="$(detect_timeout_command)"; then
     echo "FATAL: E2E tests require GNU timeout (brew install coreutils on macOS)" >&2
     exit 1
 fi
@@ -79,6 +77,9 @@ EOF
     export ENABLE_BACKUP=false
     export CLAUDE_TIMEOUT_MINUTES=1
     export CLAUDE_USE_CONTINUE=false         # tests opt in to session continuity
+    # Hermeticity: a developer's exported model/effort overrides would
+    # otherwise leak extra flags into the mock's argv
+    unset CLAUDE_MODEL CLAUDE_EFFORT
 }
 
 teardown_e2e_project() {

--- a/tests/e2e/test_full_loop.bats
+++ b/tests/e2e/test_full_loop.bats
@@ -83,7 +83,9 @@ teardown() {
     # Graceful exit resets the session (which clears .response_analysis)
     assert_equal "$(jq -r '.reset_reason' .ralph/.ralph_session)" "project_complete"
     assert_equal "$(cat .ralph/.call_count)" "2"
-    [[ $(ls .ralph/logs/claude_output_*.log 2>/dev/null | wc -l) -ge 2 ]]
+    local output_log_count
+    output_log_count=$(ls .ralph/logs/claude_output_*.log 2>/dev/null | wc -l)
+    [[ $output_log_count -ge 2 ]] || fail "Expected >= 2 output logs, found $output_log_count"
 }
 
 @test "E2E: multi-loop run progresses through fix_plan to plan_complete" {
@@ -112,8 +114,10 @@ teardown() {
 }
 
 @test "E2E: three test-only loops exit with test_saturation" {
-    # work_type TEST_ONLY at top level marks the loop test-only; productive
-    # effects keep the circuit breaker from opening first.
+    # The analyzer reads work_type from the TOP LEVEL of the JSON only
+    # (parse_json_response: `.work_type // "UNKNOWN"`); the WORK_TYPE line
+    # inside the RALPH_STATUS block is not parsed. Staged file effects keep
+    # the circuit breaker from opening before saturation triggers.
     local i
     for i in 1 2 3; do
         queue_response "$i" "IN_PROGRESS" "false" "Ran the test suite again." \
@@ -138,6 +142,10 @@ EOF
 
 @test "E2E: three no-progress loops open the circuit breaker and halt" {
     # Default mock response is a no-progress analysis loop; queue nothing.
+    # "No progress" is determined from actual git state (staged/unstaged/
+    # committed changes since loop start), NOT from the FILES_MODIFIED line
+    # in RALPH_STATUS — the default response creates no files, so the
+    # circuit breaker sees three loops without progress and opens.
 
     run run_ralph
 
@@ -289,6 +297,11 @@ EOF
     # children — exactly what a terminal Ctrl-C does to the foreground process
     # group. The mock claude keeps sleeping, which holds the loop in its
     # monitor phase and keeps the interrupted status stable for assertion.
+    # Up to 20s ceiling (100 x 0.2s): the trap fires once ralph's current
+    # monitor `sleep 10` is interrupted, so the normal case completes in
+    # well under 1s. If this loop exhausts in CI, the assertions below fail
+    # with status still "running" — that symptom means the signal never
+    # reached ralph or the trap did not run.
     kill -TERM "$ralph_pid"
     local i
     for i in $(seq 1 100); do

--- a/tests/e2e/test_full_loop.bats
+++ b/tests/e2e/test_full_loop.bats
@@ -253,7 +253,7 @@ Please try again later when your limit resets.
 EOF
 
     # Feed "2" (exit) to the interactive limit prompt
-    run bash -c "printf '2' | timeout --foreground -k 5 120 bash '$RALPH_SCRIPT'"
+    run bash -c "printf '2' | '$E2E_TIMEOUT_CMD' --foreground -k 5 120 bash '$RALPH_SCRIPT'"
 
     assert_success
     assert_equal "$(mock_call_count)" "1"

--- a/tests/e2e/test_full_loop.bats
+++ b/tests/e2e/test_full_loop.bats
@@ -1,0 +1,310 @@
+#!/usr/bin/env bats
+# E2E tests for complete Ralph loop execution (Issue #17)
+#
+# These tests run ralph_loop.sh as a TRUE SUBPROCESS with a mock `claude`
+# executable on disk — exercising the full lifecycle: startup validation,
+# loop iterations, response analysis, exit detection, and final status.
+# See tests/e2e/helpers/e2e_helper.bash for the harness.
+#
+# Scenarios already covered at unit/integration level (sourced functions) are
+# intentionally NOT duplicated here; each test below verifies behavior that
+# only manifests in a real end-to-end subprocess run.
+
+load '../helpers/test_helper'
+load 'helpers/e2e_helper'
+
+setup() {
+    setup_e2e_project
+}
+
+teardown() {
+    teardown_e2e_project
+}
+
+# =============================================================================
+# STARTUP VALIDATION
+# =============================================================================
+
+@test "E2E: missing .ralph/PROMPT.md halts startup with guidance" {
+    rm .ralph/PROMPT.md
+
+    run run_ralph
+
+    assert_failure
+    [[ "$output" == *"PROMPT.md"* ]]
+    [[ "$output" == *"ralph-enable"* ]]
+    # Claude must never have been invoked
+    assert_equal "$(mock_call_count)" "0"
+}
+
+@test "E2E: missing .ralphrc fails the integrity check at startup" {
+    rm .ralphrc
+
+    run run_ralph
+
+    assert_failure
+    [[ "$output" == *".ralphrc"* ]]
+    assert_equal "$(mock_call_count)" "0"
+}
+
+# =============================================================================
+# GRACEFUL EXITS
+# =============================================================================
+
+@test "E2E: fully completed fix_plan exits plan_complete with zero API calls" {
+    e2e_fix_plan 0 3   # all items checked
+
+    run run_ralph
+
+    assert_success
+    assert_equal "$(mock_call_count)" "0"
+    assert_equal "$(status_field exit_reason)" "plan_complete"
+    assert_equal "$(status_field status)" "completed"
+    assert_equal "$(status_field last_action)" "graceful_exit"
+}
+
+@test "E2E: repeated EXIT_SIGNAL true responses trigger graceful completion exit" {
+    queue_response 1 "COMPLETE" "true" "All planned work has shipped."
+    queue_productive_effect 1
+    queue_response 2 "COMPLETE" "true" "Confirming: nothing left to build."
+    queue_productive_effect 2
+
+    run run_ralph
+
+    assert_success
+    # Exit check at the start of loop 3 sees two completion signals
+    assert_equal "$(mock_call_count)" "2"
+    assert_equal "$(status_field exit_reason)" "completion_signals"
+    assert_equal "$(status_field status)" "completed"
+
+    # Side effects of a real loop iteration
+    assert_file_exists "src/work_1.txt"
+    [[ "$output" == *"Analyzing Claude Code response"* ]]
+    # Graceful exit resets the session (which clears .response_analysis)
+    assert_equal "$(jq -r '.reset_reason' .ralph/.ralph_session)" "project_complete"
+    assert_equal "$(cat .ralph/.call_count)" "2"
+    [[ $(ls .ralph/logs/claude_output_*.log 2>/dev/null | wc -l) -ge 2 ]]
+}
+
+@test "E2E: multi-loop run progresses through fix_plan to plan_complete" {
+    e2e_fix_plan 3 0
+    local i
+    for i in 1 2 3; do
+        queue_response "$i" "IN_PROGRESS" "false" "Implemented open task $i."
+        queue_productive_effect "$i"
+    done
+
+    run run_ralph
+
+    assert_success
+    assert_equal "$(mock_call_count)" "3"
+    assert_equal "$(status_field exit_reason)" "plan_complete"
+    # Loop counter advanced past the three working iterations
+    assert_equal "$(status_field loop_count)" "4"
+    assert_equal "$(cat .ralph/.call_count)" "3"
+    # Each loop produced its own output log
+    [[ $(ls .ralph/logs/claude_output_*.log | wc -l) -eq 3 ]]
+    # All work landed
+    assert_file_exists "src/work_1.txt"
+    assert_file_exists "src/work_2.txt"
+    assert_file_exists "src/work_3.txt"
+    ! grep -q '^- \[ \]' .ralph/fix_plan.md
+}
+
+@test "E2E: three test-only loops exit with test_saturation" {
+    # work_type TEST_ONLY at top level marks the loop test-only; productive
+    # effects keep the circuit breaker from opening first.
+    local i
+    for i in 1 2 3; do
+        queue_response "$i" "IN_PROGRESS" "false" "Ran the test suite again." \
+            "" '+ {work_type: "TEST_ONLY"}'
+        queue_effect "$i" << EOF
+echo "test run $i" > "src/tests_$i.txt"
+git add "src/tests_$i.txt"
+EOF
+    done
+
+    run run_ralph
+
+    assert_success
+    assert_equal "$(mock_call_count)" "3"
+    assert_equal "$(status_field exit_reason)" "test_saturation"
+    assert_equal "$(status_field status)" "completed"
+}
+
+# =============================================================================
+# CIRCUIT BREAKER (full-loop halt path)
+# =============================================================================
+
+@test "E2E: three no-progress loops open the circuit breaker and halt" {
+    # Default mock response is a no-progress analysis loop; queue nothing.
+
+    run run_ralph
+
+    # The loop halts via `break`; the script itself exits 0 (current behavior)
+    assert_success
+    assert_equal "$(mock_call_count)" "3"
+    assert_equal "$(status_field status)" "halted"
+    assert_equal "$(status_field last_action)" "circuit_breaker_open"
+    assert_equal "$(jq -r '.state' .ralph/.circuit_breaker_state)" "OPEN"
+}
+
+# =============================================================================
+# STALE STATE PROTECTION (Issue #194)
+# =============================================================================
+
+@test "E2E: stale exit signals from a prior run do not cause premature exit" {
+    # Simulate a crashed prior run that left completion signals behind
+    cat > .ralph/.exit_signals << 'EOF'
+{"test_only_loops": [], "done_signals": [1, 2], "completion_indicators": [1, 2]}
+EOF
+    queue_response 1 "COMPLETE" "true" "Wrapping up the remaining work."
+    queue_productive_effect 1
+    queue_response 2 "COMPLETE" "true" "Everything is finished now."
+    queue_productive_effect 2
+
+    run run_ralph
+
+    assert_success
+    # The stale signals were reset: Claude WAS invoked (twice) rather than
+    # the loop exiting at the first check with zero calls.
+    assert_equal "$(mock_call_count)" "2"
+    assert_equal "$(status_field exit_reason)" "completion_signals"
+}
+
+# =============================================================================
+# SESSION CONTINUITY
+# =============================================================================
+
+@test "E2E: session ID from loop 1 is persisted and resumed in loop 2" {
+    export CLAUDE_USE_CONTINUE=true
+    e2e_fix_plan 2 0
+
+    queue_response 1 "IN_PROGRESS" "false" "Started task one." "e2e-sess-abc123"
+    queue_productive_effect 1
+    queue_response 2 "IN_PROGRESS" "false" "Finished task two." "e2e-sess-abc123"
+    queue_productive_effect 2
+
+    run run_ralph
+
+    assert_success
+    assert_equal "$(mock_call_count)" "2"
+
+    # Session was persisted after loop 1 (the graceful exit later clears the
+    # session file, so the argv of loop 2 is the durable evidence)
+    [[ "$output" == *"Saved Claude session"* ]]
+
+    # Loop 1 started fresh (no --resume); loop 2 resumed the stored session
+    ! grep -qx -- "--resume" "$MOCK_DIR/calls/argv_1.log"
+    grep -qx -- "--resume" "$MOCK_DIR/calls/argv_2.log"
+    grep -qx "e2e-sess-abc123" "$MOCK_DIR/calls/argv_2.log"
+}
+
+# =============================================================================
+# RATE LIMIT TRACKING
+# =============================================================================
+
+@test "E2E: stale hourly counter is reset before the loop proceeds" {
+    # Simulate a counter exhausted in a previous hour
+    echo "99" > .ralph/.call_count
+    echo "2020010100" > .ralph/.last_reset
+
+    e2e_fix_plan 1 0
+    queue_response 1 "IN_PROGRESS" "false" "Knocked out the last open task."
+    queue_productive_effect 1
+
+    run run_ralph
+
+    assert_success
+    # Counter was reset for the new hour, then incremented once — not 100
+    assert_equal "$(cat .ralph/.call_count)" "1"
+    assert_equal "$(cat .ralph/.last_reset)" "$(date +%Y%m%d%H)"
+    assert_equal "$(status_field exit_reason)" "plan_complete"
+}
+
+# =============================================================================
+# CLI FLAGS IN A REAL RUN
+# =============================================================================
+
+@test "E2E: --calls and --no-continue take effect in a full run" {
+    # Pre-seed a stored session that --no-continue must ignore
+    echo "e2e-stale-session" > .ralph/.claude_session_id
+
+    e2e_fix_plan 1 0
+    queue_response 1 "IN_PROGRESS" "false" "Completed the only open task."
+    queue_productive_effect 1
+
+    run run_ralph --calls 7 --no-continue
+
+    assert_success
+    assert_equal "$(status_field max_calls_per_hour)" "7"
+    # --no-continue: the stored session must NOT be resumed
+    ! grep -qx -- "--resume" "$MOCK_DIR/calls/argv_1.log"
+}
+
+# =============================================================================
+# API LIMIT HANDLING
+# =============================================================================
+
+@test "E2E: API 5-hour limit response with user exit choice stops the loop" {
+    queue_raw_response 1 1 << 'EOF'
+You've reached your 5-hour usage limit for Claude.
+Please try again later when your limit resets.
+EOF
+
+    # Feed "2" (exit) to the interactive limit prompt
+    run bash -c "printf '2' | timeout --foreground -k 5 120 bash '$RALPH_SCRIPT'"
+
+    assert_success
+    assert_equal "$(mock_call_count)" "1"
+    assert_equal "$(status_field last_action)" "api_limit_exit"
+    assert_equal "$(status_field status)" "stopped"
+    assert_equal "$(status_field exit_reason)" "api_5hour_limit"
+}
+
+# =============================================================================
+# INTERRUPTION (signal → cleanup trap)
+# =============================================================================
+
+# Note: SIGTERM is used because background jobs started by a non-interactive
+# shell (bats) have SIGINT set to SIG_IGN, which bash cannot trap. A terminal
+# Ctrl-C (SIGINT) runs the exact same cleanup() handler.
+@test "E2E: termination signal during execution records interrupted status and preserves call count" {
+    # Mock sleeps long enough for us to interrupt mid-execution
+    echo "60" > "$MOCK_DIR/responses/1.sleep"
+
+    bash "$RALPH_SCRIPT" > "$E2E_DIR/ralph_run.log" 2>&1 < /dev/null &
+    local ralph_pid=$!
+
+    # Wait until loop 1 is executing (call counter incremented)
+    local waited=0
+    while [[ "$(mock_call_count)" == "0" && $waited -lt 200 ]]; do
+        sleep 0.1
+        waited=$((waited + 1))
+    done
+    assert_equal "$(mock_call_count)" "1"
+
+    # Signal ralph. Bash defers the trap until its current foreground command
+    # (the progress-monitor `sleep`) completes, so also signal ralph's sleep
+    # children — exactly what a terminal Ctrl-C does to the foreground process
+    # group. The mock claude keeps sleeping, which holds the loop in its
+    # monitor phase and keeps the interrupted status stable for assertion.
+    kill -TERM "$ralph_pid"
+    local i
+    for i in $(seq 1 100); do
+        pkill -TERM -P "$ralph_pid" -x sleep 2>/dev/null || true
+        if jq -e '.last_action == "interrupted"' .ralph/status.json >/dev/null 2>&1; then
+            break
+        fi
+        sleep 0.2
+    done
+
+    # cleanup() writes last_action="interrupted", status="stopped"
+    assert_equal "$(status_field last_action)" "interrupted"
+    assert_equal "$(status_field status)" "stopped"
+    # Call counter preserved across interruption
+    assert_equal "$(cat .ralph/.call_count)" "1"
+
+    kill -KILL "$ralph_pid" 2>/dev/null || true
+    wait "$ralph_pid" 2>/dev/null || true
+}


### PR DESCRIPTION
## Summary
Implements #17: [P3] Phase 4.7: Implement E2E full loop tests

- New `tests/e2e/test_full_loop.bats` (**13 tests**) — the first tests to run `ralph_loop.sh` as a **true subprocess** end-to-end, rather than sourcing functions
- New E2E harness `tests/e2e/helpers/e2e_helper.bash`: installs a real executable mock `claude` CLI on PATH (answers `--version`, logs per-call argv, replays scripted JSON responses with RALPH_STATUS blocks, runs scripted side effects like creating files / checking off fix_plan items), and builds a complete temp Ralph project (`.ralph/`, `.ralphrc`, git repo)
- CI: removed `|| true` from the E2E step in `test.yml` (failures no longer masked) and added `timeout-minutes: 15`
- Docs: CLAUDE.md test table + commands, TESTING.md structure/CI sections

### Scenarios covered
Startup validation failures (missing PROMPT.md / .ralphrc), `plan_complete` with zero API calls, multi-loop fix_plan progression, completion-signal graceful exit, test saturation, circuit-breaker halt, stale exit-signal reset (#194), session continuity proven via `--resume` in loop-2 argv, hourly counter reset, `--calls`/`--no-continue` in a real run, API 5-hour-limit exit via user choice, and termination-signal cleanup (status preserved).

## Acceptance Criteria
- [x] E2E directory created (`tests/e2e/`)
- [x] All end-to-end scenarios tested (13 tests vs ~10 requested; see deviations)
- [x] Mock Claude Code behavior (executable PATH mock with argv logging + scripted responses/effects)
- [x] Tests pass in CI/CD pipeline (`|| true` removed; verified locally 3× consecutive 13/13)
- [x] Integration with existing test helpers (loads `tests/helpers/test_helper.bash`)

## Test Plan
- [x] TDD: tests written first, iterated against real subprocess behavior
- [x] All tests passing: 771 existing unit+integration + 13 new E2E (3 consecutive clean E2E runs — no flakiness)
- [x] Diff coverage gate: N/A — no production code changed (test/CI/docs only; kcov cannot trace bats subprocesses per project policy, pass rate is the quality gate)
- [x] Linting: N/A — repo defines no lint tooling for bash/bats
- [x] Internal code review (advisory): 1 Major fixed (CI `timeout-minutes`), 2 suggestions triaged
- [x] Cross-family review pass: **codex** — 2 P2 portability findings, both fixed (GNU-only `timeout` flags → timeout/gtimeout detection; GNU-only `sed -i '0,…'` → portable awk)
- [x] Mutation sanity check: 2 mutations (done-signals exit threshold; hourly counter reset) — both caught by the new tests

## Known Limitations / Intentionally Deferred
- **Dropped from the original Traycer plan** (already covered elsewhere): tmux E2E (`test_tmux_integration.bats`), concurrent ralph-monitor E2E (`test_monitor.bats`), sourced-function circuit-breaker/response-analysis tests (`test_loop_execution.bats`, `test_circuit_breaker_recovery.bats`)
- **Full rate-limit wait cycle not E2E-tested**: `wait_for_reset` blocks until the top of the wall-clock hour — untestable without hanging CI; the hourly-reset code path (`init_call_tracking`) is covered instead, and `wait_for_reset` has unit coverage
- **Interrupt test uses SIGTERM, not SIGINT**: background jobs of non-interactive shells get `SIGINT=SIG_IGN` (POSIX), which bash cannot trap; a terminal Ctrl-C runs the identical `cleanup()` handler
- **Latent quirks documented, not changed** (behavior asserted as-is; candidates for follow-up issues):
  - ralph's early-failure detection treats *any* sub-second claude exit as a startup failure, even exit 0 (harness mock therefore takes ≥1.5s per call)
  - ralph traps SIGTERM without exiting, so a bare `timeout` against ralph waits forever (harness uses `timeout -k`)
  - circuit-breaker halt exits the script with code 0
- **E2E suite runtime ~4 min** (dominated by ralph's fixed `sleep 1`/`sleep 10`/`sleep 5` cadence per loop); bounded by per-test 120s timeouts + CI step `timeout-minutes: 15`

## Implementation Notes
The original implementation plan (Traycer, Jan 2026) predated the `.ralph/` migration and proposed extending in-process function mocks — those cannot cross a subprocess boundary, so the harness installs a real executable mock instead, which is what makes these tests genuinely end-to-end.

Closes #17

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive end-to-end test suite covering the complete application lifecycle
  * E2E tests now required to pass in CI pipeline

* **Documentation**
  * Updated testing documentation with new test suite details and execution instructions

* **Chores**
  * Enhanced CI pipeline with timeout protection for test execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->