### PR TITLE
ci(workflows): pin GitHub Actions to commit SHAs (#275)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# Keep SHA-pinned GitHub Actions up to date (Issue #275)
+# Dependabot resolves pinned SHAs and maintains the `# vX.Y.Z` tag comments.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -48,7 +48,7 @@ jobs:
         if: |
           github.event.pull_request.changed_files >= 5 ||
           steps.calc.outputs.total >= 20
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           # Checkout the PR head commit (pull_request_target defaults to base branch)
           ref: ${{ github.event.pull_request.head.sha }}
@@ -60,7 +60,7 @@ jobs:
           github.event.pull_request.changed_files >= 5 ||
           steps.calc.outputs.total >= 20
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@64de744025ca9e24df2b88204b4f1e968f39f009 # v1.0.139
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # Explicit github_token needed for pull_request_target (OIDC doesn't work)

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -31,13 +31,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@64de744025ca9e24df2b88204b4f1e968f39f009 # v1.0.139
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,10 +27,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
     - name: Setup Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
       with:
         node-version: '18'
 
@@ -63,10 +63,10 @@ jobs:
     needs: test
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
     - name: Setup Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
       with:
         node-version: '18'
 
@@ -185,7 +185,7 @@ jobs:
         fi
 
     - name: Upload coverage artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       if: always()
       with:
         name: coverage-report
@@ -193,7 +193,7 @@ jobs:
         retention-days: 7
 
     - name: Upload coverage to Codecov (optional)
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       if: always()
       continue-on-error: true
       with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,6 +242,7 @@ Tests use bats, organized under `tests/unit/`, `tests/integration/`, and `tests/
 GitHub Actions (`.github/workflows/`):
 - **test.yml** — unit, integration, E2E on push to `main`/`develop` and PRs to `main`; unit and E2E suites are blocking, integration is currently advisory (`|| true`); kcov coverage uploaded as informational artifact
 - **claude.yml** / **claude-code-review.yml** — Claude Code GitHub Actions integration and automated PR review
+- **Supply-chain hardening (Issue #275)**: all external actions in the hand-maintained workflows are pinned to full commit SHAs with `# vX.Y.Z` tag comments; `.github/dependabot.yml` (github-actions ecosystem, weekly, grouped) keeps pins updated; `tests/unit/test_workflow_sha_pinning.bats` is the regression guard. When adding an action, pin its SHA (resolve via `gh api repos/<owner>/<repo>/git/ref/tags/<tag>`, dereference annotated tags) — the guard fails on mutable tags
 
 ## Ralph-Managed Project Structure
 

--- a/tests/unit/test_workflow_sha_pinning.bats
+++ b/tests/unit/test_workflow_sha_pinning.bats
@@ -1,0 +1,66 @@
+#!/usr/bin/env bats
+# Unit Tests for GitHub Actions SHA Pinning (Issue #275)
+#
+# Supply-chain hardening: every external action in the hand-maintained
+# workflows must be pinned to a full 40-char commit SHA with a version tag
+# comment (e.g. `uses: actions/checkout@<sha> # v4.3.1`), not a mutable tag.
+# Generated workflows (gh-aw *.lock.yml) are excluded — they are pinned by
+# their generator.
+
+load '../helpers/test_helper'
+
+WORKFLOWS_DIR="$BATS_TEST_DIRNAME/../../.github/workflows"
+PINNED_WORKFLOWS=(test.yml claude.yml claude-code-review.yml)
+
+# Extract all `uses:` lines referencing external actions (owner/repo@ref).
+# Skips local actions (./) and docker:// references, which have no SHA to pin.
+extract_uses_lines() {
+    grep -hE '^\s*-?\s*uses:\s*[^./]' "$1" | grep -v 'docker://' || true
+}
+
+@test "workflow files under test exist" {
+    for wf in "${PINNED_WORKFLOWS[@]}"; do
+        [ -f "$WORKFLOWS_DIR/$wf" ] || fail "missing workflow: $wf"
+    done
+}
+
+@test "all external actions are pinned to 40-char commit SHAs" {
+    local violations=""
+    for wf in "${PINNED_WORKFLOWS[@]}"; do
+        while IFS= read -r line; do
+            [ -z "$line" ] && continue
+            if ! echo "$line" | grep -qE 'uses:\s*[A-Za-z0-9_.-]+/[A-Za-z0-9_./-]+@[0-9a-f]{40}\b'; then
+                violations+="$wf: $line"$'\n'
+            fi
+        done < <(extract_uses_lines "$WORKFLOWS_DIR/$wf")
+    done
+    if [ -n "$violations" ]; then
+        echo "Actions not pinned to a full commit SHA:"
+        echo "$violations"
+        return 1
+    fi
+}
+
+@test "all SHA-pinned actions carry a version tag comment" {
+    local violations=""
+    for wf in "${PINNED_WORKFLOWS[@]}"; do
+        while IFS= read -r line; do
+            [ -z "$line" ] && continue
+            if ! echo "$line" | grep -qE '@[0-9a-f]{40}\s*#\s*v[0-9]'; then
+                violations+="$wf: $line"$'\n'
+            fi
+        done < <(extract_uses_lines "$WORKFLOWS_DIR/$wf")
+    done
+    if [ -n "$violations" ]; then
+        echo "SHA-pinned actions missing a '# vX[.Y.Z]' tag comment:"
+        echo "$violations"
+        return 1
+    fi
+}
+
+@test "dependabot config keeps pinned actions updated" {
+    local config="$BATS_TEST_DIRNAME/../../.github/dependabot.yml"
+    [ -f "$config" ] || fail "missing .github/dependabot.yml"
+    grep -q 'package-ecosystem:\s*"\?github-actions"\?' "$config" || \
+        fail "dependabot.yml does not cover the github-actions ecosystem"
+}

--- a/tests/unit/test_workflow_sha_pinning.bats
+++ b/tests/unit/test_workflow_sha_pinning.bats
@@ -14,8 +14,9 @@ PINNED_WORKFLOWS=(test.yml claude.yml claude-code-review.yml)
 
 # Extract all `uses:` lines referencing external actions (owner/repo@ref).
 # Skips local actions (./) and docker:// references, which have no SHA to pin.
+# POSIX character classes only — BSD grep (macOS) has no \s/\b in ERE.
 extract_uses_lines() {
-    grep -hE '^\s*-?\s*uses:\s*[^./]' "$1" | grep -v 'docker://' || true
+    grep -hE '^[[:space:]]*-?[[:space:]]*uses:[[:space:]]*[^./]' "$1" | grep -v 'docker://' || true
 }
 
 @test "workflow files under test exist" {
@@ -29,7 +30,7 @@ extract_uses_lines() {
     for wf in "${PINNED_WORKFLOWS[@]}"; do
         while IFS= read -r line; do
             [ -z "$line" ] && continue
-            if ! echo "$line" | grep -qE 'uses:\s*[A-Za-z0-9_.-]+/[A-Za-z0-9_./-]+@[0-9a-f]{40}\b'; then
+            if ! echo "$line" | grep -qE 'uses:[[:space:]]*[A-Za-z0-9_.-]+/[A-Za-z0-9_./-]+@[0-9a-f]{40}([^0-9a-f]|$)'; then
                 violations+="$wf: $line"$'\n'
             fi
         done < <(extract_uses_lines "$WORKFLOWS_DIR/$wf")
@@ -46,7 +47,7 @@ extract_uses_lines() {
     for wf in "${PINNED_WORKFLOWS[@]}"; do
         while IFS= read -r line; do
             [ -z "$line" ] && continue
-            if ! echo "$line" | grep -qE '@[0-9a-f]{40}\s*#\s*v[0-9]'; then
+            if ! echo "$line" | grep -qE '@[0-9a-f]{40}[[:space:]]*#[[:space:]]*v[0-9]'; then
                 violations+="$wf: $line"$'\n'
             fi
         done < <(extract_uses_lines "$WORKFLOWS_DIR/$wf")
@@ -61,6 +62,6 @@ extract_uses_lines() {
 @test "dependabot config keeps pinned actions updated" {
     local config="$BATS_TEST_DIRNAME/../../.github/dependabot.yml"
     [ -f "$config" ] || fail "missing .github/dependabot.yml"
-    grep -q 'package-ecosystem:\s*"\?github-actions"\?' "$config" || \
+    grep -qE 'package-ecosystem:[[:space:]]*"?github-actions"?' "$config" || \
         fail "dependabot.yml does not cover the github-actions ecosystem"
 }


### PR DESCRIPTION
## Summary

Supply-chain hardening (closes #275, raised by CodeRabbit and claude-review on PR #274): mutable version tags in `uses:` entries can be retargeted by a compromised upstream; full commit SHAs cannot.

- **Pin all external actions** in `test.yml`, `claude.yml`, `claude-code-review.yml` to verified 40-char commit SHAs with version tag comments. Same major versions as before — no behavior change:
  | Action | SHA | Tag |
  |---|---|---|
  | actions/checkout@v3 | `f43a0e5f` | v3.6.0 |
  | actions/checkout@v4 | `34e11487` | v4.3.1 |
  | actions/setup-node@v3 | `3235b876` | v3.9.1 |
  | actions/upload-artifact@v4 | `ea165f8d` | v4.6.2 |
  | codecov/codecov-action@v4 | `b9fd7d16` | v4.6.0 |
  | anthropics/claude-code-action@v1 | `64de7440` | v1.0.139 |

  All SHAs resolved live from the official repos via `gh api` and verified to match the exact semver tags above.
- **Add `.github/dependabot.yml`** (github-actions ecosystem, weekly, grouped) so pinned SHAs stay updated — Dependabot natively maintains SHA pins and their `# vX.Y.Z` comments
- **Add regression guard** `tests/unit/test_workflow_sha_pinning.bats` (4 tests, TDD red→green): every `uses:` must be SHA-pinned with a tag comment; dependabot config must cover github-actions. POSIX character classes only (BSD grep compatible)

`triage-incoming-issues.lock.yml` is gh-aw-generated and already SHA-pinned — excluded.

## Test plan
- [x] New guard fails against mutable tags (RED verified) and passes after pinning
- [x] Mutation check: reverting one pin in a temp copy is caught by the guard regex
- [x] Full suites green: 636 unit + 213 integration + 13 E2E, 0 failures
- [x] YAML validity of all 4 modified/added files verified
- [x] Codex cross-family review: BSD grep portability finding fixed in `deb6e0e`

## Known Limitations
- Pins stay at current major versions (checkout/setup-node v3 in `test.yml`); Dependabot will propose upgrades separately
- The guard only covers the 3 hand-maintained workflows; generated workflows are the generator's responsibility

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Hardened CI workflows by pinning external action dependencies to fixed commits and enabled Dependabot to keep those pins updated.

* **Tests**
  * Added automated checks that verify external workflow actions are pinned and annotated for version tracking.

* **Documentation**
  * Added guidance on supply-chain hardening and the new workflow safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->