### PR TITLE
ci(workflows): set persist-credentials: false on all checkout steps (#282)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -53,6 +53,9 @@ jobs:
           # Checkout the PR head commit (pull_request_target defaults to base branch)
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
+          # Review is read-only; gh commands use GH_TOKEN, not git credentials.
+          # Especially important under pull_request_target with PR-head code (#282)
+          persist-credentials: false
 
       - name: Run Claude Code Review
         # Only review substantial changes (5+ files OR 20+ lines changed)

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,6 +34,9 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
+          # claude-code-action strips checkout's auth header (configureGitAuth)
+          # and uses its own GitHub App token for git operations (#282)
+          persist-credentials: false
 
       - name: Run Claude Code
         id: claude

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      with:
+        # Test jobs never push — don't persist GITHUB_TOKEN in git config (#282)
+        persist-credentials: false
 
     - name: Setup Node.js
       uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
@@ -64,6 +67,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      with:
+        # Test jobs never push — don't persist GITHUB_TOKEN in git config (#282)
+        persist-credentials: false
 
     - name: Setup Node.js
       uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,6 +243,7 @@ GitHub Actions (`.github/workflows/`):
 - **test.yml** — unit, integration, E2E on push to `main`/`develop` and PRs to `main`; unit and E2E suites are blocking, integration is currently advisory (`|| true`); kcov coverage uploaded as informational artifact
 - **claude.yml** / **claude-code-review.yml** — Claude Code GitHub Actions integration and automated PR review
 - **Supply-chain hardening (Issue #275)**: all external actions in the hand-maintained workflows are pinned to full commit SHAs with `# vX.Y.Z` tag comments; `.github/dependabot.yml` (github-actions ecosystem, weekly, grouped) keeps pins updated; `tests/unit/test_workflow_sha_pinning.bats` is the regression guard. When adding an action, pin its SHA (resolve via `gh api repos/<owner>/<repo>/git/ref/tags/<tag>`, dereference annotated tags) — the guard fails on mutable tags
+- **Credential hygiene (Issue #282)**: every `actions/checkout` step sets `persist-credentials: false` (guard: `tests/unit/test_workflow_credential_hygiene.bats`). Safe even for the claude workflows — claude-code-action strips checkout's auth header (`configureGitAuth`) and uses its own GitHub App token for git operations
 
 ## Ralph-Managed Project Structure
 

--- a/tests/unit/test_workflow_credential_hygiene.bats
+++ b/tests/unit/test_workflow_credential_hygiene.bats
@@ -1,0 +1,36 @@
+#!/usr/bin/env bats
+# Unit Tests for Workflow Credential Hygiene (Issue #282)
+#
+# Least-privilege hardening: every actions/checkout step in the hand-maintained
+# workflows must set `persist-credentials: false`. None of these workflows rely
+# on checkout's persisted GITHUB_TOKEN — the test jobs never push, and
+# claude-code-action strips checkout's auth header (configureGitAuth) and uses
+# its own GitHub App token for git operations.
+# POSIX character classes only — BSD grep (macOS) has no \s in ERE.
+
+load '../helpers/test_helper'
+
+WORKFLOWS_DIR="$BATS_TEST_DIRNAME/../../.github/workflows"
+HARDENED_WORKFLOWS=(test.yml claude.yml claude-code-review.yml)
+
+@test "every checkout step disables credential persistence" {
+    local violations=""
+    for wf in "${HARDENED_WORKFLOWS[@]}"; do
+        local file="$WORKFLOWS_DIR/$wf"
+        [ -f "$file" ] || { violations+="$wf: missing file"$'\n'; continue; }
+        local checkouts persists
+        # grep -c exits 1 on zero matches but still prints "0" — keep the count
+        checkouts=$(grep -cE 'uses:[[:space:]]*actions/checkout@' "$file" || true)
+        persists=$(grep -cE 'persist-credentials:[[:space:]]*false' "$file" || true)
+        if [ "$checkouts" -eq 0 ]; then
+            violations+="$wf: no checkout steps found (guard expects at least one)"$'\n'
+        elif [ "$persists" -ne "$checkouts" ]; then
+            violations+="$wf: $checkouts checkout step(s) but only $persists persist-credentials: false"$'\n'
+        fi
+    done
+    if [ -n "$violations" ]; then
+        echo "Checkout steps persisting credentials:"
+        echo "$violations"
+        return 1
+    fi
+}

--- a/tests/unit/test_workflow_credential_hygiene.bats
+++ b/tests/unit/test_workflow_credential_hygiene.bats
@@ -13,19 +13,39 @@ load '../helpers/test_helper'
 WORKFLOWS_DIR="$BATS_TEST_DIRNAME/../../.github/workflows"
 HARDENED_WORKFLOWS=(test.yml claude.yml claude-code-review.yml)
 
-@test "every checkout step disables credential persistence" {
+# Count checkout steps lacking persist-credentials: false WITHIN their own
+# step block (from the checkout `uses:` line to the next `- ` list item).
+# Per-block matching — a stray persist-credentials elsewhere in the file
+# cannot mask an unhardened checkout. Also prints total checkout count.
+unhardened_checkouts() {
+    awk '
+        /uses:[[:space:]]*actions\/checkout@/ {
+            if (inblock && !found) bad++
+            inblock = 1; found = 0; total++; next
+        }
+        inblock && /^[[:space:]]*-[[:space:]]/ {       # next step begins
+            if (!found) bad++
+            inblock = 0
+        }
+        inblock && /persist-credentials:[[:space:]]*false/ { found = 1 }
+        END {
+            if (inblock && !found) bad++
+            print total, bad+0
+        }
+    ' "$1"
+}
+
+@test "every checkout step disables credential persistence in its own block" {
     local violations=""
     for wf in "${HARDENED_WORKFLOWS[@]}"; do
         local file="$WORKFLOWS_DIR/$wf"
         [ -f "$file" ] || { violations+="$wf: missing file"$'\n'; continue; }
-        local checkouts persists
-        # grep -c exits 1 on zero matches but still prints "0" — keep the count
-        checkouts=$(grep -cE 'uses:[[:space:]]*actions/checkout@' "$file" || true)
-        persists=$(grep -cE 'persist-credentials:[[:space:]]*false' "$file" || true)
-        if [ "$checkouts" -eq 0 ]; then
+        local total bad
+        read -r total bad < <(unhardened_checkouts "$file")
+        if [ "$total" -eq 0 ]; then
             violations+="$wf: no checkout steps found (guard expects at least one)"$'\n'
-        elif [ "$persists" -ne "$checkouts" ]; then
-            violations+="$wf: $checkouts checkout step(s) but only $persists persist-credentials: false"$'\n'
+        elif [ "$bad" -ne 0 ]; then
+            violations+="$wf: $bad of $total checkout step(s) missing persist-credentials: false"$'\n'
         fi
     done
     if [ -n "$violations" ]; then

--- a/tests/unit/test_workflow_credential_hygiene.bats
+++ b/tests/unit/test_workflow_credential_hygiene.bats
@@ -27,7 +27,9 @@ unhardened_checkouts() {
             if (!found) bad++
             inblock = 0
         }
-        inblock && /persist-credentials:[[:space:]]*false/ { found = 1 }
+        # Anchored to the actual key line (optional trailing inline comment) —
+        # a commented-out "# persist-credentials: false" must not count
+        inblock && /^[[:space:]]*persist-credentials:[[:space:]]*false([[:space:]]*(#.*)?)?$/ { found = 1 }
         END {
             if (inblock && !found) bad++
             print total, bad+0


### PR DESCRIPTION
## Summary

Least-privilege hardening (closes #282, deferred from PR #281): `actions/checkout` persists the GITHUB_TOKEN into the local git config by default; none of the hand-maintained workflows use it afterwards.

- **`test.yml`** (both jobs): test/coverage jobs never push — credential persistence is pure attack surface
- **`claude.yml` + `claude-code-review.yml`**: verified safe via claude-code-action source — `configureGitAuth` ([src/github/operations/git-config.ts](https://github.com/anthropics/claude-code-action/blob/main/src/github/operations/git-config.ts)) explicitly runs `git config --unset-all http.<server>/.extraheader` (removing checkout's persisted auth) and configures its own GitHub App token for git operations. The action never relies on checkout's credentials, including for pushes. Especially relevant for `claude-code-review.yml`, which checks out PR-head code under `pull_request_target`
- **Regression guard** `tests/unit/test_workflow_credential_hygiene.bats`: per-block awk matching — every checkout step must carry `persist-credentials: false` within its own step block, so a stray mention elsewhere can't mask an unhardened checkout
- **CLAUDE.md**: credential-hygiene policy documented in the CI/CD section

## Test plan
- [x] Guard fails RED against unhardened checkouts (all 4 reported), GREEN after hardening
- [x] Mutation A: removing one `persist-credentials` line → caught
- [x] Mutation B (count-bypass): removing a line while adding a stray mention elsewhere → caught
- [x] Full unit suite green (637 tests, 0 failures); prior SHA-pinning guard unaffected
- [x] YAML validity verified
- [x] Codex cross-family review: per-block guard hardening applied in `9f0a3bf`

## Known Limitations
- `claude.yml` / `claude-code-review.yml` execute from the default branch (issue events / `pull_request_target`), so their changed behavior cannot be exercised by this PR's CI; safety is established from the action's source (link above). `claude-code-review.yml` also has `paths-ignore: .github/**`, so it skips this PR entirely
- The PR's own green `test` job IS the outcome evidence for `test.yml` — pull_request runs use the PR's version of the workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI workflow security by ensuring checkout steps do not persist runner credentials.

* **Tests**
  * Added an automated test that verifies checkout steps across workflows enforce credential isolation.

* **Documentation**
  * Updated guidance and notes to document credential-hygiene requirements for CI workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->