### PR TITLE
test(e2e): fix hour-boundary flake in full-loop call-count assertions (#285)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,7 +234,7 @@ Multi-layered defense against Claude deleting Ralph's own config:
 Tests use bats, organized under `tests/unit/`, `tests/integration/`, and `tests/e2e/` (helpers in `tests/helpers/`). Run via `npm test` (all), `npm run test:unit` / `test:integration` / `test:e2e`, or `bats <file>` for one file. `npm test` reports the current count.
 
 - File naming maps to subject: e.g. `test_circuit_breaker_recovery.bats`, `test_cli_modern.bats`, `test_exit_detection.bats`, `test_enable_core.bats` — add tests to the file matching the component you changed
-- `tests/e2e/test_full_loop.bats` runs ralph_loop.sh as a real subprocess with an executable mock `claude` CLI (`tests/e2e/helpers/e2e_helper.bash`). The mock must take >1s per call — ralph's early-failure detection treats sub-second exits as startup failures
+- `tests/e2e/test_full_loop.bats` runs ralph_loop.sh as a real subprocess with an executable mock `claude` CLI (`tests/e2e/helpers/e2e_helper.bash`). The mock must take >1s per call — ralph's early-failure detection treats sub-second exits as startup failures. Raw `.ralph/.call_count` assertions go through `assert_call_count`, which skips only when the run itself crossed an hour boundary (the hourly rate-limit reset legitimately zeroes the counter — Issue #285); `mock_call_count` stays the unconditional invocation proof
 - **Test pass rate (100%) is the quality gate.** Coverage measurement with kcov is informational only (`COVERAGE_THRESHOLD=0`): kcov cannot instrument subprocesses spawned by bats (see [bats-core#15](https://github.com/bats-core/bats-core/issues/15))
 
 ## CI/CD Pipeline

--- a/tests/e2e/helpers/e2e_helper.bash
+++ b/tests/e2e/helpers/e2e_helper.bash
@@ -273,6 +273,8 @@ e2e_hour_rolled_over() {
     if [[ -f "$E2E_DIR/.run_end_hour" ]]; then
         end_hour=$(cat "$E2E_DIR/.run_end_hour")
     else
+        # Only reachable when the caller omitted e2e_mark_run_end (run_ralph
+        # always records it) — degrades to assertion-time comparison.
         end_hour=$(date +%Y%m%d%H)
     fi
     [[ -n "$start_hour" && "$start_hour" != "$end_hour" ]]

--- a/tests/e2e/helpers/e2e_helper.bash
+++ b/tests/e2e/helpers/e2e_helper.bash
@@ -239,11 +239,45 @@ e2e_fix_plan() {
     } > .ralph/fix_plan.md
 }
 
+# Record the hour a ralph run started (Issue #285). File-based so the marker
+# survives the subshell that bats `run` executes run_ralph in. Tests that
+# invoke ralph_loop.sh directly (not via run_ralph) must call this themselves.
+e2e_mark_run_start() {
+    date +%Y%m%d%H > "$E2E_DIR/.run_start_hour"
+}
+
+# True if the clock crossed an hour boundary since e2e_mark_run_start.
+# init_call_tracking runs at the top of every loop iteration and zeroes
+# .ralph/.call_count when the hour changes (the designed hourly rate-limit
+# reset), so raw counter values are only assertable when this is false.
+e2e_hour_rolled_over() {
+    local start_hour=""
+    if [[ -f "$E2E_DIR/.run_start_hour" ]]; then
+        start_hour=$(cat "$E2E_DIR/.run_start_hour")
+    fi
+    [[ -n "$start_hour" && "$start_hour" != "$(date +%Y%m%d%H)" ]]
+}
+
+# Assert the raw .ralph/.call_count value — unless the run crossed an hour
+# boundary, in which case the hourly reset legitimately zeroed it (Issue #285)
+# and the check is skipped. mock_call_count remains the unconditional proof of
+# how many times the CLI was invoked.
+# Usage: assert_call_count EXPECTED
+assert_call_count() {
+    local expected=$1
+    if e2e_hour_rolled_over; then
+        echo "# raw .call_count assertion skipped: run crossed an hour boundary (Issue #285)"
+        return 0
+    fi
+    assert_equal "$(cat .ralph/.call_count)" "$expected"
+}
+
 # Run ralph_loop.sh as a subprocess under a hard timeout (never hang CI).
 # -k is required: ralph traps SIGTERM (cleanup handler) without exiting, so
 # a plain `timeout` would deliver TERM and then wait forever.
 # Usage: run_ralph [args...]   — use with bats `run`
 run_ralph() {
+    e2e_mark_run_start
     "$E2E_TIMEOUT_CMD" --foreground -k 5 120 bash "$RALPH_SCRIPT" "$@" < /dev/null
 }
 

--- a/tests/e2e/helpers/e2e_helper.bash
+++ b/tests/e2e/helpers/e2e_helper.bash
@@ -26,14 +26,21 @@ RALPH_SCRIPT="${BATS_TEST_DIRNAME}/../../ralph_loop.sh"
 # invokes the binary directly rather than through portable_timeout() because
 # it needs the --foreground/-k flags, which that wrapper does not pass through.
 source "${BATS_TEST_DIRNAME}/../../lib/timeout_utils.sh"
+# Soft-fail at load: unit tests of the assertion helpers (test_e2e_helper.bats)
+# don't need a timeout binary, so missing coreutils must not abort the whole
+# suite at source time. setup_e2e_project enforces the hard requirement.
 if ! E2E_TIMEOUT_CMD="$(detect_timeout_command)"; then
-    echo "FATAL: E2E tests require GNU timeout (brew install coreutils on macOS)" >&2
-    exit 1
+    E2E_TIMEOUT_CMD=""
 fi
 
 # Create a complete temp Ralph project + mock claude CLI, and cd into it.
 # Sets: E2E_DIR, MOCK_DIR, PROJECT_DIR
 setup_e2e_project() {
+    if [[ -z "$E2E_TIMEOUT_CMD" ]]; then
+        echo "FATAL: E2E tests require GNU timeout (brew install coreutils on macOS)" >&2
+        return 1
+    fi
+
     E2E_DIR="$(mktemp -d)"
     MOCK_DIR="$E2E_DIR/mock"
     PROJECT_DIR="$E2E_DIR/project"
@@ -239,14 +246,21 @@ e2e_fix_plan() {
     } > .ralph/fix_plan.md
 }
 
-# Record the hour a ralph run started (Issue #285). File-based so the marker
-# survives the subshell that bats `run` executes run_ralph in. Tests that
-# invoke ralph_loop.sh directly (not via run_ralph) must call this themselves.
+# Record the hour a ralph run started / ended (Issue #285). File-based so the
+# markers survive the subshell that bats `run` executes run_ralph in. Tests
+# that invoke ralph_loop.sh directly (not via run_ralph) must call both
+# themselves — e2e_mark_run_end as soon as the run is over, BEFORE asserting,
+# so a boundary crossed while waiting to assert doesn't suppress the check.
 e2e_mark_run_start() {
     date +%Y%m%d%H > "$E2E_DIR/.run_start_hour"
 }
 
-# True if the clock crossed an hour boundary since e2e_mark_run_start.
+e2e_mark_run_end() {
+    date +%Y%m%d%H > "$E2E_DIR/.run_end_hour"
+}
+
+# True if the clock crossed an hour boundary DURING the run (start marker vs
+# end marker; falls back to the current hour when no end was recorded).
 # init_call_tracking runs at the top of every loop iteration and zeroes
 # .ralph/.call_count when the hour changes (the designed hourly rate-limit
 # reset), so raw counter values are only assertable when this is false.
@@ -255,7 +269,13 @@ e2e_hour_rolled_over() {
     if [[ -f "$E2E_DIR/.run_start_hour" ]]; then
         start_hour=$(cat "$E2E_DIR/.run_start_hour")
     fi
-    [[ -n "$start_hour" && "$start_hour" != "$(date +%Y%m%d%H)" ]]
+    local end_hour
+    if [[ -f "$E2E_DIR/.run_end_hour" ]]; then
+        end_hour=$(cat "$E2E_DIR/.run_end_hour")
+    else
+        end_hour=$(date +%Y%m%d%H)
+    fi
+    [[ -n "$start_hour" && "$start_hour" != "$end_hour" ]]
 }
 
 # Assert the raw .ralph/.call_count value — unless the run crossed an hour
@@ -278,7 +298,10 @@ assert_call_count() {
 # Usage: run_ralph [args...]   — use with bats `run`
 run_ralph() {
     e2e_mark_run_start
-    "$E2E_TIMEOUT_CMD" --foreground -k 5 120 bash "$RALPH_SCRIPT" "$@" < /dev/null
+    local rc=0
+    "$E2E_TIMEOUT_CMD" --foreground -k 5 120 bash "$RALPH_SCRIPT" "$@" < /dev/null || rc=$?
+    e2e_mark_run_end
+    return $rc
 }
 
 # Number of times the mock claude was invoked.

--- a/tests/e2e/test_full_loop.bats
+++ b/tests/e2e/test_full_loop.bats
@@ -316,6 +316,10 @@ EOF
         fi
         sleep 0.2
     done
+    # The run is effectively over once cleanup() has written its status; mark
+    # the end now so an hour boundary crossed during the assertions below
+    # cannot suppress the call-count check (Issue #285)
+    e2e_mark_run_end
 
     # cleanup() writes last_action="interrupted", status="stopped"
     assert_equal "$(status_field last_action)" "interrupted"

--- a/tests/e2e/test_full_loop.bats
+++ b/tests/e2e/test_full_loop.bats
@@ -82,7 +82,7 @@ teardown() {
     [[ "$output" == *"Analyzing Claude Code response"* ]]
     # Graceful exit resets the session (which clears .response_analysis)
     assert_equal "$(jq -r '.reset_reason' .ralph/.ralph_session)" "project_complete"
-    assert_equal "$(cat .ralph/.call_count)" "2"
+    assert_call_count 2
     local output_log_count
     output_log_count=$(ls .ralph/logs/claude_output_*.log 2>/dev/null | wc -l)
     [[ $output_log_count -ge 2 ]] || fail "Expected >= 2 output logs, found $output_log_count"
@@ -103,7 +103,7 @@ teardown() {
     assert_equal "$(status_field exit_reason)" "plan_complete"
     # Loop counter advanced past the three working iterations
     assert_equal "$(status_field loop_count)" "4"
-    assert_equal "$(cat .ralph/.call_count)" "3"
+    assert_call_count 3
     # Each loop produced its own output log
     [[ $(ls .ralph/logs/claude_output_*.log | wc -l) -eq 3 ]]
     # All work landed
@@ -224,9 +224,11 @@ EOF
     run run_ralph
 
     assert_success
-    # Counter was reset for the new hour, then incremented once — not 100
-    assert_equal "$(cat .ralph/.call_count)" "1"
-    assert_equal "$(cat .ralph/.last_reset)" "$(date +%Y%m%d%H)"
+    # Counter was reset for the new hour, then incremented once — not 100.
+    # Raw values are only assertable when the run itself didn't cross an
+    # hour boundary (Issue #285).
+    assert_call_count 1
+    e2e_hour_rolled_over || assert_equal "$(cat .ralph/.last_reset)" "$(date +%Y%m%d%H)"
     assert_equal "$(status_field exit_reason)" "plan_complete"
 }
 
@@ -281,6 +283,9 @@ EOF
     # Mock sleeps long enough for us to interrupt mid-execution
     echo "60" > "$MOCK_DIR/responses/1.sleep"
 
+    # Direct invocation (not run_ralph), so record the start hour ourselves
+    # for the conditional call-count assertion below (Issue #285)
+    e2e_mark_run_start
     bash "$RALPH_SCRIPT" > "$E2E_DIR/ralph_run.log" 2>&1 < /dev/null &
     local ralph_pid=$!
 
@@ -316,7 +321,7 @@ EOF
     assert_equal "$(status_field last_action)" "interrupted"
     assert_equal "$(status_field status)" "stopped"
     # Call counter preserved across interruption
-    assert_equal "$(cat .ralph/.call_count)" "1"
+    assert_call_count 1
 
     kill -KILL "$ralph_pid" 2>/dev/null || true
     wait "$ralph_pid" 2>/dev/null || true

--- a/tests/integration/test_tmux_integration.bats
+++ b/tests/integration/test_tmux_integration.bats
@@ -344,7 +344,7 @@ assert_tmux_called_with() {
     run setup_tmux_session
     [ "$status" -eq 0 ]
     # pane 1 receives 'tail -f' for the live log file
-    assert_tmux_called_with "tmux send-keys -t .+\.1 tail -f"
+    assert_tmux_called_with "tmux send-keys -t [^ ]+\.1 tail -f"
 }
 
 # ==============================================================================
@@ -355,7 +355,7 @@ assert_tmux_called_with() {
     run setup_tmux_session
     [ "$status" -eq 0 ]
     # pane 2 receives either ralph-monitor or ralph_monitor.sh
-    assert_tmux_called_with "tmux send-keys -t .+\.2 .*(ralph-monitor|ralph_monitor\.sh)"
+    assert_tmux_called_with "tmux send-keys -t [^ ]+\.2 .*(ralph-monitor|ralph_monitor\.sh)"
 }
 
 # ==============================================================================
@@ -367,11 +367,11 @@ assert_tmux_called_with() {
     [ "$status" -eq 0 ]
 
     # pane 0 receives the ralph command
-    assert_tmux_called_with "tmux send-keys -t .+\.0 .*(ralph|ralph_loop\.sh)"
+    assert_tmux_called_with "tmux send-keys -t [^ ]+\.0 .*(ralph|ralph_loop\.sh)"
 
     # --monitor must NOT appear in the left-pane command (would cause infinite recursion)
     local pane0_line
-    pane0_line=$(grep -E "tmux send-keys -t .+\.0" "$TMUX_CALL_LOG" | head -1)
+    pane0_line=$(grep -E "tmux send-keys -t [^ ]+\.0" "$TMUX_CALL_LOG" | head -1)
     [[ "$pane0_line" != *"--monitor"* ]]
 }
 
@@ -384,7 +384,7 @@ assert_tmux_called_with() {
     [ "$status" -eq 0 ]
 
     local pane0_line
-    pane0_line=$(grep -E "tmux send-keys -t .+\.0" "$TMUX_CALL_LOG" | head -1)
+    pane0_line=$(grep -E "tmux send-keys -t [^ ]+\.0" "$TMUX_CALL_LOG" | head -1)
     [[ "$pane0_line" == *"--live"* ]]
 }
 
@@ -422,7 +422,7 @@ assert_tmux_called_with() {
     [ "$status" -eq 0 ]
 
     local pane0_line
-    pane0_line=$(grep -E "tmux send-keys -t .+\.0" "$TMUX_CALL_LOG" | head -1)
+    pane0_line=$(grep -E "tmux send-keys -t [^ ]+\.0" "$TMUX_CALL_LOG" | head -1)
     [[ "$pane0_line" == *"--calls 50"* ]]
 }
 
@@ -437,7 +437,7 @@ assert_tmux_called_with() {
     [ "$status" -eq 0 ]
 
     local pane0_line
-    pane0_line=$(grep -E "tmux send-keys -t .+\.0" "$TMUX_CALL_LOG" | head -1)
+    pane0_line=$(grep -E "tmux send-keys -t [^ ]+\.0" "$TMUX_CALL_LOG" | head -1)
     [[ "$pane0_line" == *"--prompt"* ]]
 }
 
@@ -485,11 +485,11 @@ assert_tmux_called_with() {
 
     # With pane-base-index=1, the 3 panes are .1 (loop), .2 (output), .3 (status)
     # Ralph loop command must target pane .1 (NOT .0 which doesn't exist)
-    assert_tmux_called_with "tmux send-keys -t .+\.1 .*(ralph|ralph_loop\.sh).*--live"
+    assert_tmux_called_with "tmux send-keys -t [^ ]+\.1 .*(ralph|ralph_loop\.sh).*--live"
     # live.log tail must target pane .2 (Claude Output)
-    assert_tmux_called_with "tmux send-keys -t .+\.2 tail -f"
+    assert_tmux_called_with "tmux send-keys -t [^ ]+\.2 tail -f"
     # monitor must target pane .3 (Status)
-    assert_tmux_called_with "tmux send-keys -t .+\.3 .*(ralph-monitor|ralph_monitor\.sh)"
+    assert_tmux_called_with "tmux send-keys -t [^ ]+\.3 .*(ralph-monitor|ralph_monitor\.sh)"
     # No send-keys to .0 — that pane does not exist in this config
     run grep -E '^tmux send-keys -t [^ ]+\.0 ' "$TMUX_CALL_LOG"
     [ "$status" -ne 0 ]

--- a/tests/unit/test_e2e_helper.bats
+++ b/tests/unit/test_e2e_helper.bats
@@ -28,16 +28,33 @@ teardown() {
 # e2e_mark_run_start / e2e_mark_run_end / e2e_hour_rolled_over
 # =============================================================================
 
-@test "e2e_mark_run_start records the current hour" {
-    e2e_mark_run_start
+# Assert a marker file holds the current hour. The hour is sampled before and
+# after the marker was written, and either value is accepted, so these tests
+# cannot themselves flake at the top of the hour.
+assert_marker_is_current_hour() {
+    local file=$1 before=$2 after=$3
+    local marker
+    marker=$(cat "$file")
+    [[ "$marker" == "$before" || "$marker" == "$after" ]] \
+        || fail "Marker '$marker' is neither '$before' nor '$after'"
+}
 
-    assert_equal "$(cat "$E2E_DIR/.run_start_hour")" "$(date +%Y%m%d%H)"
+@test "e2e_mark_run_start records the current hour" {
+    local before after
+    before=$(date +%Y%m%d%H)
+    e2e_mark_run_start
+    after=$(date +%Y%m%d%H)
+
+    assert_marker_is_current_hour "$E2E_DIR/.run_start_hour" "$before" "$after"
 }
 
 @test "e2e_mark_run_end records the current hour" {
+    local before after
+    before=$(date +%Y%m%d%H)
     e2e_mark_run_end
+    after=$(date +%Y%m%d%H)
 
-    assert_equal "$(cat "$E2E_DIR/.run_end_hour")" "$(date +%Y%m%d%H)"
+    assert_marker_is_current_hour "$E2E_DIR/.run_end_hour" "$before" "$after"
 }
 
 @test "e2e_hour_rolled_over is false when the hour has not changed" {
@@ -146,9 +163,12 @@ teardown() {
     echo 'exit 7' > "$RALPH_SCRIPT"
     rm -f "$E2E_DIR/.run_start_hour" "$E2E_DIR/.run_end_hour"
 
+    local before after
+    before=$(date +%Y%m%d%H)
     run run_ralph
+    after=$(date +%Y%m%d%H)
 
     [ "$status" -eq 7 ]
-    assert_equal "$(cat "$E2E_DIR/.run_start_hour")" "$(date +%Y%m%d%H)"
-    assert_equal "$(cat "$E2E_DIR/.run_end_hour")" "$(date +%Y%m%d%H)"
+    assert_marker_is_current_hour "$E2E_DIR/.run_start_hour" "$before" "$after"
+    assert_marker_is_current_hour "$E2E_DIR/.run_end_hour" "$before" "$after"
 }

--- a/tests/unit/test_e2e_helper.bats
+++ b/tests/unit/test_e2e_helper.bats
@@ -25,7 +25,7 @@ teardown() {
 }
 
 # =============================================================================
-# e2e_mark_run_start / e2e_hour_rolled_over
+# e2e_mark_run_start / e2e_mark_run_end / e2e_hour_rolled_over
 # =============================================================================
 
 @test "e2e_mark_run_start records the current hour" {
@@ -34,22 +34,49 @@ teardown() {
     assert_equal "$(cat "$E2E_DIR/.run_start_hour")" "$(date +%Y%m%d%H)"
 }
 
+@test "e2e_mark_run_end records the current hour" {
+    e2e_mark_run_end
+
+    assert_equal "$(cat "$E2E_DIR/.run_end_hour")" "$(date +%Y%m%d%H)"
+}
+
 @test "e2e_hour_rolled_over is false when the hour has not changed" {
     e2e_mark_run_start
+    e2e_mark_run_end
 
     run e2e_hour_rolled_over
     assert_failure
 }
 
-@test "e2e_hour_rolled_over is true when the recorded hour is stale" {
+@test "e2e_hour_rolled_over compares start to recorded end, not assertion time" {
+    # Run started and ended in the same (old) hour — even though the current
+    # wall clock differs, the run itself never crossed a boundary, so the
+    # counter cannot have been reset and assertions must stay strict.
     echo "2020010100" > "$E2E_DIR/.run_start_hour"
+    echo "2020010100" > "$E2E_DIR/.run_end_hour"
+
+    run e2e_hour_rolled_over
+    assert_failure
+}
+
+@test "e2e_hour_rolled_over is true when the hour changed during the run" {
+    echo "2020010100" > "$E2E_DIR/.run_start_hour"
+    echo "2020010101" > "$E2E_DIR/.run_end_hour"
+
+    run e2e_hour_rolled_over
+    assert_success
+}
+
+@test "e2e_hour_rolled_over falls back to current time when no end was recorded" {
+    echo "2020010100" > "$E2E_DIR/.run_start_hour"
+    rm -f "$E2E_DIR/.run_end_hour"
 
     run e2e_hour_rolled_over
     assert_success
 }
 
 @test "e2e_hour_rolled_over is false when no run start was recorded" {
-    rm -f "$E2E_DIR/.run_start_hour"
+    rm -f "$E2E_DIR/.run_start_hour" "$E2E_DIR/.run_end_hour"
 
     run e2e_hour_rolled_over
     assert_failure
@@ -61,6 +88,7 @@ teardown() {
 
 @test "assert_call_count passes when hour unchanged and count matches" {
     e2e_mark_run_start
+    e2e_mark_run_end
     echo "3" > .ralph/.call_count
 
     run assert_call_count 3
@@ -69,6 +97,18 @@ teardown() {
 
 @test "assert_call_count fails when hour unchanged and count differs" {
     e2e_mark_run_start
+    e2e_mark_run_end
+    echo "0" > .ralph/.call_count
+
+    run assert_call_count 3
+    assert_failure
+}
+
+@test "assert_call_count stays strict when the hour changed only after the run" {
+    # Boundary crossed between run end and assertion — the counter was not
+    # reset during the run, so a wrong value must still fail.
+    echo "2020010100" > "$E2E_DIR/.run_start_hour"
+    echo "2020010100" > "$E2E_DIR/.run_end_hour"
     echo "0" > .ralph/.call_count
 
     run assert_call_count 3
@@ -77,6 +117,7 @@ teardown() {
 
 @test "assert_call_count skips the check when the run crossed an hour boundary" {
     echo "2020010100" > "$E2E_DIR/.run_start_hour"
+    echo "2020010101" > "$E2E_DIR/.run_end_hour"
     echo "0" > .ralph/.call_count
 
     run assert_call_count 3
@@ -85,7 +126,7 @@ teardown() {
 }
 
 @test "assert_call_count stays strict when no run start was recorded" {
-    rm -f "$E2E_DIR/.run_start_hour"
+    rm -f "$E2E_DIR/.run_start_hour" "$E2E_DIR/.run_end_hour"
     echo "0" > .ralph/.call_count
 
     run assert_call_count 3
@@ -96,14 +137,18 @@ teardown() {
 # run_ralph integration point
 # =============================================================================
 
-@test "run_ralph records the run start hour before invoking ralph" {
-    # Stub ralph itself — this test only verifies the marker side effect.
+@test "run_ralph records run start and end hours and preserves exit status" {
+    [[ -n "$E2E_TIMEOUT_CMD" ]] || skip "GNU timeout unavailable"
+
+    # Stub ralph itself — this test only verifies the marker side effects
+    # and that the exit status passes through the marker bookkeeping.
     RALPH_SCRIPT="$E2E_DIR/fake_ralph.sh"
-    echo 'exit 0' > "$RALPH_SCRIPT"
-    rm -f "$E2E_DIR/.run_start_hour"
+    echo 'exit 7' > "$RALPH_SCRIPT"
+    rm -f "$E2E_DIR/.run_start_hour" "$E2E_DIR/.run_end_hour"
 
     run run_ralph
 
-    assert_success
+    [ "$status" -eq 7 ]
     assert_equal "$(cat "$E2E_DIR/.run_start_hour")" "$(date +%Y%m%d%H)"
+    assert_equal "$(cat "$E2E_DIR/.run_end_hour")" "$(date +%Y%m%d%H)"
 }

--- a/tests/unit/test_e2e_helper.bats
+++ b/tests/unit/test_e2e_helper.bats
@@ -1,0 +1,109 @@
+#!/usr/bin/env bats
+# Unit tests for the E2E harness assertion helpers (Issue #285)
+#
+# The hourly rate-limit reset (init_call_tracking) legitimately zeroes
+# .ralph/.call_count whenever `date +%Y%m%d%H` changes mid-run, so raw
+# counter assertions in the E2E suite must be conditional: assert_call_count
+# only checks the value when the recorded run-start hour still matches the
+# current hour (mock_call_count remains the unconditional invocation proof).
+
+load '../helpers/test_helper'
+load '../e2e/helpers/e2e_helper'
+
+setup() {
+    E2E_DIR="$(mktemp -d)"
+    PROJECT_DIR="$E2E_DIR/project"
+    mkdir -p "$PROJECT_DIR/.ralph"
+    cd "$PROJECT_DIR"
+}
+
+teardown() {
+    cd /
+    if [[ -n "$E2E_DIR" && -d "$E2E_DIR" ]]; then
+        rm -rf "$E2E_DIR"
+    fi
+}
+
+# =============================================================================
+# e2e_mark_run_start / e2e_hour_rolled_over
+# =============================================================================
+
+@test "e2e_mark_run_start records the current hour" {
+    e2e_mark_run_start
+
+    assert_equal "$(cat "$E2E_DIR/.run_start_hour")" "$(date +%Y%m%d%H)"
+}
+
+@test "e2e_hour_rolled_over is false when the hour has not changed" {
+    e2e_mark_run_start
+
+    run e2e_hour_rolled_over
+    assert_failure
+}
+
+@test "e2e_hour_rolled_over is true when the recorded hour is stale" {
+    echo "2020010100" > "$E2E_DIR/.run_start_hour"
+
+    run e2e_hour_rolled_over
+    assert_success
+}
+
+@test "e2e_hour_rolled_over is false when no run start was recorded" {
+    rm -f "$E2E_DIR/.run_start_hour"
+
+    run e2e_hour_rolled_over
+    assert_failure
+}
+
+# =============================================================================
+# assert_call_count
+# =============================================================================
+
+@test "assert_call_count passes when hour unchanged and count matches" {
+    e2e_mark_run_start
+    echo "3" > .ralph/.call_count
+
+    run assert_call_count 3
+    assert_success
+}
+
+@test "assert_call_count fails when hour unchanged and count differs" {
+    e2e_mark_run_start
+    echo "0" > .ralph/.call_count
+
+    run assert_call_count 3
+    assert_failure
+}
+
+@test "assert_call_count skips the check when the run crossed an hour boundary" {
+    echo "2020010100" > "$E2E_DIR/.run_start_hour"
+    echo "0" > .ralph/.call_count
+
+    run assert_call_count 3
+    assert_success
+    [[ "$output" == *"hour boundary"* ]]
+}
+
+@test "assert_call_count stays strict when no run start was recorded" {
+    rm -f "$E2E_DIR/.run_start_hour"
+    echo "0" > .ralph/.call_count
+
+    run assert_call_count 3
+    assert_failure
+}
+
+# =============================================================================
+# run_ralph integration point
+# =============================================================================
+
+@test "run_ralph records the run start hour before invoking ralph" {
+    # Stub ralph itself — this test only verifies the marker side effect.
+    RALPH_SCRIPT="$E2E_DIR/fake_ralph.sh"
+    echo 'exit 0' > "$RALPH_SCRIPT"
+    rm -f "$E2E_DIR/.run_start_hour"
+
+    run run_ralph
+
+    assert_success
+    assert_equal "$(cat "$E2E_DIR/.run_start_hour")" "$(date +%Y%m%d%H)"
+}


### PR DESCRIPTION
## Summary
Implements #285: E2E full-loop tests flake when a run crosses an hour boundary (hourly counter reset)

- `init_call_tracking` (ralph_loop.sh:451) runs at the top of every loop iteration and zeroes `.ralph/.call_count` when `date +%Y%m%d%H` changes — designed hourly rate-limit behavior. E2E runs crossing an hour boundary therefore end with a legitimately zeroed counter, flaking the raw-value assertions (seen on PR #284 CI).
- New harness helpers in `tests/e2e/helpers/e2e_helper.bash`: `e2e_mark_run_start` / `e2e_mark_run_end` record the run window (file-based, surviving bats `run` subshells; `run_ralph` calls both automatically and preserves the subprocess exit status); `assert_call_count` asserts the raw counter only when the hour did **not** roll over **during the run** (start marker vs end marker — a boundary crossed after the run ended, e.g. while the interruption test polls for status, does not suppress the check).
- Applied to the four exposed assertions, including the stale-counter test's `.last_reset` check (same time-dependence, not listed in the issue) — `mock_call_count` assertions remain unchanged and unconditional as the proof of CLI invocation count.
- New `tests/unit/test_e2e_helper.bats` (13 tests) covers the helpers, including mutation-killing tests for the run-window semantics.
- **Drive-by flake fix** (surfaced while running the gate): `tests/integration/test_tmux_integration.bats` pane-target regexes used `-t .+\.0`, which matches `.0` anywhere later in the line — including the temp-dir path inside the pane-1 `tail` command whenever mktemp's `test.XXXXXX` suffix starts with `0` (~1/62 of runs), making `head -1` return the wrong line. Reproduced deterministically with a TMPDIR containing `.0`; anchored all patterns to a single token (`[^ ]+`, the form tests 26–28 already used).

## Acceptance Criteria
- [x] Exposed raw `.call_count` assertions no longer fail when the run crosses an hour boundary (proven by simulated-rollover unit tests)
- [x] Non-rollover runs still assert the exact raw counter value — including when the boundary is crossed only after the run ends (codex round-1 finding, fixed)
- [x] `mock_call_count` assertions unchanged and unconditional
- [x] 100% test pass rate: 863 unit+integration + 13 E2E

## Test Plan
- [x] Unit tests written first (TDD; RED confirmed before implementation)
- [x] All tests passing (863 + 13 E2E)
- [x] Diff coverage: test-only change; all new helper logic directly exercised by the 13 new unit tests (kcov coverage is informational-only in this repo — bats subprocess limitation)
- [x] Linting: no lint tooling configured for this bash repo (no npm lint script / shellcheck) — gate is a no-op
- [x] Internal code review (advisory) completed
- [x] Cross-family review pass: codex (round 1: two P2 findings, both fixed in 2e2e1b6; round 2: clean)
- [x] Test mutation sanity check: 4 mutations (neutered assert_call_count, inverted rollover predicate, removed run_ralph marker call, ignored end marker) each killed by the intended tests; tmux regex fix proven by deterministic pre-fix repro

## Known Limitations / Intentionally Deferred
- The skip path (`assert_call_count` during a genuine mid-run rollover) cannot be exercised end-to-end in CI without pinning the clock; it is covered at the unit level by simulating marker files. A `date` shim in the mock PATH was considered and rejected — ralph uses `date +%s` for early-failure/elapsed-time logic and a shim risks masking real behavior.
- The residual flake window is now only a boundary crossed exactly between `e2e_mark_run_start` and the first counter increment vs the assertions — the same window in which the product itself legitimately resets, so the skip is correct by construction.

## Implementation Notes
- Deviation from the issue's suggested fix: also guarded the "stale hourly counter" test's `.call_count`/`.last_reset` assertions (same exposure, not listed in the issue).
- Codex round-1 P2s addressed: rollover detection scoped to the run window (not assertion time), and the GNU-timeout requirement is no longer enforced at helper load time (soft-fail at source; hard check in `setup_e2e_project`; the one `run_ralph` unit test skips when no timeout binary exists) so the unit suite stays runnable without coreutils.

Closes #285

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Test setup now validates timeout availability before running.
  * Added run-start/run-end markers and hour-boundary detection to avoid timing flakiness.
  * Introduced tolerant call-count assertions that skip strict checks when an hour rollover occurred.
  * Added unit tests for time-boundary helpers and a test verifying subprocess exit passthrough.
  * Tightened integration test patterns for more precise matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->