### PR TITLE
feat(loop): GitHub issue lifecycle (#73) + optional fix_plan sections (#239)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ Ralph for Claude Code — an autonomous AI development loop system enabling cont
     - `--select first|interactive|priority` picks among multiple matches: priority understands bare `P0`–`P9` and `priority: PN` labels (ties → oldest, none → first); interactive falls back to first on non-TTY/EOF. `--dry-run` previews the match table + would-be selection without importing
   - Completeness assessment + plan generation (Issue #70): issues are scored 0–100 via `lib/issue_analyzer.sh`; below `--completeness-threshold` (default 60) an implementation plan is generated via Claude CLI (`--plan-model` passthrough) and appended to the PRD before conversion, plus saved to `.ralph/specs/implementation-plan.md`. Flags: `--generate-plan` (force), `--no-generate-plan` (fail if below threshold), `--plan-model <model>`, `--completeness-threshold <0-100>`, `--auto-approve` (skip the approval prompt; non-TTY sessions auto-accept)
 - **ralph_queue.sh** — `ralph-queue` command: batch processing and issue queue management (Issue #72). Builds a persistent queue at `.ralph/queue.json` of GitHub issues (reuses `ralph_import.sh`'s `gh` machinery: `resolve_github_issue_candidates`, `fetch_github_issue`, `format_issue_as_prd`) or local PRD specs. Subcommands: `add` (`--github-issues N,N` | filter flags | `--prd <file>`), `status [--json]`, `next`, `remove`, `clear`, `reorder`, `validate`, `process [--halt-on-failure]`, `resume`. The sequential processor stages `.ralph/` from each ready item (priority + dependency order), runs the loop via `RALPH_LOOP_CMD` (default `ralph_loop.sh`; overridable for tests), commits `Fix #N: <title>` per issue, skips failures (or halts), and writes `.ralph/logs/queue_processing.log`. Single branch, no concurrency. See [docs/QUEUE_MANAGEMENT.md](docs/QUEUE_MANAGEMENT.md)
+- **GitHub issue lifecycle** (Issue #73): when `ralph` is run with `--github-issue <ref>`, it tracks the issue across the loop via `lib/github_lifecycle.sh`. During development it can post progress comments every N loops (`--comment-progress`, `--comment-interval`); on graceful completion it runs a completion workflow — summary comment (`--close-summary`), PR creation linked with `Closes #N` (`--create-pr --link-issue`, optional `--draft-pr`), grouped follow-up issue from TODO/FIXME markers added during dev (`--create-followups --followup-label`), and issue close with optional labels (`--auto-close --add-label`). All steps are opt-in and degrade gracefully (a gh permission failure is logged and the loop continues). State lives in `.ralph/.github_lifecycle_state`. Uses the `gh` CLI exclusively (not raw REST/`GITHUB_TOKEN`)
 - **ralph_enable.sh** — interactive wizard enabling Ralph in existing projects (environment detection, task source selection, generates `.ralphrc`)
 - **ralph_enable_ci.sh** — non-interactive version for CI/automation; `--json` output mode; exit codes: 0 (success), 1 (error), 2 (already enabled)
 
@@ -38,6 +39,7 @@ Ralph for Claude Code — an autonomous AI development loop system enabling cont
 - **issue_analyzer.sh** — `assess_issue_completeness()`: deterministic 0–100 heuristic scoring of issue PRDs (acceptance criteria +25, checklists/code blocks/sections/keywords/length +15 each); JSON output with `confidence_score`, `completeness_level`, `missing_elements`, `recommendation`; `log_issue_analysis()` for summaries
 - **file_protection.sh** — `validate_ralph_integrity()` checks `RALPH_REQUIRED_PATHS` exist; runs every loop iteration; `get_integrity_report()` for recovery instructions
 - **log_utils.sh** — `rotate_logs()` rotates `$LOG_DIR/ralph.log` at 10MB, keeping 4 archives (`.log.1`–`.log.4`); GNU `stat -c%s` with BSD `stat -f%z` fallback
+- **github_lifecycle.sh** — GitHub issue lifecycle management backing `ralph --github-issue` (Issue #73). `parse_issue_reference` (N | #N | owner/repo#N | URL → number+repo); gh wrappers `gh_issue_comment`/`gh_close_issue`/`gh_add_labels`/`gh_create_pr`/`gh_create_issue` (each logs + returns non-zero on failure, never exits); state primitives `init_github_lifecycle`/`lifecycle_get`/`_lifecycle_apply` (atomic temp+`mv` at `.ralph/.github_lifecycle_state`, program-first signature like `_queue_apply`); generators `generate_progress_comment`/`generate_completion_summary`/`scan_for_todos`; orchestration `lifecycle_post_progress <loop>` (interval-gated) and `lifecycle_on_completion` (summary → PR → followups → close, each flag-guarded, always returns 0). Reuses `lib/date_utils.sh` timestamps
 - **queue_manager.sh** — queue state primitives backing `ralph-queue` (Issue #72). State at `.ralph/queue.json` (`{version, created_at, updated_at, repository, queue:[…]}`); entries carry `id`/`source` (`github`|`prd`)/`issue_number`/`path`/`title`/`priority`/`labels`/`milestone`/`dependencies`/`status`/timestamps. Functions: `init_queue`, `add_to_queue` (dedupe by id, fills defaults; rc 0/1/2), `remove_from_queue`, `clear_queue`, `mark_issue_status` (validates status, stamps started/completed), `get_queue_status` (counts JSON), `sort_queue_by_priority` (rank then FIFO), `get_priority_from_labels` (reuses the P0–P9 / `priority: PN` parser), `parse_issue_dependencies` (`depends on/blocked by/requires #N`), `is_dependency_satisfied`, `get_next_issue` (ready+priority+FIFO), `validate_dependencies` (jq cycle detection). All mutations are atomic temp-file+`mv` via `_queue_apply`
 
 ## Key Commands
@@ -82,6 +84,24 @@ ralph --backup                   # (-b) Enable automatic backup before each loop
 ralph --rollback                 # List available backup branches
 ralph --rollback ralph-backup-loop-3-1775155286   # Roll back to a specific backup
 ```
+
+### GitHub Issue Lifecycle (Issue #73)
+```bash
+# Track an issue and post progress comments every 5 loops
+ralph --github-issue 69 --comment-progress --comment-interval 5
+
+# On completion: open a PR that closes the issue, then close it with a summary
+ralph --github-issue 69 --create-pr --link-issue --close-summary --auto-close
+
+# Add labels on close and open a follow-up issue for any TODO/FIXME left behind
+ralph --github-issue owner/repo#69 --auto-close --add-label completed \
+      --create-followups --followup-label tech-debt
+
+# Draft PR for manual review before merge
+ralph --github-issue 69 --create-pr --draft-pr
+```
+All lifecycle flags are opt-in and require `--github-issue`. Each GitHub operation
+degrades gracefully — a permission failure is logged and the loop continues.
 
 ### Batch Processing / Issue Queue (Issue #72)
 ```bash
@@ -178,7 +198,7 @@ Exit requires BOTH conditions (dual-condition check prevents premature exits):
 - `MAX_CONSECUTIVE_DONE_SIGNALS=2` — repeated "done" signals from Claude
 - `MAX_CONSECUTIVE_TEST_LOOPS=3` — too many test-only iterations (feature completeness)
 - `TEST_PERCENTAGE_THRESHOLD=30%` — flag if testing dominates recent loops
-- All items in `.ralph/fix_plan.md` marked complete
+- All items in `.ralph/fix_plan.md` marked complete — but unchecked items under **optional sections** are excluded (Issue #239). `_count_blocking_unchecked()` (awk, section-aware) counts only unchecked `- [ ]` items NOT under a heading whose title matches `OPTIONAL_SECTIONS` (default `"Optional,Future,Future Enhancements,Nice to Have"`, case-insensitive, comma-separated, configurable in `.ralphrc`). Optional context persists into deeper subsections and closes at the next same-or-higher-level heading. This resolves the deadlock where Claude treats "Low Priority"/optional items as skippable while Ralph keeps looping for them. With no optional sections present, behavior is identical to the prior full-file count (backward compatible)
 
 **Startup state reset (Issue #194)**: every `ralph` invocation unconditionally resets `.exit_signals` and removes `.response_analysis` before the main loop, so stale completion signals from a prior run (crash, SIGKILL, API-limit exit) can't trigger `should_exit_gracefully()` on the first iteration. The API-limit "user chose exit" path also calls `reset_session()`.
 

--- a/README.md
+++ b/README.md
@@ -321,10 +321,29 @@ Loop 8: Claude outputs "All tasks complete, project ready"
 ```
 
 **Other exit conditions:**
-- All tasks in `.ralph/fix_plan.md` marked complete
+- All tasks in `.ralph/fix_plan.md` marked complete — except unchecked items under **optional sections**
 - Multiple consecutive "done" signals from Claude Code
 - Too many test-focused loops (indicating feature completeness)
 - Claude API 5-hour usage limit reached (with user prompt to wait or exit)
+
+#### Optional / Future sections in fix_plan.md
+
+By default, Ralph keeps looping until **every** `- [ ]` item is checked. To mark work as
+genuinely optional so it does not block completion, put it under an optional section:
+
+```markdown
+## High Priority
+- [x] Core feature
+
+## Optional
+- [ ] Frontend integration   # does NOT block exit
+- [ ] SMS notifications      # does NOT block exit
+```
+
+Unchecked items under `Optional`, `Future`, `Future Enhancements`, or `Nice to Have` headings
+(and their subsections) are ignored by the completion check. Customize the section names with
+`OPTIONAL_SECTIONS` in `.ralphrc` (comma-separated, case-insensitive). This resolves the
+deadlock where Claude treats low-priority items as skippable while Ralph waits for them.
 
 ## Enabling Ralph in Existing Projects
 
@@ -485,6 +504,46 @@ Generated plans are shown for approval before conversion. Non-interactive sessio
 ### Troubleshooting
 - **"GitHub CLI (gh) is not installed"** — install it from https://cli.github.com
 - **"GitHub CLI is not authenticated"** — run `gh auth login`
+
+## GitHub Issue Lifecycle
+
+Once development is underway, Ralph can close the loop on the whole GitHub workflow. Pass
+`--github-issue <ref>` (a number `69`, `#69`, `owner/repo#69`, or a full issue URL) to `ralph`
+and opt into any of the lifecycle actions below. They all use the `gh` CLI (so the same
+`gh auth login` prerequisite applies), and every GitHub operation degrades gracefully — if a
+call is denied, Ralph logs a warning and keeps developing rather than crashing the loop.
+
+```bash
+# Post a progress comment to the issue every 5 loops while developing
+ralph --github-issue 69 --comment-progress --comment-interval 5
+
+# On completion: open a PR linked to the issue, comment a summary, and close it
+ralph --github-issue 69 --create-pr --link-issue --close-summary --auto-close
+
+# Add labels when closing, and open a follow-up issue for any TODO/FIXME left in the diff
+ralph --github-issue 69 --auto-close --add-label completed \
+      --create-followups --followup-label tech-debt
+
+# Open the PR as a draft for manual review before merge
+ralph --github-issue 69 --create-pr --draft-pr
+```
+
+| Flag | Effect |
+|------|--------|
+| `--github-issue REF` | Track the issue (required for all lifecycle features) |
+| `--comment-progress` | Post progress comments during development |
+| `--comment-interval N` | Comment every N loops (default: 5) |
+| `--auto-close` | Close the issue on graceful completion |
+| `--close-summary` | Post a completion summary comment |
+| `--create-pr` | Create a pull request on completion |
+| `--link-issue` | Add `Closes #N` to the PR body |
+| `--draft-pr` | Create the PR as a draft |
+| `--create-followups` | Open a grouped follow-up issue for TODO/FIXME markers added during dev |
+| `--followup-label LABEL` | Label for follow-up issues (default: `tech-debt`) |
+| `--add-label LABEL` | Label to add on close (repeatable) |
+
+These can also be set in `.ralphrc` (`COMMENT_PROGRESS`, `AUTO_CLOSE`, `CREATE_PR`, etc.).
+Lifecycle state is tracked in `.ralph/.github_lifecycle_state`.
 
 ## Batch Processing and Issue Queue
 

--- a/lib/github_lifecycle.sh
+++ b/lib/github_lifecycle.sh
@@ -190,7 +190,14 @@ init_github_lifecycle() {
     # Capture HEAD at the start of the run so follow-up TODO scanning covers every
     # commit Ralph makes during development, not just the last one (empty if not a repo).
     start_sha=$(git rev-parse HEAD 2>/dev/null) || start_sha=""
-    jq -n \
+    # Write through a temp file + mv so an interrupted init never leaves a
+    # truncated/corrupt state file (same atomicity as _lifecycle_apply).
+    local tmp
+    tmp=$(mktemp "${GITHUB_LIFECYCLE_STATE_FILE}.XXXXXX" 2>/dev/null) || {
+        _lifecycle_log "WARN" "Could not initialize GitHub lifecycle state file"
+        return 1
+    }
+    if jq -n \
         --arg number "$number" \
         --arg repo "$repo" \
         --arg title "$title" \
@@ -210,10 +217,13 @@ init_github_lifecycle() {
                 followups_created: []
             },
             updated_at: $now
-        }' > "$GITHUB_LIFECYCLE_STATE_FILE" 2>/dev/null || {
-            _lifecycle_log "WARN" "Could not initialize GitHub lifecycle state file"
-            return 1
-        }
+        }' > "$tmp" 2>/dev/null; then
+        mv "$tmp" "$GITHUB_LIFECYCLE_STATE_FILE"
+    else
+        rm -f "$tmp"
+        _lifecycle_log "WARN" "Could not initialize GitHub lifecycle state file"
+        return 1
+    fi
 
     _lifecycle_log "INFO" "🔗 GitHub issue lifecycle tracking #${number}${repo:+ ($repo)}"
     return 0
@@ -294,7 +304,8 @@ EOF
 # Scan lines ADDED since the lifecycle start SHA (all commits made during the run
 # plus the working tree) for TODO/FIXME/HACK/XXX markers. Falls back to the last
 # commit + working tree when no start SHA is recorded (e.g. lib used standalone).
-# Prints one marker per line (deduplicated).
+# Prints one "<file>: <marker text>" per line (deduplicated) so the follow-up
+# issue points reviewers at where each marker lives.
 scan_for_todos() {
     local base diff
     base=$(lifecycle_get '.lifecycle.start_sha' 2>/dev/null)
@@ -304,12 +315,29 @@ scan_for_todos() {
     else
         diff=$(git diff -U0 HEAD 2>/dev/null; git diff -U0 --cached 2>/dev/null; git diff -U0 HEAD~1 HEAD 2>/dev/null)
     fi
-    printf '%s\n' "$diff" \
-        | grep -E "^\+" \
-        | grep -vE "^\+\+\+" \
-        | grep -oiE "(TODO|FIXME|HACK|XXX):?.*" \
-        | sed 's/[[:space:]]*$//' \
-        | sort -u
+    # Track the current file from "+++ b/<path>" headers and prefix each marker.
+    # POSIX awk (no IGNORECASE): match on an upper-cased copy, slice from the
+    # original line to preserve the marker's text verbatim.
+    printf '%s\n' "$diff" | awk '
+        function first_marker(s,   kws, n, i, idx, best) {
+            n = split("TODO FIXME HACK XXX", kws, " ")
+            best = 0
+            for (i = 1; i <= n; i++) {
+                idx = index(s, kws[i])
+                if (idx > 0 && (best == 0 || idx < best)) best = idx
+            }
+            return best
+        }
+        /^\+\+\+ / { file = $2; sub(/^b\//, "", file); next }
+        /^\+/ {
+            p = first_marker(toupper($0))
+            if (p > 0) {
+                txt = substr($0, p)
+                sub(/[[:space:]]+$/, "", txt)
+                print (file == "" ? "" : file ": ") txt
+            }
+        }
+    ' | sort -u
 }
 
 # --- orchestration (always returns 0: graceful degradation) -----------------

--- a/lib/github_lifecycle.sh
+++ b/lib/github_lifecycle.sh
@@ -365,14 +365,15 @@ lifecycle_on_completion() {
         if [[ -z "$branch" || "$branch" == "HEAD" || "$branch" == "$default_branch" || "$branch" == "main" || "$branch" == "master" ]]; then
             _lifecycle_log "WARN" "Skipping PR creation: current branch ('${branch:-detached HEAD}') is the default/protected branch. Run Ralph on a feature branch to open a PR."
         else
-            local title="${GITHUB_PR_TITLE:-}"
-            [[ -z "$title" ]] && title="$(lifecycle_get '.issue.title')"
+            local title
+            title="$(lifecycle_get '.issue.title')"
             [[ -z "$title" ]] && title="Ralph: resolve issue #${number}"
             local pr_body="$summary"
             if [[ "${LINK_ISSUE:-false}" == "true" ]]; then
                 pr_body="$summary"$'\n\n'"Closes #${number}"
             fi
             # Best-effort push of the feature branch so gh has something to open a PR from.
+            _lifecycle_log "INFO" "⬆️  Pushing '$branch' to origin for PR creation"
             git push -u origin "$branch" >/dev/null 2>&1 || true
             local pr_url
             if pr_url=$(gh_create_pr "$title" "$pr_body" "${DRAFT_PR:-false}" "$repo"); then
@@ -407,7 +408,11 @@ EOF
         fi
     fi
 
-    # 4. Close the issue (+ optional completion labels)
+    # 4. Close the issue (+ optional completion labels).
+    # Note: with both --auto-close and --link-issue, the issue is closed here AND
+    # would be auto-closed again when the "Closes #N" PR merges. GitHub treats the
+    # second close as a no-op; this is intentional so an --auto-close run closes the
+    # issue immediately rather than waiting on the merge.
     if [[ "${AUTO_CLOSE:-false}" == "true" ]]; then
         if [[ -n "${ADD_COMPLETION_LABELS:-}" ]]; then
             gh_add_labels "$number" "$repo" "$ADD_COMPLETION_LABELS" || true

--- a/lib/github_lifecycle.sh
+++ b/lib/github_lifecycle.sh
@@ -185,17 +185,22 @@ init_github_lifecycle() {
     GITHUB_ISSUE_REPO="$repo"
 
     mkdir -p "$(dirname "$GITHUB_LIFECYCLE_STATE_FILE")" 2>/dev/null
-    local now
+    local now start_sha
     now=$(get_iso_timestamp)
+    # Capture HEAD at the start of the run so follow-up TODO scanning covers every
+    # commit Ralph makes during development, not just the last one (empty if not a repo).
+    start_sha=$(git rev-parse HEAD 2>/dev/null) || start_sha=""
     jq -n \
         --arg number "$number" \
         --arg repo "$repo" \
         --arg title "$title" \
         --arg now "$now" \
+        --arg start_sha "$start_sha" \
         '{
             issue: { number: ($number | tonumber), repo: $repo, title: $title },
             lifecycle: {
                 initialized_at: $now,
+                start_sha: $start_sha,
                 last_progress_comment: null,
                 progress_comments_posted: 0,
                 completion_detected_at: null,
@@ -286,11 +291,19 @@ EOF
 }
 
 # scan_for_todos
-# Scan lines ADDED in the working tree / last commit for TODO/FIXME/HACK/XXX
-# markers. Prints one "file: marker text" per line (deduplicated).
+# Scan lines ADDED since the lifecycle start SHA (all commits made during the run
+# plus the working tree) for TODO/FIXME/HACK/XXX markers. Falls back to the last
+# commit + working tree when no start SHA is recorded (e.g. lib used standalone).
+# Prints one marker per line (deduplicated).
 scan_for_todos() {
-    local diff
-    diff=$(git diff -U0 HEAD 2>/dev/null; git diff -U0 --cached 2>/dev/null; git diff -U0 HEAD~1 HEAD 2>/dev/null)
+    local base diff
+    base=$(lifecycle_get '.lifecycle.start_sha' 2>/dev/null)
+    if [[ -n "$base" ]] && git rev-parse --quiet --verify "$base^{commit}" >/dev/null 2>&1; then
+        # Diff the start SHA against the working tree: covers every commit + uncommitted change.
+        diff=$(git diff -U0 "$base" 2>/dev/null)
+    else
+        diff=$(git diff -U0 HEAD 2>/dev/null; git diff -U0 --cached 2>/dev/null; git diff -U0 HEAD~1 HEAD 2>/dev/null)
+    fi
     printf '%s\n' "$diff" \
         | grep -E "^\+" \
         | grep -vE "^\+\+\+" \
@@ -341,25 +354,31 @@ lifecycle_on_completion() {
         gh_issue_comment "$number" "$repo" "$summary" || true
     fi
 
-    # 2. Pull request linked to the issue
+    # 2. Pull request linked to the issue.
+    # Refuse to operate on the default/protected branch: pushing it would land the
+    # work directly on the base instead of proposing it in a PR (codex P1).
     if [[ "${CREATE_PR:-false}" == "true" ]]; then
-        local title="${GITHUB_PR_TITLE:-}"
-        [[ -z "$title" ]] && title="$(lifecycle_get '.issue.title')"
-        [[ -z "$title" ]] && title="Ralph: resolve issue #${number}"
-        local pr_body="$summary"
-        if [[ "${LINK_ISSUE:-false}" == "true" ]]; then
-            pr_body="$summary"$'\n\n'"Closes #${number}"
-        fi
-        # Best-effort push of the current branch so gh has something to open a PR from.
-        local branch=""
+        local branch="" default_branch=""
         branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || branch=""
-        if [[ -n "$branch" && "$branch" != "HEAD" ]]; then
+        default_branch=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##') || default_branch=""
+        [[ -z "$default_branch" ]] && default_branch="main"
+        if [[ -z "$branch" || "$branch" == "HEAD" || "$branch" == "$default_branch" || "$branch" == "main" || "$branch" == "master" ]]; then
+            _lifecycle_log "WARN" "Skipping PR creation: current branch ('${branch:-detached HEAD}') is the default/protected branch. Run Ralph on a feature branch to open a PR."
+        else
+            local title="${GITHUB_PR_TITLE:-}"
+            [[ -z "$title" ]] && title="$(lifecycle_get '.issue.title')"
+            [[ -z "$title" ]] && title="Ralph: resolve issue #${number}"
+            local pr_body="$summary"
+            if [[ "${LINK_ISSUE:-false}" == "true" ]]; then
+                pr_body="$summary"$'\n\n'"Closes #${number}"
+            fi
+            # Best-effort push of the feature branch so gh has something to open a PR from.
             git push -u origin "$branch" >/dev/null 2>&1 || true
-        fi
-        local pr_url
-        if pr_url=$(gh_create_pr "$title" "$pr_body" "${DRAFT_PR:-false}" "$repo"); then
-            _lifecycle_apply '.lifecycle.pr_created = true | .lifecycle.pr_url = $url' \
-                --arg url "$pr_url" >/dev/null 2>&1 || true
+            local pr_url
+            if pr_url=$(gh_create_pr "$title" "$pr_body" "${DRAFT_PR:-false}" "$repo"); then
+                _lifecycle_apply '.lifecycle.pr_created = true | .lifecycle.pr_url = $url' \
+                    --arg url "$pr_url" >/dev/null 2>&1 || true
+            fi
         fi
     fi
 

--- a/lib/github_lifecycle.sh
+++ b/lib/github_lifecycle.sh
@@ -1,0 +1,402 @@
+#!/bin/bash
+# GitHub Issue Lifecycle Management for Ralph (Issue #73)
+#
+# Closes the loop on GitHub issue workflows: posts progress comments during
+# development, and on graceful completion generates a summary, creates a PR
+# linked to the issue, opens follow-up issues for discovered TODOs, and closes
+# the issue with optional labels.
+#
+# Design notes:
+#   - Uses the `gh` CLI exclusively (consistent with ralph_import.sh /
+#     ralph_queue.sh), NOT raw REST + GITHUB_TOKEN.
+#   - State lives in $RALPH_DIR/.github_lifecycle_state (JSON), mutated through
+#     a temp file + mv so a crashed jq never leaves half-written state — the
+#     same convention as lib/queue_manager.sh / lib/circuit_breaker.sh.
+#   - Every GitHub operation degrades gracefully: a failure (e.g. missing
+#     permission) is logged and returns non-zero, but the orchestration helpers
+#     always return 0 so the development loop never crashes on a lifecycle hiccup.
+
+# Source date utilities for cross-platform ISO timestamps
+source "$(dirname "${BASH_SOURCE[0]}")/date_utils.sh"
+
+# Use RALPH_DIR if set by the main script, otherwise default to .ralph
+RALPH_DIR="${RALPH_DIR:-.ralph}"
+GITHUB_LIFECYCLE_STATE_FILE="${GITHUB_LIFECYCLE_STATE_FILE:-$RALPH_DIR/.github_lifecycle_state}"
+
+# --- logging ----------------------------------------------------------------
+
+# _lifecycle_log <level> <message>
+# Prefer the main script's log_status() when available; otherwise fall back to
+# stderr so the lib is usable (and testable) standalone.
+_lifecycle_log() {
+    local level="$1"
+    local message="$2"
+    if declare -F log_status >/dev/null 2>&1; then
+        log_status "$level" "$message" >&2
+    else
+        echo "[$level] $message" >&2
+    fi
+}
+
+# --- reference parsing ------------------------------------------------------
+
+# parse_issue_reference <ref>
+# Accepts: bare "42", "#42", "owner/repo#42", or a full issue URL.
+# Prints "<number>\t<repo>" where <repo> is empty for bare/#N forms (meaning
+# "the current repo", which gh infers from the git remote).
+# Returns 1 if no issue number can be extracted.
+parse_issue_reference() {
+    local ref="$1"
+    local number="" repo=""
+
+    if [[ "$ref" =~ ^https?://github\.com/([^/]+/[^/]+)/issues/([0-9]+) ]]; then
+        repo="${BASH_REMATCH[1]}"
+        number="${BASH_REMATCH[2]}"
+    elif [[ "$ref" =~ ^([^/]+/[^/#]+)#([0-9]+)$ ]]; then
+        repo="${BASH_REMATCH[1]}"
+        number="${BASH_REMATCH[2]}"
+    elif [[ "$ref" =~ ^#?([0-9]+)$ ]]; then
+        number="${BASH_REMATCH[1]}"
+    else
+        return 1
+    fi
+
+    printf '%s\t%s\n' "$number" "$repo"
+    return 0
+}
+
+# --- gh wrappers (each degrades gracefully) ---------------------------------
+
+# gh_issue_comment <number> <repo> <body>
+gh_issue_comment() {
+    local number="$1" repo="$2" body="$3"
+    local args=("issue" "comment" "$number" "--body-file" "-")
+    [[ -n "$repo" ]] && args+=("--repo" "$repo")
+    if ! printf '%s\n' "$body" | gh "${args[@]}" >/dev/null 2>&1; then
+        _lifecycle_log "WARN" "🚫 Could not post comment to issue #${number}${repo:+ ($repo)} — check gh auth / permissions"
+        return 1
+    fi
+    _lifecycle_log "INFO" "💬 Posted comment to issue #${number}"
+    return 0
+}
+
+# gh_close_issue <number> <repo>
+gh_close_issue() {
+    local number="$1" repo="$2"
+    local args=("issue" "close" "$number")
+    [[ -n "$repo" ]] && args+=("--repo" "$repo")
+    if ! gh "${args[@]}" >/dev/null 2>&1; then
+        _lifecycle_log "WARN" "🚫 Could not close issue #${number}${repo:+ ($repo)} — check gh auth / permissions"
+        return 1
+    fi
+    _lifecycle_log "INFO" "✅ Closed issue #${number}"
+    return 0
+}
+
+# gh_add_labels <number> <repo> <labels_csv>
+gh_add_labels() {
+    local number="$1" repo="$2" labels="$3"
+    [[ -z "$labels" ]] && return 0
+    local args=("issue" "edit" "$number" "--add-label" "$labels")
+    [[ -n "$repo" ]] && args+=("--repo" "$repo")
+    if ! gh "${args[@]}" >/dev/null 2>&1; then
+        _lifecycle_log "WARN" "🚫 Could not add labels '$labels' to issue #${number} — check gh auth / permissions"
+        return 1
+    fi
+    _lifecycle_log "INFO" "🏷️  Added labels '$labels' to issue #${number}"
+    return 0
+}
+
+# gh_create_pr <title> <body> <draft:true|false> <repo>
+# Prints the created PR URL on success.
+gh_create_pr() {
+    local title="$1" body="$2" draft="$3" repo="$4"
+    local args=("pr" "create" "--title" "$title" "--body-file" "-")
+    [[ "$draft" == "true" ]] && args+=("--draft")
+    [[ -n "$repo" ]] && args+=("--repo" "$repo")
+    local url
+    if ! url=$(printf '%s\n' "$body" | gh "${args[@]}" 2>/dev/null); then
+        _lifecycle_log "WARN" "🚫 Could not create PR — check the branch is pushed and gh has permission"
+        return 1
+    fi
+    _lifecycle_log "INFO" "🔀 Created PR: ${url}"
+    printf '%s\n' "$url"
+    return 0
+}
+
+# gh_create_issue <title> <body> <labels_csv> <repo>
+# Prints the created issue URL on success.
+gh_create_issue() {
+    local title="$1" body="$2" labels="$3" repo="$4"
+    local args=("issue" "create" "--title" "$title" "--body-file" "-")
+    [[ -n "$labels" ]] && args+=("--label" "$labels")
+    [[ -n "$repo" ]] && args+=("--repo" "$repo")
+    local url
+    if ! url=$(printf '%s\n' "$body" | gh "${args[@]}" 2>/dev/null); then
+        _lifecycle_log "WARN" "🚫 Could not create follow-up issue '$title' — check gh auth / permissions"
+        return 1
+    fi
+    _lifecycle_log "INFO" "📌 Created follow-up issue: ${url}"
+    printf '%s\n' "$url"
+    return 0
+}
+
+# --- state management -------------------------------------------------------
+
+# _lifecycle_apply <jq_program> [extra jq options...]
+# Atomically transform the state file, always refreshing updated_at. The program
+# may reference $now (the new timestamp).
+_lifecycle_apply() {
+    local program=$1
+    shift
+    local now tmp
+    now=$(get_iso_timestamp)
+    [[ -f "$GITHUB_LIFECYCLE_STATE_FILE" ]] || return 1
+    tmp=$(mktemp "${GITHUB_LIFECYCLE_STATE_FILE}.XXXXXX") || return 1
+    if jq --arg now "$now" "$@" "($program) | .updated_at = \$now" "$GITHUB_LIFECYCLE_STATE_FILE" > "$tmp" 2>/dev/null; then
+        mv "$tmp" "$GITHUB_LIFECYCLE_STATE_FILE"
+        return 0
+    fi
+    rm -f "$tmp"
+    return 1
+}
+
+# lifecycle_get <jq_filter>  -> read a value from the state file (raw output)
+lifecycle_get() {
+    [[ -f "$GITHUB_LIFECYCLE_STATE_FILE" ]] || { echo ""; return 1; }
+    jq -r "$1 // empty" "$GITHUB_LIFECYCLE_STATE_FILE" 2>/dev/null
+}
+
+# init_github_lifecycle <issue_ref> [title]
+# Parses the reference, writes initial lifecycle state, and exports
+# GITHUB_ISSUE_NUMBER / GITHUB_ISSUE_REPO for the rest of the run.
+# Returns 1 (without writing state) if the reference is unparseable.
+init_github_lifecycle() {
+    local ref="$1" title="${2:-}"
+    local parsed number repo
+    if ! parsed=$(parse_issue_reference "$ref"); then
+        _lifecycle_log "WARN" "Invalid --github-issue reference: '$ref' (expected N, #N, owner/repo#N, or an issue URL)"
+        return 1
+    fi
+    number=$(printf '%s' "$parsed" | cut -f1)
+    repo=$(printf '%s' "$parsed" | cut -f2)
+
+    GITHUB_ISSUE_NUMBER="$number"
+    GITHUB_ISSUE_REPO="$repo"
+
+    mkdir -p "$(dirname "$GITHUB_LIFECYCLE_STATE_FILE")" 2>/dev/null
+    local now
+    now=$(get_iso_timestamp)
+    jq -n \
+        --arg number "$number" \
+        --arg repo "$repo" \
+        --arg title "$title" \
+        --arg now "$now" \
+        '{
+            issue: { number: ($number | tonumber), repo: $repo, title: $title },
+            lifecycle: {
+                initialized_at: $now,
+                last_progress_comment: null,
+                progress_comments_posted: 0,
+                completion_detected_at: null,
+                pr_created: false,
+                pr_url: null,
+                issue_closed: false,
+                followups_created: []
+            },
+            updated_at: $now
+        }' > "$GITHUB_LIFECYCLE_STATE_FILE" 2>/dev/null || {
+            _lifecycle_log "WARN" "Could not initialize GitHub lifecycle state file"
+            return 1
+        }
+
+    _lifecycle_log "INFO" "🔗 GitHub issue lifecycle tracking #${number}${repo:+ ($repo)}"
+    return 0
+}
+
+# --- content generators -----------------------------------------------------
+
+# _fix_plan_file -> path to the active fix_plan.md
+_fix_plan_file() {
+    echo "${RALPH_DIR}/fix_plan.md"
+}
+
+# generate_progress_comment <loop_count>
+# Markdown progress update: completed vs remaining tasks (from fix_plan.md),
+# files changed so far, and the loop number.
+generate_progress_comment() {
+    local loop_count="$1"
+    local plan
+    plan="$(_fix_plan_file)"
+
+    local completed remaining
+    completed=$(grep -cE "^[[:space:]]*- \[[xX]\]" "$plan" 2>/dev/null | tr -d '[:space:]'); completed="${completed:-0}"
+    remaining=$(grep -cE "^[[:space:]]*- \[ \]" "$plan" 2>/dev/null | tr -d '[:space:]'); remaining="${remaining:-0}"
+
+    local files
+    files=$(git diff --name-only HEAD 2>/dev/null; git diff --name-only --cached 2>/dev/null)
+    files=$(printf '%s\n' "$files" | sed '/^$/d' | sort -u)
+    local file_lines
+    if [[ -n "$files" ]]; then
+        file_lines=$(printf '%s\n' "$files" | head -20 | sed 's/^/- `/; s/$/`/')
+    else
+        file_lines="_No tracked changes since last commit._"
+    fi
+
+    cat <<EOF
+## 🔄 Ralph progress update — loop #${loop_count}
+
+**Tasks:** ${completed} completed, ${remaining} remaining (in \`fix_plan.md\`)
+
+### Files changed
+${file_lines}
+
+---
+*Posted automatically by Ralph's autonomous development loop.*
+EOF
+}
+
+# generate_completion_summary
+# Markdown summary posted when the issue is closed / PR is opened.
+generate_completion_summary() {
+    local plan
+    plan="$(_fix_plan_file)"
+
+    local completed_tasks
+    completed_tasks=$(grep -E "^[[:space:]]*- \[[xX]\]" "$plan" 2>/dev/null | sed 's/^[[:space:]]*//' | head -30)
+    [[ -z "$completed_tasks" ]] && completed_tasks="_(no completed tasks recorded)_"
+
+    local diffstat
+    diffstat=$(git diff --shortstat HEAD~1 2>/dev/null)
+    [[ -z "$diffstat" ]] && diffstat=$(git diff --shortstat 2>/dev/null)
+    [[ -z "$diffstat" ]] && diffstat="(no diff stats available)"
+
+    cat <<EOF
+## ✅ Ralph completed development
+
+### Completed tasks
+${completed_tasks}
+
+### Changes
+${diffstat}
+
+---
+*Posted automatically by Ralph's autonomous development loop.*
+EOF
+}
+
+# scan_for_todos
+# Scan lines ADDED in the working tree / last commit for TODO/FIXME/HACK/XXX
+# markers. Prints one "file: marker text" per line (deduplicated).
+scan_for_todos() {
+    local diff
+    diff=$(git diff -U0 HEAD 2>/dev/null; git diff -U0 --cached 2>/dev/null; git diff -U0 HEAD~1 HEAD 2>/dev/null)
+    printf '%s\n' "$diff" \
+        | grep -E "^\+" \
+        | grep -vE "^\+\+\+" \
+        | grep -oiE "(TODO|FIXME|HACK|XXX):?.*" \
+        | sed 's/[[:space:]]*$//' \
+        | sort -u
+}
+
+# --- orchestration (always returns 0: graceful degradation) -----------------
+
+# lifecycle_post_progress <loop_count>
+# Posts a progress comment when COMMENT_PROGRESS=true and the loop number is a
+# multiple of COMMENT_INTERVAL. No-op otherwise. Never fails the loop.
+lifecycle_post_progress() {
+    local loop_count="$1"
+    [[ "${COMMENT_PROGRESS:-false}" == "true" ]] || return 0
+    [[ -n "${GITHUB_ISSUE_NUMBER:-}" ]] || return 0
+
+    local interval="${COMMENT_INTERVAL:-5}"
+    [[ "$interval" =~ ^[0-9]+$ ]] && [[ "$interval" -gt 0 ]] || interval=5
+    [[ $((loop_count % interval)) -eq 0 ]] || return 0
+
+    local body
+    body="$(generate_progress_comment "$loop_count")"
+    if gh_issue_comment "$GITHUB_ISSUE_NUMBER" "${GITHUB_ISSUE_REPO:-}" "$body"; then
+        _lifecycle_apply '.lifecycle.last_progress_comment = $now
+            | .lifecycle.progress_comments_posted += 1' >/dev/null 2>&1 || true
+    fi
+    return 0
+}
+
+# lifecycle_on_completion
+# Runs the completion workflow in order: summary comment, PR creation, follow-up
+# issues, then issue close (+ labels). Each step is guarded by its own flag and
+# degrades gracefully. Never fails the loop.
+lifecycle_on_completion() {
+    [[ -n "${GITHUB_ISSUE_NUMBER:-}" ]] || return 0
+    local number="$GITHUB_ISSUE_NUMBER"
+    local repo="${GITHUB_ISSUE_REPO:-}"
+
+    _lifecycle_apply '.lifecycle.completion_detected_at = $now' >/dev/null 2>&1 || true
+
+    local summary
+    summary="$(generate_completion_summary)"
+
+    # 1. Summary comment (when closing with a summary, or always if requested)
+    if [[ "${CLOSE_SUMMARY:-false}" == "true" ]]; then
+        gh_issue_comment "$number" "$repo" "$summary" || true
+    fi
+
+    # 2. Pull request linked to the issue
+    if [[ "${CREATE_PR:-false}" == "true" ]]; then
+        local title="${GITHUB_PR_TITLE:-}"
+        [[ -z "$title" ]] && title="$(lifecycle_get '.issue.title')"
+        [[ -z "$title" ]] && title="Ralph: resolve issue #${number}"
+        local pr_body="$summary"
+        if [[ "${LINK_ISSUE:-false}" == "true" ]]; then
+            pr_body="$summary"$'\n\n'"Closes #${number}"
+        fi
+        # Best-effort push of the current branch so gh has something to open a PR from.
+        local branch=""
+        branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || branch=""
+        if [[ -n "$branch" && "$branch" != "HEAD" ]]; then
+            git push -u origin "$branch" >/dev/null 2>&1 || true
+        fi
+        local pr_url
+        if pr_url=$(gh_create_pr "$title" "$pr_body" "${DRAFT_PR:-false}" "$repo"); then
+            _lifecycle_apply '.lifecycle.pr_created = true | .lifecycle.pr_url = $url' \
+                --arg url "$pr_url" >/dev/null 2>&1 || true
+        fi
+    fi
+
+    # 3. Follow-up issues for discovered TODOs (grouped into one issue)
+    if [[ "${CREATE_FOLLOWUPS:-false}" == "true" ]]; then
+        local todos
+        todos="$(scan_for_todos)"
+        if [[ -n "$todos" ]]; then
+            local fbody
+            fbody="$(cat <<EOF
+Follow-up work discovered while resolving #${number}:
+
+$(printf '%s\n' "$todos" | sed 's/^/- /')
+
+---
+*Auto-generated by Ralph from TODO/FIXME markers added during development.*
+EOF
+)"
+            local furl
+            if furl=$(gh_create_issue "Follow-up: TODOs from #${number}" "$fbody" "${FOLLOWUP_LABEL:-tech-debt}" "$repo"); then
+                _lifecycle_apply '.lifecycle.followups_created += [$url]' \
+                    --arg url "$furl" >/dev/null 2>&1 || true
+            fi
+        else
+            _lifecycle_log "INFO" "No TODO/FIXME markers found for follow-up issues"
+        fi
+    fi
+
+    # 4. Close the issue (+ optional completion labels)
+    if [[ "${AUTO_CLOSE:-false}" == "true" ]]; then
+        if [[ -n "${ADD_COMPLETION_LABELS:-}" ]]; then
+            gh_add_labels "$number" "$repo" "$ADD_COMPLETION_LABELS" || true
+        fi
+        if gh_close_issue "$number" "$repo"; then
+            _lifecycle_apply '.lifecycle.issue_closed = true' >/dev/null 2>&1 || true
+        fi
+    fi
+
+    return 0
+}

--- a/ralph_loop.sh
+++ b/ralph_loop.sh
@@ -502,6 +502,20 @@ setup_tmux_session() {
     if [[ "$ENABLE_BACKUP" == "true" ]]; then
         ralph_cmd="$ralph_cmd --backup"
     fi
+    # Forward GitHub issue lifecycle flags (Issue #73) so --monitor preserves them
+    if [[ -n "${GITHUB_ISSUE:-}" ]]; then
+        ralph_cmd="$ralph_cmd --github-issue '$GITHUB_ISSUE'"
+        [[ "$COMMENT_PROGRESS" == "true" ]] && ralph_cmd="$ralph_cmd --comment-progress"
+        [[ "$COMMENT_INTERVAL" != "5" ]] && ralph_cmd="$ralph_cmd --comment-interval $COMMENT_INTERVAL"
+        [[ "$AUTO_CLOSE" == "true" ]] && ralph_cmd="$ralph_cmd --auto-close"
+        [[ "$CLOSE_SUMMARY" == "true" ]] && ralph_cmd="$ralph_cmd --close-summary"
+        [[ "$CREATE_PR" == "true" ]] && ralph_cmd="$ralph_cmd --create-pr"
+        [[ "$LINK_ISSUE" == "true" ]] && ralph_cmd="$ralph_cmd --link-issue"
+        [[ "$DRAFT_PR" == "true" ]] && ralph_cmd="$ralph_cmd --draft-pr"
+        [[ "$CREATE_FOLLOWUPS" == "true" ]] && ralph_cmd="$ralph_cmd --create-followups"
+        [[ "$FOLLOWUP_LABEL" != "tech-debt" ]] && ralph_cmd="$ralph_cmd --followup-label '$FOLLOWUP_LABEL'"
+        [[ -n "$ADD_COMPLETION_LABELS" ]] && ralph_cmd="$ralph_cmd --add-label '$ADD_COMPLETION_LABELS'"
+    fi
 
     # Chain tmux kill-session after the loop command so the entire tmux
     # session is torn down when the Ralph loop exits (graceful completion,

--- a/ralph_loop.sh
+++ b/ralph_loop.sh
@@ -16,6 +16,7 @@ source "$SCRIPT_DIR/lib/response_analyzer.sh" || { echo "FATAL: Failed to source
 source "$SCRIPT_DIR/lib/circuit_breaker.sh" || { echo "FATAL: Failed to source lib/circuit_breaker.sh" >&2; exit 1; }
 source "$SCRIPT_DIR/lib/file_protection.sh" || { echo "FATAL: Failed to source lib/file_protection.sh" >&2; exit 1; }
 source "$SCRIPT_DIR/lib/log_utils.sh" || { echo "FATAL: Failed to source lib/log_utils.sh" >&2; exit 1; }
+source "$SCRIPT_DIR/lib/github_lifecycle.sh" || { echo "FATAL: Failed to source lib/github_lifecycle.sh" >&2; exit 1; }
 
 # Configuration
 # Ralph-specific files live in .ralph/ subfolder
@@ -53,6 +54,19 @@ _env_RALPH_SHELL_INIT_FILE="${RALPH_SHELL_INIT_FILE:-}"
 _env_ENABLE_NOTIFICATIONS="${ENABLE_NOTIFICATIONS:-}"
 _env_ENABLE_BACKUP="${ENABLE_BACKUP:-}"
 _env_LIVE_SHOW_TOOL_ARGS="${LIVE_SHOW_TOOL_ARGS:-}"
+_env_OPTIONAL_SECTIONS="${OPTIONAL_SECTIONS:-}"
+# Issue #73: GitHub issue lifecycle configuration
+_env_GITHUB_ISSUE="${GITHUB_ISSUE:-}"
+_env_COMMENT_PROGRESS="${COMMENT_PROGRESS:-}"
+_env_COMMENT_INTERVAL="${COMMENT_INTERVAL:-}"
+_env_AUTO_CLOSE="${AUTO_CLOSE:-}"
+_env_CLOSE_SUMMARY="${CLOSE_SUMMARY:-}"
+_env_CREATE_PR="${CREATE_PR:-}"
+_env_LINK_ISSUE="${LINK_ISSUE:-}"
+_env_DRAFT_PR="${DRAFT_PR:-}"
+_env_CREATE_FOLLOWUPS="${CREATE_FOLLOWUPS:-}"
+_env_FOLLOWUP_LABEL="${FOLLOWUP_LABEL:-}"
+_env_ADD_COMPLETION_LABELS="${ADD_COMPLETION_LABELS:-}"
 
 # Now set defaults (only if not already set by environment)
 MAX_CALLS_PER_HOUR="${MAX_CALLS_PER_HOUR:-100}"
@@ -76,6 +90,21 @@ DRY_RUN="${DRY_RUN:-false}"                      # Simulate loop without making 
 ENABLE_NOTIFICATIONS="${ENABLE_NOTIFICATIONS:-false}"  # Enable desktop notifications; set true or use --notify flag
 ENABLE_BACKUP="${ENABLE_BACKUP:-false}"               # Enable automatic git backups before each loop; set true or use --backup flag
 LIVE_SHOW_TOOL_ARGS="${LIVE_SHOW_TOOL_ARGS:-false}"  # Show tool arguments in live streaming output (file paths, commands, patterns)
+# Issue #239: comma-separated fix_plan.md section titles whose unchecked items do NOT block the
+# plan-complete exit (case-insensitive). Lets users mark truly optional/future work as non-blocking.
+OPTIONAL_SECTIONS="${OPTIONAL_SECTIONS:-Optional,Future,Future Enhancements,Nice to Have}"
+# Issue #73: GitHub issue lifecycle management (all opt-in; require --github-issue)
+GITHUB_ISSUE="${GITHUB_ISSUE:-}"                       # Issue reference: N, #N, owner/repo#N, or URL
+COMMENT_PROGRESS="${COMMENT_PROGRESS:-false}"          # Post progress comments during development
+COMMENT_INTERVAL="${COMMENT_INTERVAL:-5}"              # Post a progress comment every N loops
+AUTO_CLOSE="${AUTO_CLOSE:-false}"                      # Close the issue on graceful completion
+CLOSE_SUMMARY="${CLOSE_SUMMARY:-false}"                # Post a summary comment on completion
+CREATE_PR="${CREATE_PR:-false}"                        # Create a PR on completion
+LINK_ISSUE="${LINK_ISSUE:-false}"                      # Add "Closes #N" to the PR body
+DRAFT_PR="${DRAFT_PR:-false}"                          # Create the PR as a draft
+CREATE_FOLLOWUPS="${CREATE_FOLLOWUPS:-false}"          # Open a follow-up issue for discovered TODOs
+FOLLOWUP_LABEL="${FOLLOWUP_LABEL:-tech-debt}"          # Label applied to follow-up issues
+ADD_COMPLETION_LABELS="${ADD_COMPLETION_LABELS:-}"     # Comma-separated labels added to the issue on close
 
 # Session management configuration (Phase 1.2)
 # Note: SESSION_EXPIRATION_SECONDS is defined in lib/response_analyzer.sh (86400 = 24 hours)
@@ -135,6 +164,52 @@ _safe_count() {
     fi
 }
 
+# _count_blocking_unchecked - Count unchecked "- [ ]" items that BLOCK the plan-complete exit.
+# Issue #239: unchecked items under "Optional"/"Future" sections do NOT block exit, resolving
+# the deadlock where Claude treats "Low Priority"/optional items as skippable while Ralph keeps
+# looping waiting for them. A heading marks its section optional when the heading title matches
+# (case-insensitive, trimmed) an entry in $OPTIONAL_SECTIONS (comma-separated). The optional
+# context persists into deeper subsections and closes at the next same-or-higher-level heading.
+# With no optional sections configured (or none present) this counts every unchecked item, so
+# behavior is identical to the previous full-file count (backward compatible).
+# Usage: count=$(_count_blocking_unchecked "$file")
+_count_blocking_unchecked() {
+    local file="$1"
+    [[ ! -f "$file" ]] && { printf '0'; return 0; }
+    local raw
+    raw=$(awk -v sections="${OPTIONAL_SECTIONS:-}" '
+        BEGIN {
+            n = split(sections, arr, ",")
+            for (i = 1; i <= n; i++) {
+                s = arr[i]
+                gsub(/^[ \t]+|[ \t]+$/, "", s)
+                if (s != "") opt[tolower(s)] = 1
+            }
+        }
+        # ATX heading (requires "# " — a space after the #s): track optional context by level
+        /^[[:space:]]*#+[[:space:]]+/ {
+            line = $0
+            sub(/^[[:space:]]+/, "", line)
+            level = 0
+            while (substr(line, level + 1, 1) == "#") level++
+            title = substr(line, level + 1)
+            sub(/^[[:space:]]+/, "", title)
+            sub(/[[:space:]]+$/, "", title)
+            if (optional_active && level <= optional_level) optional_active = 0
+            if (tolower(title) in opt) { optional_active = 1; optional_level = level }
+            next
+        }
+        # Unchecked checkbox outside any optional section blocks exit
+        !optional_active && /^[[:space:]]*- \[ \]/ { count++ }
+        END { print count + 0 }
+    ' "$file" 2>/dev/null | tr -d '\r\n[:space:]' | head -c 10)
+    if [[ "$raw" =~ ^[0-9]+$ ]]; then
+        printf '%d' "$raw"
+    else
+        printf '0'
+    fi
+}
+
 # .ralphrc configuration file
 RALPHRC_FILE=".ralphrc"
 RALPHRC_LOADED=false
@@ -159,6 +234,7 @@ RALPHRC_LOADED=false
 #   - CLAUDE_CODE_CMD (path or command for Claude Code CLI)
 #   - CLAUDE_AUTO_UPDATE (auto-update Claude CLI at startup)
 #   - RALPH_SHELL_INIT_FILE (shell init file to source before running claude)
+#   - OPTIONAL_SECTIONS (fix_plan.md sections whose unchecked items don't block exit, Issue #239)
 #
 load_ralphrc() {
     if [[ ! -f "$RALPHRC_FILE" ]]; then
@@ -204,6 +280,18 @@ load_ralphrc() {
     [[ -n "$_env_ENABLE_NOTIFICATIONS" ]] && ENABLE_NOTIFICATIONS="$_env_ENABLE_NOTIFICATIONS"
     [[ -n "$_env_ENABLE_BACKUP" ]] && ENABLE_BACKUP="$_env_ENABLE_BACKUP"
     [[ -n "$_env_LIVE_SHOW_TOOL_ARGS" ]] && LIVE_SHOW_TOOL_ARGS="$_env_LIVE_SHOW_TOOL_ARGS"
+    [[ -n "$_env_OPTIONAL_SECTIONS" ]] && OPTIONAL_SECTIONS="$_env_OPTIONAL_SECTIONS"
+    [[ -n "$_env_GITHUB_ISSUE" ]] && GITHUB_ISSUE="$_env_GITHUB_ISSUE"
+    [[ -n "$_env_COMMENT_PROGRESS" ]] && COMMENT_PROGRESS="$_env_COMMENT_PROGRESS"
+    [[ -n "$_env_COMMENT_INTERVAL" ]] && COMMENT_INTERVAL="$_env_COMMENT_INTERVAL"
+    [[ -n "$_env_AUTO_CLOSE" ]] && AUTO_CLOSE="$_env_AUTO_CLOSE"
+    [[ -n "$_env_CLOSE_SUMMARY" ]] && CLOSE_SUMMARY="$_env_CLOSE_SUMMARY"
+    [[ -n "$_env_CREATE_PR" ]] && CREATE_PR="$_env_CREATE_PR"
+    [[ -n "$_env_LINK_ISSUE" ]] && LINK_ISSUE="$_env_LINK_ISSUE"
+    [[ -n "$_env_DRAFT_PR" ]] && DRAFT_PR="$_env_DRAFT_PR"
+    [[ -n "$_env_CREATE_FOLLOWUPS" ]] && CREATE_FOLLOWUPS="$_env_CREATE_FOLLOWUPS"
+    [[ -n "$_env_FOLLOWUP_LABEL" ]] && FOLLOWUP_LABEL="$_env_FOLLOWUP_LABEL"
+    [[ -n "$_env_ADD_COMPLETION_LABELS" ]] && ADD_COMPLETION_LABELS="$_env_ADD_COMPLETION_LABELS"
 
     RALPHRC_LOADED=true
     return 0
@@ -778,11 +866,13 @@ should_exit_gracefully() {
     # 5. Check fix_plan.md for completion
     # Fix #144: Only match valid markdown checkboxes, not date entries like [2026-01-29]
     # Valid patterns: "- [ ]" (uncompleted) and "- [x]" or "- [X]" (completed)
+    # Issue #239: unchecked items under OPTIONAL_SECTIONS (Optional/Future/...) do NOT block
+    # exit, so _count_blocking_unchecked is used instead of a full-file unchecked count.
     if [[ -f "$RALPH_DIR/fix_plan.md" ]]; then
         # Use _safe_count to avoid arithmetic crash on CRLF / no-match (issues #255, #251, #260)
         local uncompleted_items
         local completed_items
-        uncompleted_items=$(_safe_count "^[[:space:]]*- \[ \]" "$RALPH_DIR/fix_plan.md")
+        uncompleted_items=$(_count_blocking_unchecked "$RALPH_DIR/fix_plan.md")
         completed_items=$(_safe_count "^[[:space:]]*- \[[xX]\]" "$RALPH_DIR/fix_plan.md")
         local total_items=$((uncompleted_items + completed_items))
 
@@ -2196,6 +2286,18 @@ main() {
     # _cli_ENABLE_BACKUP is set only when --backup / -b was explicitly passed
     [[ "${_cli_ENABLE_BACKUP:-false}" == "true" ]] && ENABLE_BACKUP=true
     [[ "${_cli_LIVE_SHOW_TOOL_ARGS:-false}" == "true" ]] && LIVE_SHOW_TOOL_ARGS=true
+    # GitHub issue lifecycle flags (Issue #73) — CLI overrides .ralphrc
+    [[ -n "${_cli_GITHUB_ISSUE:-}" ]] && GITHUB_ISSUE="$_cli_GITHUB_ISSUE"
+    [[ "${_cli_COMMENT_PROGRESS:-false}" == "true" ]] && COMMENT_PROGRESS=true
+    [[ -n "${_cli_COMMENT_INTERVAL:-}" ]] && COMMENT_INTERVAL="$_cli_COMMENT_INTERVAL"
+    [[ "${_cli_AUTO_CLOSE:-false}" == "true" ]] && AUTO_CLOSE=true
+    [[ "${_cli_CLOSE_SUMMARY:-false}" == "true" ]] && CLOSE_SUMMARY=true
+    [[ "${_cli_CREATE_PR:-false}" == "true" ]] && CREATE_PR=true
+    [[ "${_cli_LINK_ISSUE:-false}" == "true" ]] && LINK_ISSUE=true
+    [[ "${_cli_DRAFT_PR:-false}" == "true" ]] && DRAFT_PR=true
+    [[ "${_cli_CREATE_FOLLOWUPS:-false}" == "true" ]] && CREATE_FOLLOWUPS=true
+    [[ -n "${_cli_FOLLOWUP_LABEL:-}" ]] && FOLLOWUP_LABEL="$_cli_FOLLOWUP_LABEL"
+    [[ -n "${_cli_ADD_COMPLETION_LABELS:-}" ]] && ADD_COMPLETION_LABELS="$_cli_ADD_COMPLETION_LABELS"
 
     # Source user shell init file if configured (e.g. ~/.zshrc for zsh environments)
     # This allows non-bash shells or non-standard setups to export PATH/env vars
@@ -2260,6 +2362,16 @@ main() {
 
     # Initialize session tracking before entering the loop
     init_session_tracking
+
+    # Initialize GitHub issue lifecycle tracking if an issue was provided (Issue #73)
+    if [[ -n "$GITHUB_ISSUE" ]]; then
+        if init_github_lifecycle "$GITHUB_ISSUE"; then
+            log_status "INFO" "GitHub issue lifecycle enabled for: $GITHUB_ISSUE"
+        else
+            log_status "WARN" "Disabling GitHub issue lifecycle (invalid reference): $GITHUB_ISSUE"
+            GITHUB_ISSUE=""
+        fi
+    fi
 
     # Reset exit signals to prevent stale state from prior run causing premature exit (Issue #194)
     # This is unconditional: regardless of how the previous run ended (crash, SIGKILL, API limit exit),
@@ -2365,6 +2477,12 @@ main() {
             log_status "INFO" "  - Exit reason: $exit_reason"
             print_metrics_summary
 
+            # GitHub issue lifecycle completion workflow (Issue #73): summary, PR,
+            # follow-ups, close. Each step is opt-in and degrades gracefully.
+            if [[ -n "$GITHUB_ISSUE" ]]; then
+                lifecycle_on_completion
+            fi
+
             break
         fi
         
@@ -2399,6 +2517,11 @@ main() {
         if [ $exec_result -eq 0 ]; then
             update_status "$loop_count" "$(cat "$CALL_COUNT_FILE")" "completed" "success"
             send_notification "Ralph - Loop Complete" "Loop #$loop_count completed successfully"
+
+            # Post a GitHub progress comment every COMMENT_INTERVAL loops (Issue #73)
+            if [[ -n "$GITHUB_ISSUE" ]]; then
+                lifecycle_post_progress "$loop_count"
+            fi
 
             # Brief pause between successful executions
             sleep 5
@@ -2498,6 +2621,19 @@ Batch processing / issue queue (Issue #72; see 'ralph-queue --help'):
     --queue-next            Print the id of the next ready queued issue
     --queue-clear           Remove all items from the queue
     --queue-remove <id|N>   Remove one item from the queue by id or issue number
+
+GitHub issue lifecycle (Issue #73; all opt-in, require --github-issue):
+    --github-issue REF      Track a GitHub issue (N, #N, owner/repo#N, or URL)
+    --comment-progress      Post progress comments to the issue during development
+    --comment-interval NUM  Post a progress comment every NUM loops (default: $COMMENT_INTERVAL)
+    --auto-close            Close the issue on graceful completion
+    --close-summary         Post a summary comment on completion
+    --create-pr             Create a pull request on completion
+    --link-issue            Add "Closes #N" to the PR body (with --create-pr)
+    --draft-pr              Create the PR as a draft (with --create-pr)
+    --create-followups      Open a follow-up issue for TODO/FIXME markers added during dev
+    --followup-label LABEL  Label for follow-up issues (default: $FOLLOWUP_LABEL)
+    --add-label LABEL       Label to add to the issue on close (repeatable)
 
 Modern CLI Options (Phase 1.1):
     --output-format FORMAT  Set Claude output format: json or text (default: $CLAUDE_OUTPUT_FORMAT)
@@ -2659,6 +2795,72 @@ while [[ $# -gt 0 ]]; do
             source "$SCRIPT_DIR/lib/date_utils.sh"
             rollback_to_backup "${2:-}"
             exit $?
+            ;;
+        --github-issue)
+            # GitHub issue lifecycle management (Issue #73)
+            GITHUB_ISSUE="$2"
+            _cli_GITHUB_ISSUE="$2"
+            shift 2
+            ;;
+        --comment-progress)
+            COMMENT_PROGRESS=true
+            _cli_COMMENT_PROGRESS=true
+            shift
+            ;;
+        --comment-interval)
+            if [[ "$2" =~ ^[1-9][0-9]*$ ]]; then
+                COMMENT_INTERVAL="$2"
+                _cli_COMMENT_INTERVAL="$2"
+            else
+                echo "Error: --comment-interval must be a positive integer"
+                exit 1
+            fi
+            shift 2
+            ;;
+        --auto-close)
+            AUTO_CLOSE=true
+            _cli_AUTO_CLOSE=true
+            shift
+            ;;
+        --close-summary)
+            CLOSE_SUMMARY=true
+            _cli_CLOSE_SUMMARY=true
+            shift
+            ;;
+        --create-pr)
+            CREATE_PR=true
+            _cli_CREATE_PR=true
+            shift
+            ;;
+        --link-issue)
+            LINK_ISSUE=true
+            _cli_LINK_ISSUE=true
+            shift
+            ;;
+        --draft-pr)
+            DRAFT_PR=true
+            _cli_DRAFT_PR=true
+            shift
+            ;;
+        --create-followups)
+            CREATE_FOLLOWUPS=true
+            _cli_CREATE_FOLLOWUPS=true
+            shift
+            ;;
+        --followup-label)
+            FOLLOWUP_LABEL="$2"
+            _cli_FOLLOWUP_LABEL="$2"
+            shift 2
+            ;;
+        --add-label)
+            # Repeatable: accumulate into a comma-separated list
+            if [[ -n "$ADD_COMPLETION_LABELS" ]]; then
+                ADD_COMPLETION_LABELS="${ADD_COMPLETION_LABELS},$2"
+            else
+                ADD_COMPLETION_LABELS="$2"
+            fi
+            _cli_ADD_COMPLETION_LABELS="$ADD_COMPLETION_LABELS"
+            shift 2
             ;;
         --queue-status)
             # Batch processing / issue queue management (Issue #72)

--- a/templates/fix_plan.md
+++ b/templates/fix_plan.md
@@ -18,6 +18,13 @@
 - [ ] Integration with external services
 - [ ] Advanced error recovery
 
+## Optional
+<!-- Issue #239: unchecked items in this section (and "Future"/"Future Enhancements"/
+     "Nice to Have") do NOT block Ralph's exit. Use it for genuinely optional/future work
+     so Ralph can finish once the required sections above are complete. Configure the section
+     names via OPTIONAL_SECTIONS in .ralphrc. -->
+- [ ] Nice-to-have enhancements (non-blocking)
+
 ## Completed
 - [x] Project initialization
 

--- a/tests/integration/test_tmux_integration.bats
+++ b/tests/integration/test_tmux_integration.bats
@@ -144,6 +144,20 @@ setup_tmux_session() {
     if [[ "$ENABLE_BACKUP" == "true" ]]; then
         ralph_cmd="$ralph_cmd --backup"
     fi
+    # Forward GitHub issue lifecycle flags (Issue #73) so --monitor preserves them
+    if [[ -n "${GITHUB_ISSUE:-}" ]]; then
+        ralph_cmd="$ralph_cmd --github-issue '$GITHUB_ISSUE'"
+        [[ "${COMMENT_PROGRESS:-false}" == "true" ]] && ralph_cmd="$ralph_cmd --comment-progress"
+        [[ "${COMMENT_INTERVAL:-5}" != "5" ]] && ralph_cmd="$ralph_cmd --comment-interval $COMMENT_INTERVAL"
+        [[ "${AUTO_CLOSE:-false}" == "true" ]] && ralph_cmd="$ralph_cmd --auto-close"
+        [[ "${CLOSE_SUMMARY:-false}" == "true" ]] && ralph_cmd="$ralph_cmd --close-summary"
+        [[ "${CREATE_PR:-false}" == "true" ]] && ralph_cmd="$ralph_cmd --create-pr"
+        [[ "${LINK_ISSUE:-false}" == "true" ]] && ralph_cmd="$ralph_cmd --link-issue"
+        [[ "${DRAFT_PR:-false}" == "true" ]] && ralph_cmd="$ralph_cmd --draft-pr"
+        [[ "${CREATE_FOLLOWUPS:-false}" == "true" ]] && ralph_cmd="$ralph_cmd --create-followups"
+        [[ "${FOLLOWUP_LABEL:-tech-debt}" != "tech-debt" ]] && ralph_cmd="$ralph_cmd --followup-label '$FOLLOWUP_LABEL'"
+        [[ -n "${ADD_COMPLETION_LABELS:-}" ]] && ralph_cmd="$ralph_cmd --add-label '$ADD_COMPLETION_LABELS'"
+    fi
 
     tmux send-keys -t "$session_name:${base_win}.${pane0}" "$ralph_cmd; tmux kill-session -t $session_name 2>/dev/null" Enter
 
@@ -439,6 +453,43 @@ assert_tmux_called_with() {
     local pane0_line
     pane0_line=$(grep -E "tmux send-keys -t [^ ]+\.0" "$TMUX_CALL_LOG" | head -1)
     [[ "$pane0_line" == *"--prompt"* ]]
+}
+
+# ==============================================================================
+# Issue #73: --monitor forwards GitHub issue lifecycle flags to the loop command
+# ==============================================================================
+
+@test "setup_tmux_session forwards GitHub lifecycle flags to loop command" {
+    export GITHUB_ISSUE="69"
+    export COMMENT_PROGRESS=true COMMENT_INTERVAL=3
+    export AUTO_CLOSE=true CREATE_PR=true LINK_ISSUE=true
+    export CREATE_FOLLOWUPS=true FOLLOWUP_LABEL=followup ADD_COMPLETION_LABELS=done
+
+    run setup_tmux_session
+    [ "$status" -eq 0 ]
+
+    local pane0_line
+    pane0_line=$(grep -E "tmux send-keys -t [^ ]+\.0" "$TMUX_CALL_LOG" | head -1)
+    [[ "$pane0_line" == *"--github-issue '69'"* ]]
+    [[ "$pane0_line" == *"--comment-progress"* ]]
+    [[ "$pane0_line" == *"--comment-interval 3"* ]]
+    [[ "$pane0_line" == *"--auto-close"* ]]
+    [[ "$pane0_line" == *"--create-pr"* ]]
+    [[ "$pane0_line" == *"--link-issue"* ]]
+    [[ "$pane0_line" == *"--create-followups"* ]]
+    [[ "$pane0_line" == *"--followup-label 'followup'"* ]]
+    [[ "$pane0_line" == *"--add-label 'done'"* ]]
+}
+
+@test "setup_tmux_session omits lifecycle flags when no issue is tracked" {
+    # No GITHUB_ISSUE set -> no lifecycle flags forwarded
+    run setup_tmux_session
+    [ "$status" -eq 0 ]
+
+    local pane0_line
+    pane0_line=$(grep -E "tmux send-keys -t [^ ]+\.0" "$TMUX_CALL_LOG" | head -1)
+    [[ "$pane0_line" != *"--github-issue"* ]]
+    [[ "$pane0_line" != *"--auto-close"* ]]
 }
 
 # ==============================================================================

--- a/tests/unit/test_cli_modern.bats
+++ b/tests/unit/test_cli_modern.bats
@@ -278,6 +278,31 @@ teardown() {
 }
 
 # =============================================================================
+# GITHUB ISSUE LIFECYCLE FLAGS (Issue #73)
+# =============================================================================
+
+@test "issue #73: GitHub lifecycle flags are accepted" {
+    local flags="--github-issue 42 --comment-progress --comment-interval 3 --auto-close --close-summary --create-pr --link-issue --draft-pr --create-followups --followup-label tech-debt --add-label done"
+    run bash -c "source ${BATS_TEST_DIRNAME}/../../ralph_loop.sh $flags --help 2>&1 || true"
+    [[ "$output" != *"Unknown option"* ]]
+}
+
+@test "issue #73: --comment-interval rejects non-positive values" {
+    run bash -c "source ${BATS_TEST_DIRNAME}/../../ralph_loop.sh --comment-interval 0 2>&1"
+    [[ $status -ne 0 ]]
+    [[ "$output" == *"comment-interval"* ]]
+}
+
+@test "issue #73: help text documents the lifecycle flags" {
+    run bash -c "source ${BATS_TEST_DIRNAME}/../../ralph_loop.sh --help 2>&1 || true"
+    [[ "$output" == *"--github-issue"* ]]
+    [[ "$output" == *"--comment-progress"* ]]
+    [[ "$output" == *"--auto-close"* ]]
+    [[ "$output" == *"--create-pr"* ]]
+    [[ "$output" == *"--create-followups"* ]]
+}
+
+# =============================================================================
 # BUILD_LOOP_CONTEXT TESTS
 # =============================================================================
 

--- a/tests/unit/test_exit_detection.bats
+++ b/tests/unit/test_exit_detection.bats
@@ -13,6 +13,8 @@ setup() {
     export RESPONSE_ANALYSIS_FILE="$RALPH_DIR/.response_analysis"
     export MAX_CONSECUTIVE_TEST_LOOPS=3
     export MAX_CONSECUTIVE_DONE_SIGNALS=2
+    # Issue #239: default optional sections (matches ralph_loop.sh default); tests may override
+    export OPTIONAL_SECTIONS="Optional,Future,Future Enhancements,Nice to Have"
 
     # Create temp test directory
     export TEST_TEMP_DIR="$(mktemp -d)"
@@ -26,6 +28,43 @@ setup() {
 teardown() {
     cd /
     rm -rf "$TEST_TEMP_DIR"
+}
+
+# Helper: _count_blocking_unchecked (extracted from ralph_loop.sh, Issue #239)
+# Counts unchecked "- [ ]" items that block exit, skipping items under OPTIONAL_SECTIONS.
+_count_blocking_unchecked() {
+    local file="$1"
+    [[ ! -f "$file" ]] && { printf '0'; return 0; }
+    local raw
+    raw=$(awk -v sections="${OPTIONAL_SECTIONS:-}" '
+        BEGIN {
+            n = split(sections, arr, ",")
+            for (i = 1; i <= n; i++) {
+                s = arr[i]
+                gsub(/^[ \t]+|[ \t]+$/, "", s)
+                if (s != "") opt[tolower(s)] = 1
+            }
+        }
+        /^[[:space:]]*#+[[:space:]]+/ {
+            line = $0
+            sub(/^[[:space:]]+/, "", line)
+            level = 0
+            while (substr(line, level + 1, 1) == "#") level++
+            title = substr(line, level + 1)
+            sub(/^[[:space:]]+/, "", title)
+            sub(/[[:space:]]+$/, "", title)
+            if (optional_active && level <= optional_level) optional_active = 0
+            if (tolower(title) in opt) { optional_active = 1; optional_level = level }
+            next
+        }
+        !optional_active && /^[[:space:]]*- \[ \]/ { count++ }
+        END { print count + 0 }
+    ' "$file" 2>/dev/null | tr -d '\r\n[:space:]' | head -c 10)
+    if [[ "$raw" =~ ^[0-9]+$ ]]; then
+        printf '%d' "$raw"
+    else
+        printf '0'
+    fi
 }
 
 # Helper function: should_exit_gracefully (extracted from ralph_loop.sh)
@@ -76,11 +115,11 @@ should_exit_gracefully() {
 
     # 4. Check fix_plan.md for completion
     # Fix #144: Only match valid markdown checkboxes, not date entries like [2026-01-29]
+    # Issue #239: unchecked items under OPTIONAL_SECTIONS do not block exit
     if [[ -f "$RALPH_DIR/fix_plan.md" ]]; then
         local uncompleted_items
         local completed_items
-        uncompleted_items=$(grep -cE "^[[:space:]]*- \[ \]" "$RALPH_DIR/fix_plan.md" 2>/dev/null || echo "0")
-        uncompleted_items=$(echo "$uncompleted_items" | tr -d '[:space:]')
+        uncompleted_items=$(_count_blocking_unchecked "$RALPH_DIR/fix_plan.md")
         completed_items=$(grep -cE "^[[:space:]]*- \[[xX]\]" "$RALPH_DIR/fix_plan.md" 2>/dev/null || echo "0")
         completed_items=$(echo "$completed_items" | tr -d '[:space:]')
         local total_items=$((uncompleted_items + completed_items))
@@ -182,6 +221,159 @@ EOF
 - [x] Task 1
 - [ ] Task 2
 - [ ] Task 3
+EOF
+
+    result=$(should_exit_gracefully || true)
+    assert_equal "$result" ""
+}
+
+# --- Issue #239: Optional/Future section support in fix_plan.md ---
+
+# Unchecked items under an Optional section do not block exit when required work is done
+@test "issue #239: exits when only Optional-section items remain unchecked" {
+    cat > "$RALPH_DIR/fix_plan.md" << 'EOF'
+# Fix Plan
+
+## High Priority
+- [x] Core feature implementation
+
+## Optional
+- [ ] Frontend integration
+- [ ] SMS verification
+EOF
+
+    result=$(should_exit_gracefully)
+    assert_equal "$result" "plan_complete"
+}
+
+# Unchecked items under a Future section also do not block exit
+@test "issue #239: exits when only Future-section items remain unchecked" {
+    cat > "$RALPH_DIR/fix_plan.md" << 'EOF'
+# Fix Plan
+
+## Medium Priority
+- [x] Additional features
+
+## Future Enhancements
+- [ ] Multi-language support
+EOF
+
+    result=$(should_exit_gracefully)
+    assert_equal "$result" "plan_complete"
+}
+
+# Unchecked items in a NON-optional section still block exit (backward compatible)
+@test "issue #239: still blocks when a required section has unchecked items" {
+    cat > "$RALPH_DIR/fix_plan.md" << 'EOF'
+# Fix Plan
+
+## High Priority
+- [x] Core feature
+
+## Low Priority
+- [ ] Configurable settings
+
+## Optional
+- [ ] Frontend integration
+EOF
+
+    result=$(should_exit_gracefully || true)
+    assert_equal "$result" ""
+}
+
+# Section matching is case-insensitive
+@test "issue #239: optional section match is case-insensitive" {
+    cat > "$RALPH_DIR/fix_plan.md" << 'EOF'
+# Fix Plan
+
+## Done
+- [x] Real work
+
+## OPTIONAL
+- [ ] Skippable extra
+EOF
+
+    result=$(should_exit_gracefully)
+    assert_equal "$result" "plan_complete"
+}
+
+# Optional context persists into deeper subsections...
+@test "issue #239: subsections under an optional section stay optional" {
+    cat > "$RALPH_DIR/fix_plan.md" << 'EOF'
+# Fix Plan
+
+## Core
+- [x] Implemented
+
+## Optional
+### Nice extras
+- [ ] Themeing
+- [ ] Animations
+EOF
+
+    result=$(should_exit_gracefully)
+    assert_equal "$result" "plan_complete"
+}
+
+# ...and a same-or-higher-level heading after an optional section ends optional context
+@test "issue #239: a following required section re-blocks after an optional one" {
+    cat > "$RALPH_DIR/fix_plan.md" << 'EOF'
+# Fix Plan
+
+## Core
+- [x] Implemented
+
+## Optional
+- [ ] Skippable
+
+## Cleanup
+- [ ] Required teardown
+EOF
+
+    result=$(should_exit_gracefully || true)
+    assert_equal "$result" ""
+}
+
+# OPTIONAL_SECTIONS is configurable; default names are NOT optional when overridden
+@test "issue #239: OPTIONAL_SECTIONS is configurable" {
+    export OPTIONAL_SECTIONS="Backlog"
+    cat > "$RALPH_DIR/fix_plan.md" << 'EOF'
+# Fix Plan
+
+## Core
+- [x] Implemented
+
+## Backlog
+- [ ] Someday item
+EOF
+
+    result=$(should_exit_gracefully)
+    assert_equal "$result" "plan_complete"
+}
+
+# With OPTIONAL_SECTIONS overridden, the default "Optional" header is no longer optional
+@test "issue #239: overriding OPTIONAL_SECTIONS drops the built-in defaults" {
+    export OPTIONAL_SECTIONS="Backlog"
+    cat > "$RALPH_DIR/fix_plan.md" << 'EOF'
+# Fix Plan
+
+## Core
+- [x] Implemented
+
+## Optional
+- [ ] Now required because defaults were overridden
+EOF
+
+    result=$(should_exit_gracefully || true)
+    assert_equal "$result" ""
+}
+
+# Backward compatibility: a plan with no optional sections behaves exactly as before
+@test "issue #239: no optional sections present preserves prior behavior" {
+    cat > "$RALPH_DIR/fix_plan.md" << 'EOF'
+# Fix Plan
+- [x] Task 1
+- [ ] Task 2
 EOF
 
     result=$(should_exit_gracefully || true)

--- a/tests/unit/test_github_lifecycle.bats
+++ b/tests/unit/test_github_lifecycle.bats
@@ -1,0 +1,334 @@
+#!/usr/bin/env bats
+# Unit tests for lib/github_lifecycle.sh (Issue #73)
+#
+# Covers GitHub issue lifecycle management: reference parsing, the gh wrappers
+# (comment/close/labels/PR/issue) via a mocked `gh` binary on PATH, content
+# generators (progress comment, completion summary, TODO scan), lifecycle state
+# read/write, and the orchestration helpers (progress interval gating, the
+# completion workflow ordering, and graceful degradation when gh fails).
+#
+# The `gh` mock records its args to a file so assertions survive `run`'s
+# subshell boundary — same pattern as test_github_import.bats.
+
+load '../helpers/test_helper'
+
+PROJECT_ROOT="${BATS_TEST_DIRNAME}/../.."
+
+setup() {
+    TEST_DIR="$(mktemp -d "${BATS_TEST_TMPDIR}/ghlifecycle.XXXXXX")"
+    cd "$TEST_DIR"
+
+    export RALPH_DIR="$TEST_DIR/.ralph"
+    export GITHUB_LIFECYCLE_STATE_FILE="$RALPH_DIR/.github_lifecycle_state"
+    mkdir -p "$RALPH_DIR"
+
+    # A clean default config (orchestration reads these globals)
+    export COMMENT_PROGRESS=false COMMENT_INTERVAL=5
+    export AUTO_CLOSE=false CLOSE_SUMMARY=false CREATE_PR=false LINK_ISSUE=false
+    export DRAFT_PR=false CREATE_FOLLOWUPS=false FOLLOWUP_LABEL=tech-debt
+    export ADD_COMPLETION_LABELS=""
+
+    source "$PROJECT_ROOT/lib/github_lifecycle.sh"
+}
+
+teardown() {
+    cd /
+    [[ -n "$TEST_DIR" && -d "$TEST_DIR" ]] && rm -rf "$TEST_DIR"
+}
+
+# Build a mock gh that records each invocation's args and the stdin body, and
+# can be told to fail. $1 = "ok" | "fail".
+_mock_gh() {
+    local mode="${1:-ok}"
+    mkdir -p "$TEST_DIR/mock_bin"
+    cat > "$TEST_DIR/mock_bin/gh" << EOF
+#!/bin/bash
+printf '%s\n' "\$*" >> "$TEST_DIR/gh_args"
+# Capture stdin body (comment/PR/issue use --body-file -)
+if [[ " \$* " == *" --body-file - "* ]]; then
+    cat >> "$TEST_DIR/gh_stdin"
+fi
+if [[ "$mode" == "fail" ]]; then
+    echo "permission denied" >&2
+    exit 1
+fi
+# pr create / issue create print a URL
+if [[ "\$1" == "pr" && "\$2" == "create" ]]; then echo "https://github.com/o/r/pull/100"; fi
+if [[ "\$1" == "issue" && "\$2" == "create" ]]; then echo "https://github.com/o/r/issues/200"; fi
+exit 0
+EOF
+    chmod +x "$TEST_DIR/mock_bin/gh"
+    export PATH="$TEST_DIR/mock_bin:$PATH"
+}
+
+_gh_args() { cat "$TEST_DIR/gh_args" 2>/dev/null; }
+
+# -----------------------------------------------------------------------------
+# parse_issue_reference
+# -----------------------------------------------------------------------------
+
+@test "parse_issue_reference: bare number" {
+    run parse_issue_reference "42"
+    assert_success
+    assert_output $'42\t'
+}
+
+@test "parse_issue_reference: #N form" {
+    run parse_issue_reference "#7"
+    assert_success
+    assert_output $'7\t'
+}
+
+@test "parse_issue_reference: owner/repo#N form" {
+    run parse_issue_reference "octo/cat#15"
+    assert_success
+    assert_output $'15\tocto/cat'
+}
+
+@test "parse_issue_reference: full issue URL" {
+    run parse_issue_reference "https://github.com/octo/cat/issues/123"
+    assert_success
+    assert_output $'123\tocto/cat'
+}
+
+@test "parse_issue_reference: rejects garbage" {
+    run parse_issue_reference "not-an-issue"
+    assert_failure
+}
+
+# -----------------------------------------------------------------------------
+# init / state
+# -----------------------------------------------------------------------------
+
+@test "init_github_lifecycle writes state and exports number/repo" {
+    init_github_lifecycle "octo/cat#15" "Fix the thing"
+    [[ -f "$GITHUB_LIFECYCLE_STATE_FILE" ]]
+    assert_equal "$(lifecycle_get '.issue.number')" "15"
+    assert_equal "$(lifecycle_get '.issue.repo')" "octo/cat"
+    assert_equal "$(lifecycle_get '.issue.title')" "Fix the thing"
+    assert_equal "$GITHUB_ISSUE_NUMBER" "15"
+    assert_equal "$GITHUB_ISSUE_REPO" "octo/cat"
+}
+
+@test "init_github_lifecycle fails on invalid reference and writes no state" {
+    run init_github_lifecycle "garbage"
+    assert_failure
+    [[ ! -f "$GITHUB_LIFECYCLE_STATE_FILE" ]]
+}
+
+@test "lifecycle state mutation is atomic and persists" {
+    init_github_lifecycle "5"
+    _lifecycle_apply '.lifecycle.progress_comments_posted = 3'
+    assert_equal "$(lifecycle_get '.lifecycle.progress_comments_posted')" "3"
+}
+
+# -----------------------------------------------------------------------------
+# gh wrappers
+# -----------------------------------------------------------------------------
+
+@test "gh_issue_comment posts body via --body-file and records issue number" {
+    _mock_gh ok
+    run gh_issue_comment "42" "" "Hello world"
+    assert_success
+    [[ "$(_gh_args)" == *"issue comment 42 --body-file -"* ]]
+    [[ "$(cat "$TEST_DIR/gh_stdin")" == *"Hello world"* ]]
+}
+
+@test "gh_issue_comment includes --repo when provided" {
+    _mock_gh ok
+    gh_issue_comment "42" "octo/cat" "hi"
+    [[ "$(_gh_args)" == *"--repo octo/cat"* ]]
+}
+
+@test "gh_issue_comment degrades gracefully when gh fails" {
+    _mock_gh fail
+    run gh_issue_comment "42" "" "hi"
+    assert_failure
+    [[ "$output" == *"Could not post comment"* ]]
+}
+
+@test "gh_close_issue closes the issue" {
+    _mock_gh ok
+    run gh_close_issue "42" ""
+    assert_success
+    [[ "$(_gh_args)" == *"issue close 42"* ]]
+}
+
+@test "gh_add_labels is a no-op for empty labels" {
+    _mock_gh ok
+    run gh_add_labels "42" "" ""
+    assert_success
+    [[ ! -f "$TEST_DIR/gh_args" ]]
+}
+
+@test "gh_add_labels passes labels to gh issue edit" {
+    _mock_gh ok
+    gh_add_labels "42" "" "completed,done"
+    [[ "$(_gh_args)" == *"issue edit 42 --add-label completed,done"* ]]
+}
+
+@test "gh_create_pr adds --draft only when requested and returns URL" {
+    _mock_gh ok
+    run gh_create_pr "My title" "body" "true" ""
+    assert_success
+    [[ "$output" == *"pull/100"* ]]
+    [[ "$(_gh_args)" == *"pr create --title My title --body-file - --draft"* ]]
+}
+
+@test "gh_create_pr omits --draft when not requested" {
+    _mock_gh ok
+    gh_create_pr "T" "b" "false" "" >/dev/null
+    [[ "$(_gh_args)" != *"--draft"* ]]
+}
+
+@test "gh_create_issue passes label and returns URL" {
+    _mock_gh ok
+    run gh_create_issue "Follow-up" "body" "tech-debt" ""
+    assert_success
+    [[ "$output" == *"issues/200"* ]]
+    [[ "$(_gh_args)" == *"issue create --title Follow-up --body-file - --label tech-debt"* ]]
+}
+
+# -----------------------------------------------------------------------------
+# content generators
+# -----------------------------------------------------------------------------
+
+@test "generate_progress_comment counts completed and remaining tasks" {
+    cat > "$RALPH_DIR/fix_plan.md" << 'EOF'
+# Plan
+- [x] Done one
+- [x] Done two
+- [ ] Pending one
+EOF
+    run generate_progress_comment 7
+    assert_success
+    [[ "$output" == *"loop #7"* ]]
+    [[ "$output" == *"2 completed, 1 remaining"* ]]
+}
+
+@test "generate_completion_summary lists completed tasks" {
+    cat > "$RALPH_DIR/fix_plan.md" << 'EOF'
+# Plan
+- [x] Implement feature
+- [ ] Not done
+EOF
+    run generate_completion_summary
+    assert_success
+    [[ "$output" == *"Implement feature"* ]]
+    [[ "$output" == *"Completed tasks"* ]]
+}
+
+@test "scan_for_todos finds TODO/FIXME markers in added lines" {
+    git init -q
+    git config user.email t@t.co; git config user.name t
+    echo "line" > code.txt
+    git add code.txt && git commit -qm init
+    printf 'line\n# TODO: wire up the thing\n# FIXME: handle errors\n' > code.txt
+    run scan_for_todos
+    assert_success
+    [[ "$output" == *"TODO: wire up the thing"* ]]
+    [[ "$output" == *"FIXME: handle errors"* ]]
+}
+
+# -----------------------------------------------------------------------------
+# orchestration: lifecycle_post_progress
+# -----------------------------------------------------------------------------
+
+@test "lifecycle_post_progress is a no-op when COMMENT_PROGRESS is false" {
+    _mock_gh ok
+    init_github_lifecycle "42"
+    COMMENT_PROGRESS=false
+    lifecycle_post_progress 5
+    [[ ! -f "$TEST_DIR/gh_args" ]]
+}
+
+@test "lifecycle_post_progress only posts on the interval boundary" {
+    _mock_gh ok
+    init_github_lifecycle "42"
+    COMMENT_PROGRESS=true COMMENT_INTERVAL=5
+    : > "$RALPH_DIR/fix_plan.md"
+    lifecycle_post_progress 3   # not a multiple of 5
+    [[ ! -f "$TEST_DIR/gh_args" ]]
+    lifecycle_post_progress 5   # boundary -> posts
+    [[ "$(_gh_args)" == *"issue comment 42"* ]]
+    assert_equal "$(lifecycle_get '.lifecycle.progress_comments_posted')" "1"
+}
+
+@test "lifecycle_post_progress never fails the loop when gh fails" {
+    _mock_gh fail
+    init_github_lifecycle "42"
+    COMMENT_PROGRESS=true COMMENT_INTERVAL=1
+    : > "$RALPH_DIR/fix_plan.md"
+    run lifecycle_post_progress 1
+    assert_success   # returns 0 despite gh failure
+}
+
+# -----------------------------------------------------------------------------
+# orchestration: lifecycle_on_completion
+# -----------------------------------------------------------------------------
+
+@test "lifecycle_on_completion does nothing when all flags are off" {
+    _mock_gh ok
+    init_github_lifecycle "42"
+    : > "$RALPH_DIR/fix_plan.md"
+    lifecycle_on_completion
+    # completion_detected_at is stamped, but no gh write operations happen
+    [[ ! -f "$TEST_DIR/gh_args" ]]
+    [[ -n "$(lifecycle_get '.lifecycle.completion_detected_at')" ]]
+}
+
+@test "lifecycle_on_completion closes issue and adds labels with --auto-close" {
+    _mock_gh ok
+    init_github_lifecycle "42"
+    : > "$RALPH_DIR/fix_plan.md"
+    AUTO_CLOSE=true ADD_COMPLETION_LABELS="completed"
+    lifecycle_on_completion
+    [[ "$(_gh_args)" == *"issue edit 42 --add-label completed"* ]]
+    [[ "$(_gh_args)" == *"issue close 42"* ]]
+    assert_equal "$(lifecycle_get '.lifecycle.issue_closed')" "true"
+}
+
+@test "lifecycle_on_completion adds Closes #N to PR body with --create-pr --link-issue" {
+    _mock_gh ok
+    init_github_lifecycle "42"
+    : > "$RALPH_DIR/fix_plan.md"
+    CREATE_PR=true LINK_ISSUE=true GITHUB_PR_TITLE="My PR"
+    lifecycle_on_completion
+    [[ "$(_gh_args)" == *"pr create --title My PR"* ]]
+    [[ "$(cat "$TEST_DIR/gh_stdin")" == *"Closes #42"* ]]
+    assert_equal "$(lifecycle_get '.lifecycle.pr_created')" "true"
+    assert_equal "$(lifecycle_get '.lifecycle.pr_url')" "https://github.com/o/r/pull/100"
+}
+
+@test "lifecycle_on_completion posts a summary comment with --close-summary" {
+    _mock_gh ok
+    init_github_lifecycle "42"
+    : > "$RALPH_DIR/fix_plan.md"
+    CLOSE_SUMMARY=true
+    lifecycle_on_completion
+    [[ "$(_gh_args)" == *"issue comment 42"* ]]
+    [[ "$(cat "$TEST_DIR/gh_stdin")" == *"Ralph completed development"* ]]
+}
+
+@test "lifecycle_on_completion creates a grouped follow-up issue when TODOs exist" {
+    _mock_gh ok
+    init_github_lifecycle "42"
+    git init -q; git config user.email t@t.co; git config user.name t
+    echo base > f.txt; git add f.txt; git commit -qm init
+    printf 'base\n// TODO: refactor later\n' > f.txt
+    CREATE_FOLLOWUPS=true FOLLOWUP_LABEL=tech-debt
+    lifecycle_on_completion
+    [[ "$(_gh_args)" == *"issue create --title Follow-up: TODOs from #42"* ]]
+    [[ "$(_gh_args)" == *"--label tech-debt"* ]]
+    assert_equal "$(lifecycle_get '.lifecycle.followups_created | length')" "1"
+}
+
+@test "lifecycle_on_completion skips follow-ups when no TODOs found" {
+    _mock_gh ok
+    init_github_lifecycle "42"
+    git init -q; git config user.email t@t.co; git config user.name t
+    echo clean > f.txt; git add f.txt; git commit -qm init
+    CREATE_FOLLOWUPS=true
+    lifecycle_on_completion
+    [[ "$(_gh_args 2>/dev/null)" != *"issue create"* ]]
+}

--- a/tests/unit/test_github_lifecycle.bats
+++ b/tests/unit/test_github_lifecycle.bats
@@ -228,6 +228,8 @@ EOF
     assert_success
     [[ "$output" == *"TODO: wire up the thing"* ]]
     [[ "$output" == *"FIXME: handle errors"* ]]
+    # Each marker is prefixed with the file it lives in (CodeRabbit nitpick)
+    [[ "$output" == *"code.txt: TODO: wire up the thing"* ]]
 }
 
 @test "scan_for_todos covers TODOs across all commits since lifecycle start (codex P2)" {

--- a/tests/unit/test_github_lifecycle.bats
+++ b/tests/unit/test_github_lifecycle.bats
@@ -230,6 +230,20 @@ EOF
     [[ "$output" == *"FIXME: handle errors"* ]]
 }
 
+@test "scan_for_todos covers TODOs across all commits since lifecycle start (codex P2)" {
+    git init -q; git config user.email t@t.co; git config user.name t
+    echo base > code.txt; git add code.txt; git commit -qm init
+    # init captures the start SHA HERE, before the development commits
+    init_github_lifecycle "42"
+    printf 'base\n# TODO: from first commit\n' > code.txt; git add code.txt; git commit -qm c1
+    printf 'base\n# TODO: from first commit\n# FIXME: from second commit\n' > code.txt; git add code.txt; git commit -qm c2
+    run scan_for_todos
+    assert_success
+    # Both the earlier-commit TODO and the later-commit FIXME are found
+    [[ "$output" == *"TODO: from first commit"* ]]
+    [[ "$output" == *"FIXME: from second commit"* ]]
+}
+
 # -----------------------------------------------------------------------------
 # orchestration: lifecycle_post_progress
 # -----------------------------------------------------------------------------
@@ -290,6 +304,10 @@ EOF
 
 @test "lifecycle_on_completion adds Closes #N to PR body with --create-pr --link-issue" {
     _mock_gh ok
+    # PR creation requires a feature branch (not the default/protected branch)
+    git init -q; git config user.email t@t.co; git config user.name t
+    git checkout -q -b feature/work
+    echo a > a.txt; git add a.txt; git commit -qm init
     init_github_lifecycle "42"
     : > "$RALPH_DIR/fix_plan.md"
     CREATE_PR=true LINK_ISSUE=true GITHUB_PR_TITLE="My PR"
@@ -298,6 +316,20 @@ EOF
     [[ "$(cat "$TEST_DIR/gh_stdin")" == *"Closes #42"* ]]
     assert_equal "$(lifecycle_get '.lifecycle.pr_created')" "true"
     assert_equal "$(lifecycle_get '.lifecycle.pr_url')" "https://github.com/o/r/pull/100"
+}
+
+@test "lifecycle_on_completion skips PR creation on the default branch (codex P1)" {
+    _mock_gh ok
+    git init -q; git config user.email t@t.co; git config user.name t
+    git checkout -q -b main 2>/dev/null || git branch -m main
+    echo a > a.txt; git add a.txt; git commit -qm init
+    init_github_lifecycle "42"
+    : > "$RALPH_DIR/fix_plan.md"
+    CREATE_PR=true LINK_ISSUE=true
+    lifecycle_on_completion
+    [[ "$(_gh_args 2>/dev/null)" != *"pr create"* ]]
+    # pr_created stays false (lifecycle_get's `// empty` renders a false boolean as "")
+    [[ "$(lifecycle_get '.lifecycle.pr_created')" != "true" ]]
 }
 
 @test "lifecycle_on_completion posts a summary comment with --close-summary" {

--- a/tests/unit/test_github_lifecycle.bats
+++ b/tests/unit/test_github_lifecycle.bats
@@ -308,11 +308,12 @@ EOF
     git init -q; git config user.email t@t.co; git config user.name t
     git checkout -q -b feature/work
     echo a > a.txt; git add a.txt; git commit -qm init
-    init_github_lifecycle "42"
+    init_github_lifecycle "42" "Resolve the bug"
     : > "$RALPH_DIR/fix_plan.md"
-    CREATE_PR=true LINK_ISSUE=true GITHUB_PR_TITLE="My PR"
+    CREATE_PR=true LINK_ISSUE=true
     lifecycle_on_completion
-    [[ "$(_gh_args)" == *"pr create --title My PR"* ]]
+    # PR title defaults to the tracked issue title
+    [[ "$(_gh_args)" == *"pr create --title Resolve the bug"* ]]
     [[ "$(cat "$TEST_DIR/gh_stdin")" == *"Closes #42"* ]]
     assert_equal "$(lifecycle_get '.lifecycle.pr_created')" "true"
     assert_equal "$(lifecycle_get '.lifecycle.pr_url')" "https://github.com/o/r/pull/100"


### PR DESCRIPTION
Implements **#73** (GitHub issue lifecycle management) and **#239** (Optional/Future section support in `fix_plan.md`) in one PR.

## #73 — GitHub issue lifecycle management
New `ralph --github-issue <ref>` tracking, backed by `lib/github_lifecycle.sh`. All actions are opt-in and require `--github-issue` (a number, `#N`, `owner/repo#N`, or issue URL):

| Flag | Effect |
|------|--------|
| `--comment-progress` / `--comment-interval N` | Post progress comments every N loops (default 5) |
| `--close-summary` | Post a completion summary comment |
| `--create-pr` / `--link-issue` / `--draft-pr` | Open a PR on completion, optionally `Closes #N`, optionally draft |
| `--create-followups` / `--followup-label` | Open a grouped follow-up issue from TODO/FIXME markers added during dev |
| `--auto-close` / `--add-label` | Close the issue (with labels) on completion |

**Adapted from the Traycer plan on the issue**, which assumed a greenfield repo using raw REST + `GITHUB_TOKEN`. This repo uses the `gh` CLI everywhere and the `.ralph/` subfolder, so the implementation uses `gh issue comment/close/edit`, `gh pr create`, `gh issue create`, with state at `.ralph/.github_lifecycle_state` (atomic temp+mv). Dropped as YAGNI: multi-repo/cross-repo, custom rate-limit backoff (gh handles its own), GITHUB_TOKEN scope validation.

**Graceful degradation**: every gh operation logs and returns non-zero on failure (e.g. missing permission) but the orchestration helpers always return 0 — a lifecycle hiccup never crashes the development loop.

## #239 — Optional/Future sections in fix_plan.md
`_count_blocking_unchecked()` (awk, section-aware) makes the "all checkboxes complete" exit ignore unchecked `- [ ]` items under sections whose heading matches `OPTIONAL_SECTIONS` (default `Optional,Future,Future Enhancements,Nice to Have`; case-insensitive; configurable in `.ralphrc`). Optional context persists into deeper subsections and closes at the next same-or-higher-level heading. Resolves the deadlock where Claude treats low-priority items as skippable while Ralph keeps looping for them. **Backward compatible** — with no optional sections present, behavior is identical to the prior full-file count.

## Tests
- `tests/unit/test_github_lifecycle.bats` (29) — reference parsing, gh wrappers (mocked), generators, state, interval gating, completion-workflow ordering, graceful degradation
- `tests/unit/test_exit_detection.bats` (+9) — optional-section exclusion, nesting, case-insensitivity, configurability, backward compat (real + inlined copy kept in sync)
- `tests/unit/test_cli_modern.bats` (+3) — flag acceptance, `--comment-interval` validation, help text

Full suite green: **769 unit + 250 integration + 13 e2e = 1032, 0 failures**.

## Demo evidence
Both features were demoed against the real functions (gh mocked to capture exact commands). #239: `should_exit_gracefully` returns `plan_complete` with optional items present (counted 1/1, not 3/3) and `""` when a required section has unchecked items. #73: full lifecycle issued, in order, `gh issue comment` → `gh pr create … --draft` (body contains `Closes #73`) → `gh issue create … --label tech-debt` → `gh issue edit … --add-label` → `gh issue close`; a 403 from gh left the loop running (returned 0).

## Known limitations
- Follow-up scanning keys off TODO/FIXME/HACK/XXX markers in the diff; this repo's own style forbids TODO comments, so it will rarely fire here (off by default).
- `--create-pr` best-effort pushes the current branch; PR creation needs a pushed branch and push permission.

Closes #73
Closes #239

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * GitHub issue lifecycle automation: automatically track progress, post periodic updates, and create linked PRs for referenced issues
  * Auto-create follow-up issues from code TODOs/FIXMEs upon completion
  * Optional task sections in fix plans that don't block exit detection
  * Auto-close issues and apply labels on workflow completion

* **Documentation**
  * Added GitHub issue lifecycle feature guide with configuration options
  * Updated exit detection documentation for optional sections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->