### PR TITLE
fix(session): unify Claude session file on canonical JSON format (#123)

### DIFF
--- a/lib/response_analyzer.sh
+++ b/lib/response_analyzer.sh
@@ -1038,8 +1038,11 @@ write_session_id_file() {
         --arg session_id "$session_id" \
         --arg timestamp "$(get_iso_timestamp)" \
         '{ session_id: $session_id, timestamp: $timestamp }' > "$tmp" 2>/dev/null; then
-        mv "$tmp" "$file"
-        return 0
+        # Only report success if the atomic rename actually lands (don't mask a
+        # failed mv on a read-only path / full disk as success — would orphan tmp).
+        if mv "$tmp" "$file" 2>/dev/null; then
+            return 0
+        fi
     fi
     rm -f "$tmp" 2>/dev/null
     return 1
@@ -1062,11 +1065,14 @@ read_session_id_file() {
         return 0
     fi
 
-    # Legacy plain-text fallback
-    local line
-    line=$(head -n 1 "$file" 2>/dev/null | tr -d '\r\n[:space:]')
-    if [[ "$line" =~ ^[A-Za-z0-9_-]+$ ]]; then
-        printf '%s\n' "$line"
+    # Legacy plain-text fallback: the first line must be a single clean session-id
+    # token. Surrounding whitespace/CR is tolerated, but interior whitespace or JSON
+    # punctuation is rejected (so corrupt content like "abc 123" or "{...}" → "" rather
+    # than being normalized into a valid-looking id).
+    local raw
+    raw=$(head -n 1 "$file" 2>/dev/null)
+    if [[ "$raw" =~ ^[[:space:]]*([A-Za-z0-9_-]+)[[:space:]]*$ ]]; then
+        printf '%s\n' "${BASH_REMATCH[1]}"
     else
         echo ""
     fi

--- a/lib/response_analyzer.sh
+++ b/lib/response_analyzer.sh
@@ -1017,6 +1017,62 @@ SESSION_FILE="$RALPH_DIR/.claude_session_id"
 # Session expiration time in seconds (24 hours)
 SESSION_EXPIRATION_SECONDS=86400
 
+# Issue #123: canonical session-file format. Every site that persists the Claude
+# session id (store_session_id here, save_claude_session and the timeout fallback
+# in ralph_loop.sh) writes the SAME JSON shape — {session_id, timestamp} — through
+# this writer, and every reader goes through read_session_id_file. Previously the
+# file was written as JSON in one place and bare text in another, which could make
+# init_claude_session resume with a garbage id (e.g. "{") read off a JSON file.
+
+# write_session_id_file <session_id> [file]
+# Atomically write the canonical JSON session record. Returns 1 on empty id.
+write_session_id_file() {
+    local session_id="$1"
+    local file="${2:-$SESSION_FILE}"
+
+    [[ -z "$session_id" ]] && return 1
+
+    local tmp
+    tmp=$(mktemp "${file}.XXXXXX" 2>/dev/null) || tmp="${file}.tmp.$$"
+    if jq -n \
+        --arg session_id "$session_id" \
+        --arg timestamp "$(get_iso_timestamp)" \
+        '{ session_id: $session_id, timestamp: $timestamp }' > "$tmp" 2>/dev/null; then
+        mv "$tmp" "$file"
+        return 0
+    fi
+    rm -f "$tmp" 2>/dev/null
+    return 1
+}
+
+# read_session_id_file [file]
+# Read a session id, tolerating both the canonical JSON format and the legacy
+# plain-text format (a bare id on the first line, written by older Ralph versions).
+# JSON is tried first; the plain-text fallback only accepts a clean session-id
+# token (no JSON punctuation/whitespace), so corrupt content yields "".
+# The fallback keeps the issue #254 robustness: first line only, CR/whitespace stripped.
+read_session_id_file() {
+    local file="${1:-$SESSION_FILE}"
+    [[ -f "$file" ]] || { echo ""; return 0; }
+
+    local session_id
+    session_id=$(jq -r '.session_id // empty' "$file" 2>/dev/null)
+    if [[ -n "$session_id" && "$session_id" != "null" ]]; then
+        printf '%s\n' "$session_id"
+        return 0
+    fi
+
+    # Legacy plain-text fallback
+    local line
+    line=$(head -n 1 "$file" 2>/dev/null | tr -d '\r\n[:space:]')
+    if [[ "$line" =~ ^[A-Za-z0-9_-]+$ ]]; then
+        printf '%s\n' "$line"
+    else
+        echo ""
+    fi
+    return 0
+}
+
 # Store session ID to file with timestamp
 # Usage: store_session_id "session-uuid-123"
 store_session_id() {
@@ -1026,30 +1082,13 @@ store_session_id() {
         return 1
     fi
 
-    # Write session with timestamp using jq for safe JSON construction
-    jq -n \
-        --arg session_id "$session_id" \
-        --arg timestamp "$(get_iso_timestamp)" \
-        '{
-            session_id: $session_id,
-            timestamp: $timestamp
-        }' > "$SESSION_FILE"
-
-    return 0
+    write_session_id_file "$session_id" "$SESSION_FILE"
 }
 
-# Get the last stored session ID
-# Returns: session ID string or empty if not found
+# Get the last stored session ID (tolerates JSON and legacy plain-text formats)
+# Returns: session ID string or empty if not found/corrupt
 get_last_session_id() {
-    if [[ ! -f "$SESSION_FILE" ]]; then
-        echo ""
-        return 0
-    fi
-
-    # Extract session_id from JSON file
-    local session_id=$(jq -r '.session_id // ""' "$SESSION_FILE" 2>/dev/null)
-    echo "$session_id"
-    return 0
+    read_session_id_file "$SESSION_FILE"
 }
 
 # Check if the stored session should be resumed
@@ -1120,6 +1159,8 @@ export -f update_exit_signals
 export -f log_analysis_summary
 export -f detect_stuck_loop
 export -f detect_questions
+export -f write_session_id_file
+export -f read_session_id_file
 export -f store_session_id
 export -f get_last_session_id
 export -f should_resume_session

--- a/ralph_loop.sh
+++ b/ralph_loop.sh
@@ -1169,12 +1169,13 @@ init_claude_session() {
             return 0
         fi
 
-        # Session is valid, try to read it
-        # Fix #254: Read only the first line and strip any whitespace/CR — if the file was
-        # corrupted by a multi-line write (e.g. jq returning multiple matches), don't pass
-        # multi-line content to --resume.
+        # Session is valid, try to read it.
+        # Issue #123: read through the shared format-tolerant reader so a JSON session
+        # file (written by store_session_id / save_claude_session) resolves to the real
+        # id, while legacy plain-text files still work. The reader keeps the #254
+        # robustness (first line only, CR/whitespace stripped) in its plain fallback.
         local session_id
-        session_id=$(head -n 1 "$CLAUDE_SESSION_FILE" 2>/dev/null | tr -d '\r\n[:space:]')
+        session_id=$(read_session_id_file "$CLAUDE_SESSION_FILE")
         if [[ -n "$session_id" ]]; then
             log_status "INFO" "Resuming Claude session: ${session_id:0:20}... (${age_hours}h old)"
             echo "$session_id"
@@ -1211,7 +1212,8 @@ save_claude_session() {
                      | head -n 1 \
                      | tr -d '\r\n[:space:]')
         if [[ -n "$session_id" && "$session_id" != "null" ]]; then
-            echo "$session_id" > "$CLAUDE_SESSION_FILE"
+            # Issue #123: persist as canonical JSON so every write site agrees on format
+            write_session_id_file "$session_id" "$CLAUDE_SESSION_FILE"
             log_status "INFO" "Saved Claude session: ${session_id:0:20}..."
         fi
     fi
@@ -1890,7 +1892,8 @@ execute_claude_code() {
                     local fallback_session_id
                     fallback_session_id=$(echo "$system_line" | jq -r '.session_id // empty' 2>/dev/null)
                     if [[ -n "$fallback_session_id" ]]; then
-                        echo "$fallback_session_id" > "$CLAUDE_SESSION_FILE"
+                        # Issue #123: persist as canonical JSON (was a bare echo)
+                        write_session_id_file "$fallback_session_id" "$CLAUDE_SESSION_FILE"
                         log_status "INFO" "Extracted session ID from system message (timeout fallback)"
                     fi
                 fi

--- a/tests/unit/test_session_continuity.bats
+++ b/tests/unit/test_session_continuity.bats
@@ -383,6 +383,110 @@ EOF
 }
 
 # =============================================================================
+# Issue #123: UNIFIED SESSION STORAGE FORMAT (JSON, tolerant readers)
+# =============================================================================
+
+@test "issue #123: write_session_id_file writes canonical JSON with timestamp" {
+    write_session_id_file "sess-123-abc" "$CLAUDE_SESSION_FILE"
+
+    # Valid JSON, with session_id and a non-empty timestamp
+    run jq -e . "$CLAUDE_SESSION_FILE"
+    [ "$status" -eq 0 ]
+    [[ "$(jq -r '.session_id' "$CLAUDE_SESSION_FILE")" == "sess-123-abc" ]]
+    [[ -n "$(jq -r '.timestamp' "$CLAUDE_SESSION_FILE")" ]]
+}
+
+@test "issue #123: write_session_id_file rejects empty id" {
+    rm -f "$CLAUDE_SESSION_FILE"
+    run write_session_id_file "" "$CLAUDE_SESSION_FILE"
+    [ "$status" -ne 0 ]
+    [[ ! -f "$CLAUDE_SESSION_FILE" ]]
+}
+
+@test "issue #123: read_session_id_file reads JSON format" {
+    echo '{"session_id": "json-id-1", "timestamp": "2026-01-09T10:00:00Z"}' > "$CLAUDE_SESSION_FILE"
+    run read_session_id_file "$CLAUDE_SESSION_FILE"
+    [ "$status" -eq 0 ]
+    [[ "$output" == "json-id-1" ]]
+}
+
+@test "issue #123: read_session_id_file reads legacy plain-text format" {
+    printf 'plain-legacy-id-2\n' > "$CLAUDE_SESSION_FILE"
+    run read_session_id_file "$CLAUDE_SESSION_FILE"
+    [ "$status" -eq 0 ]
+    [[ "$output" == "plain-legacy-id-2" ]]
+}
+
+@test "issue #123: read_session_id_file strips CR from legacy plain id (issue #254 robustness)" {
+    printf 'abc123-session-id\r\n' > "$CLAUDE_SESSION_FILE"
+    run read_session_id_file "$CLAUDE_SESSION_FILE"
+    [[ "$output" == "abc123-session-id" ]]
+}
+
+@test "issue #123: read_session_id_file returns empty on corrupt/JSON-looking junk" {
+    echo 'not valid json at all {{{' > "$CLAUDE_SESSION_FILE"
+    run read_session_id_file "$CLAUDE_SESSION_FILE"
+    [ "$status" -eq 0 ]
+    [[ -z "$output" ]]
+}
+
+@test "issue #123: read_session_id_file returns empty for missing file" {
+    rm -f "$CLAUDE_SESSION_FILE"
+    run read_session_id_file "$CLAUDE_SESSION_FILE"
+    [ "$status" -eq 0 ]
+    [[ -z "$output" ]]
+}
+
+@test "issue #123: save_claude_session persists canonical JSON (not plain text)" {
+    source "${BATS_TEST_DIRNAME}/../../ralph_loop.sh"
+    local output_file="$LOG_DIR/claude_out.json"
+    echo '{"session_id": "save-json-id", "result": "ok"}' > "$output_file"
+
+    save_claude_session "$output_file"
+
+    [[ -f "$CLAUDE_SESSION_FILE" ]]
+    run jq -e . "$CLAUDE_SESSION_FILE"
+    [ "$status" -eq 0 ]                                   # file is valid JSON
+    [[ "$(jq -r '.session_id' "$CLAUDE_SESSION_FILE")" == "save-json-id" ]]
+}
+
+@test "issue #123: init_claude_session resumes from a JSON session file" {
+    source "${BATS_TEST_DIRNAME}/../../ralph_loop.sh"
+    # Recent JSON file (mtime = now -> not expired)
+    write_session_id_file "resume-json-id" "$CLAUDE_SESSION_FILE"
+
+    run init_claude_session
+    # Must return the real id, NOT "{" (the old plain-text reader's failure mode)
+    [[ "$output" == *"resume-json-id"* ]]
+    [[ "$output" != *"{"* ]]
+}
+
+@test "issue #123: init_claude_session resumes from a legacy plain-text file" {
+    source "${BATS_TEST_DIRNAME}/../../ralph_loop.sh"
+    printf 'legacy-plain-resume\n' > "$CLAUDE_SESSION_FILE"
+
+    run init_claude_session
+    [[ "$output" == *"legacy-plain-resume"* ]]
+}
+
+@test "issue #123: save_claude_session -> init_claude_session round-trips the id" {
+    source "${BATS_TEST_DIRNAME}/../../ralph_loop.sh"
+    local output_file="$LOG_DIR/claude_out.json"
+    echo '{"session_id": "roundtrip-xyz"}' > "$output_file"
+
+    save_claude_session "$output_file"
+    run init_claude_session
+    [[ "$output" == *"roundtrip-xyz"* ]]
+    [[ "$output" != *"{"* ]]
+}
+
+@test "issue #123: get_last_session_id reads a legacy plain-text id" {
+    printf 'legacy-getlast-id\n' > "$CLAUDE_SESSION_FILE"
+    run get_last_session_id
+    [[ "$output" == "legacy-getlast-id" ]]
+}
+
+# =============================================================================
 # SESSION RESET CLEARS EXIT SIGNALS (Issue #91 Fix)
 # =============================================================================
 

--- a/tests/unit/test_session_continuity.bats
+++ b/tests/unit/test_session_continuity.bats
@@ -393,7 +393,8 @@ EOF
     run jq -e . "$CLAUDE_SESSION_FILE"
     [ "$status" -eq 0 ]
     [[ "$(jq -r '.session_id' "$CLAUDE_SESSION_FILE")" == "sess-123-abc" ]]
-    [[ -n "$(jq -r '.timestamp' "$CLAUDE_SESSION_FILE")" ]]
+    # // empty so a missing field is "" (jq -r prints "null" otherwise, passing falsely)
+    [[ -n "$(jq -r '.timestamp // empty' "$CLAUDE_SESSION_FILE")" ]]
 }
 
 @test "issue #123: write_session_id_file rejects empty id" {
@@ -401,6 +402,20 @@ EOF
     run write_session_id_file "" "$CLAUDE_SESSION_FILE"
     [ "$status" -ne 0 ]
     [[ ! -f "$CLAUDE_SESSION_FILE" ]]
+}
+
+@test "issue #123: write_session_id_file reports failure (rc 1) when it cannot write" {
+    [[ "$(id -u)" -eq 0 ]] && skip "root bypasses directory permissions"
+    local rodir="$TEST_DIR/readonly"
+    mkdir -p "$rodir"; chmod 555 "$rodir"
+
+    run write_session_id_file "no-write-id" "$rodir/sess"
+    chmod 755 "$rodir"   # restore so teardown can clean up
+
+    [ "$status" -ne 0 ]
+    [[ ! -f "$rodir/sess" ]]
+    # No orphaned temp files left behind
+    [[ -z "$(ls -A "$rodir" 2>/dev/null)" ]]
 }
 
 @test "issue #123: read_session_id_file reads JSON format" {
@@ -425,6 +440,14 @@ EOF
 
 @test "issue #123: read_session_id_file returns empty on corrupt/JSON-looking junk" {
     echo 'not valid json at all {{{' > "$CLAUDE_SESSION_FILE"
+    run read_session_id_file "$CLAUDE_SESSION_FILE"
+    [ "$status" -eq 0 ]
+    [[ -z "$output" ]]
+}
+
+@test "issue #123: read_session_id_file rejects a legacy line with interior whitespace" {
+    # "abc 123" must NOT be normalized into a valid "abc123" id (CodeRabbit)
+    printf 'abc 123\n' > "$CLAUDE_SESSION_FILE"
     run read_session_id_file "$CLAUDE_SESSION_FILE"
     [ "$status" -eq 0 ]
     [[ -z "$output" ]]


### PR DESCRIPTION
Fixes **#123**.

## Problem (confirmed active, not cosmetic)
`.ralph/.claude_session_id` was written in two formats:
- `store_session_id` (called from `analyze_response`) → JSON `{session_id, timestamp}`
- `save_claude_session` + the timeout-fallback path → bare `echo "$id"` (plain text)

…and the **active resume reader** `init_claude_session` parsed only the plain format (`head -n1 | tr`). The plain write usually lands last and masks the clash, but when it's skipped (e.g. the `is_error` guard short-circuits `save_claude_session`) a JSON file remains, and `init_claude_session` reads the first line `{` as the session id → `claude --resume {` fails.

## Fix — standardize on JSON, tolerant readers
Per the maintainer's recommendation on the issue (JSON carries the timestamp), with readers handling both formats:
- New shared helpers in `lib/response_analyzer.sh`:
  - `write_session_id_file <id> [file]` — atomic (temp+mv) JSON writer.
  - `read_session_id_file [file]` — JSON-first; legacy plain-text fallback that only accepts a clean session-id token (`^[A-Za-z0-9_-]+$`), so corrupt content → `""`. Keeps the #254 robustness (first line only, CR/whitespace stripped).
- `store_session_id` / `get_last_session_id` delegate to the shared helpers.
- `ralph_loop.sh`: all three write sites (`save_claude_session`, timeout fallback) and the `init_claude_session` reader route through the shared writer/reader.

**Expiration is unchanged** (still mtime-based in `init_claude_session`). `should_resume_session` stays JSON-only — it isn't used in the active loop, and a legacy plain file → "don't resume" is safe.

## Tests
+12 in `tests/unit/test_session_continuity.bats`: writer/reader formats, JSON resume, legacy-plain resume, save→resume round-trip, corrupt-input handling, CR stripping. Full suite green: **783 unit + 252 integration + 13 e2e = 1048, 0 failures**.

## Demo evidence
Against the real functions: all three write sites emit identical `{session_id, timestamp}` JSON; `save_claude_session` produces valid JSON; the original bug scenario (file first line `{`) now resolves to the real id via `init_claude_session`; legacy plain files still resume; corrupt content → empty.

## Backward compatibility
Legacy plain-text session files (written by older Ralph versions) still resume correctly.

Closes #123

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session persistence now writes a canonical JSON record (session id + timestamp) and reads tolerate legacy/plain-text and mixed/corrupt contents.
  * Session save/load flows unified to use the new tolerant read/write helpers.

* **Tests**
  * Added comprehensive tests covering JSON format, legacy compatibility, error cases, and round-trip session continuity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->