### PR TITLE
feat(sandbox): local Docker sandbox execution — ralph --sandbox docker (#74)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+# Keep the sandbox image build context minimal (Issue #74)
+.git/
+node_modules/
+tests/
+docs/
+logs/
+examples/
+specs/
+tasks/
+*.log
+.ralph/
+.claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,7 @@ Ralph for Claude Code — an autonomous AI development loop system enabling cont
 - **file_protection.sh** — `validate_ralph_integrity()` checks `RALPH_REQUIRED_PATHS` exist; runs every loop iteration; `get_integrity_report()` for recovery instructions
 - **log_utils.sh** — `rotate_logs()` rotates `$LOG_DIR/ralph.log` at 10MB, keeping 4 archives (`.log.1`–`.log.4`); GNU `stat -c%s` with BSD `stat -f%z` fallback
 - **github_lifecycle.sh** — GitHub issue lifecycle management backing `ralph --github-issue` (Issue #73). `parse_issue_reference` (N | #N | owner/repo#N | URL → number+repo); gh wrappers `gh_issue_comment`/`gh_close_issue`/`gh_add_labels`/`gh_create_pr`/`gh_create_issue` (each logs + returns non-zero on failure, never exits); state primitives `init_github_lifecycle`/`lifecycle_get`/`_lifecycle_apply` (atomic temp+`mv` at `.ralph/.github_lifecycle_state`, program-first signature like `_queue_apply`); generators `generate_progress_comment`/`generate_completion_summary`/`scan_for_todos`; orchestration `lifecycle_post_progress <loop>` (interval-gated) and `lifecycle_on_completion` (summary → PR → followups → close, each flag-guarded, always returns 0). Reuses `lib/date_utils.sh` timestamps
+- **sandbox_docker.sh** — Docker sandbox execution backing `ralph --sandbox docker` (Issue #74). Containerizes only the Claude CLI execution: one persistent container per run (`docker run -d … sleep infinity`, project bind-mounted rw at `/workspace`), each iteration wrapped as `docker exec -i -w /workspace <cid> claude …` via `build_sandbox_exec_args`/`wrap_claude_command_for_sandbox` (works in live and background modes); ralph orchestration, analysis, and status.json stay host-side so ralph-monitor is unaffected. `validate_sandbox_config` (image/memory/cpus/network), `init_docker_sandbox` (daemon + image checks with build/pull guidance), `setup_docker_credentials` (ANTHROPIC_API_KEY → 0600 env-file via `--env-file`, else host `~/.claude/.credentials.json` copied into a container-scoped home — never `docker secret`, which needs Swarm), `handle_sandbox_timeout` (exit 124 kills only the docker-exec client → `docker restart` reaps orphans), idempotent `cleanup_docker_sandbox` on all exit paths. State: `.ralph/.docker_sandbox_state` (atomic temp+`mv`). Setup failure is fatal — never falls back to host execution. Config: `SANDBOX_PROVIDER`, `SANDBOX_DOCKER_IMAGE/MEMORY/CPUS/NETWORK` (env > CLI > .ralphrc); sandbox `_env_*` capture sits BEFORE the lib source block in ralph_loop.sh because the lib sets defaults at source time. Default image built locally from the repo `Dockerfile` (`docker build -t ralph-sandbox .`; install.sh copies it to `~/.ralph`)
 - **queue_manager.sh** — queue state primitives backing `ralph-queue` (Issue #72). State at `.ralph/queue.json` (`{version, created_at, updated_at, repository, queue:[…]}`); entries carry `id`/`source` (`github`|`prd`)/`issue_number`/`path`/`title`/`priority`/`labels`/`milestone`/`dependencies`/`status`/timestamps. Functions: `init_queue`, `add_to_queue` (dedupe by id, fills defaults; rc 0/1/2), `remove_from_queue`, `clear_queue`, `mark_issue_status` (validates status, stamps started/completed), `get_queue_status` (counts JSON), `sort_queue_by_priority` (rank then FIFO), `get_priority_from_labels` (reuses the P0–P9 / `priority: PN` parser), `parse_issue_dependencies` (`depends on/blocked by/requires #N`), `is_dependency_satisfied`, `get_next_issue` (ready+priority+FIFO), `validate_dependencies` (jq cycle detection). All mutations are atomic temp-file+`mv` via `_queue_apply`
 
 ## Key Commands
@@ -124,6 +125,17 @@ ralph --process-queue            # also: ralph-queue process
 ralph --process-queue --halt-on-failure
 ralph --resume-queue             # continue remaining pending items
 ```
+
+### Docker Sandbox Execution (Issue #74)
+```bash
+docker build -t ralph-sandbox .          # One time: build the default image (or ~/.ralph post-install)
+
+ralph --sandbox docker                   # Run Claude in an isolated container
+ralph --sandbox docker --sandbox-image node:20 --sandbox-memory 8g --sandbox-cpus 4
+ralph --sandbox docker --sandbox-network none   # Full isolation (blocks Claude API — special images only)
+ralph --monitor --sandbox docker         # Flags forwarded through tmux
+```
+Providers e2b/daytona/cloudflare are rejected with "not yet implemented" (#75/#79/#80). Sub-flags require a provider. See [docs/DOCKER_SANDBOX.md](docs/DOCKER_SANDBOX.md).
 
 ### Monitoring
 ```bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,10 +27,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Claude Code CLI — the execution engine the sandbox runs
 RUN npm install -g @anthropic-ai/claude-code
 
-# Non-root user: autonomous code execution should not run as root even inside
-# the container (defense in depth alongside resource/network limits)
-RUN useradd -m -s /bin/bash ralph
-USER ralph
+# Non-root default user: reuse the base image's `node` user (uid 1000) rather
+# than useradd-ing a new one, which would land at uid 1001 and break writes to
+# bind mounts owned by a uid-1000 host user. At runtime ralph_loop.sh overrides
+# this anyway with `--user "$(id -u):$(id -g)"` so workspace files keep host
+# ownership; this USER is the safe default for manual `docker run` usage.
+USER node
 
 WORKDIR /workspace
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+# Default Ralph sandbox image (Issue #74)
+#
+# Used by `ralph --sandbox docker`: Ralph's loop stays on the host and runs the
+# Claude Code CLI inside a container built from this image, with the project
+# bind-mounted at /workspace. The image only needs the Claude CLI plus common
+# development tooling — Ralph itself is NOT installed in the container.
+#
+# Build:  docker build -t ralph-sandbox .
+# Custom: FROM ralph-sandbox:latest, then add your project's toolchain
+#         (or point --sandbox-image at any image with `claude` on PATH).
+
+FROM node:20-slim
+
+# Common development tooling for autonomous loops (git for commits, jq for
+# JSON, python3 + pip for Python projects, curl/ca-certificates for installs)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bash \
+    ca-certificates \
+    curl \
+    git \
+    jq \
+    procps \
+    python3 \
+    python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+
+# Claude Code CLI — the execution engine the sandbox runs
+RUN npm install -g @anthropic-ai/claude-code
+
+# Non-root user: autonomous code execution should not run as root even inside
+# the container (defense in depth alongside resource/network limits)
+RUN useradd -m -s /bin/bash ralph
+USER ralph
+
+WORKDIR /workspace
+
+# Keepalive default; ralph_loop.sh passes `sleep infinity` explicitly on
+# `docker run` and executes Claude via `docker exec` per loop iteration.
+CMD ["sleep", "infinity"]

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Ralph is an implementation of the Geoffrey Huntley's technique for Claude Code t
 - **CI/CD Integration** - GitHub Actions workflow with automated testing
 - **Clean Uninstall** - Dedicated uninstall script for complete removal
 - **Live Streaming Output** - Real-time visibility into Claude Code execution with `--live` flag
+- **Docker Sandbox Execution** - Run Claude Code in an isolated container with `--sandbox docker` (resource limits, network policy, secure credential handoff)
 
 ## Quick Start
 
@@ -597,6 +598,38 @@ For each ready item the processor stages the project from the issue/spec, runs t
 Concurrent (parallel) processing is intentionally out of scope — items are processed one at a time on a single branch.
 - **"Could not fetch issue #N"** — check the issue number, your repo access, and the `--repo` value
 - **"No issues match the specified filters"** — relax or remove some filters; only open issues are matched unless `--github-state closed|all` is given. `--dry-run` shows what a filter set matches.
+
+## Docker Sandbox Execution
+
+Run Claude Code inside an isolated Docker container instead of directly on your machine (Issue #74). Ralph's loop, rate limiting, and monitoring stay on the host; only Claude's execution — the part that edits files and runs commands autonomously — is containerized. The project directory is bind-mounted read-write at `/workspace`, so changes land on the host directly and `ralph-monitor` works unchanged.
+
+### Setup
+
+```bash
+# One time: build the default sandbox image (from a source checkout, or ~/.ralph after install)
+docker build -t ralph-sandbox .
+```
+
+### Usage
+
+```bash
+ralph --sandbox docker                          # Default image, 4g RAM, 2 CPUs, bridge network
+ralph --sandbox docker --sandbox-image node:20  # Any image with `claude` on PATH
+ralph --sandbox docker --sandbox-memory 8g --sandbox-cpus 4
+ralph --sandbox docker --sandbox-network none   # Full network isolation (blocks the Claude API —
+                                                # only for images with their own auth/proxy setup)
+ralph --monitor --sandbox docker                # Works with tmux monitoring
+```
+
+Equivalent `.ralphrc` settings: `SANDBOX_PROVIDER`, `SANDBOX_DOCKER_IMAGE`, `SANDBOX_DOCKER_MEMORY`, `SANDBOX_DOCKER_CPUS`, `SANDBOX_DOCKER_NETWORK` (CLI flags override).
+
+### How credentials reach the container
+
+- `ANTHROPIC_API_KEY` set → handed off via a `0600` env-file passed to `docker run --env-file` (never logged)
+- Otherwise, your `~/.claude/.credentials.json` is **copied** into a container-scoped directory mounted as the container's home — the container never touches your real `~/.claude`
+- Both are removed by the automatic cleanup on exit (including Ctrl+C)
+
+A persistent container serves all loop iterations (Claude session state survives between loops); it is stopped and removed when the loop exits. If sandbox setup fails, Ralph refuses to fall back to host execution. E2B, Daytona, and Cloudflare cloud sandboxes are planned (#75, #79, #80). See [docs/DOCKER_SANDBOX.md](docs/DOCKER_SANDBOX.md) for details.
 
 ## Configuration
 

--- a/docs/DOCKER_SANDBOX.md
+++ b/docs/DOCKER_SANDBOX.md
@@ -80,15 +80,17 @@ Environment variables of the same names take precedence over `.ralphrc`, and
 
 Handled by `setup_docker_credentials()` in `lib/sandbox_docker.sh`, in order:
 
-1. **`ANTHROPIC_API_KEY` set** — written to a `0600` env-file under `.ralph/`
-   and passed via `docker run --env-file`. The value is never logged; the file
-   is deleted on cleanup. (`docker secret` is not used — it requires Swarm
-   mode and does not work with plain `docker run`.)
+1. **`ANTHROPIC_API_KEY` set** — written to a `0600` env-file in a per-run
+   runtime directory under `/tmp` (deliberately **outside** the bind-mounted
+   project, so the sandboxed process cannot read it as a workspace file and it
+   can never be swept into a commit) and passed via `docker run --env-file`.
+   The value is never logged; the file is deleted on cleanup. (`docker secret`
+   is not used — it requires Swarm mode and does not work with plain
+   `docker run`.)
 2. **Host `~/.claude/.credentials.json` exists** — *copied* into a
-   container-scoped directory (`.ralph/.docker_claude_home`) that is mounted
-   as the container's `HOME`. The container can refresh its own session state
-   there without ever touching the host's real `~/.claude`. Removed on
-   cleanup.
+   container-scoped directory in the same runtime dir, mounted as the
+   container's `HOME`. The container can refresh its own session state there
+   without ever touching the host's real `~/.claude`. Removed on cleanup.
 3. **Neither** — a warning is logged and the loop continues (useful for
    custom images with authentication baked in).
 

--- a/docs/DOCKER_SANDBOX.md
+++ b/docs/DOCKER_SANDBOX.md
@@ -44,7 +44,10 @@ docker build -t ralph-sandbox ~/.ralph
 ```
 
 The default image is `node:20-slim` plus git, jq, python3, and the Claude Code
-CLI, running as a non-root `ralph` user.
+CLI, with the base image's non-root `node` user as the default. At runtime the
+container is started with `--user "$(id -u):$(id -g)"`, so everything Claude
+writes to the bind-mounted workspace keeps your host ownership and the seeded
+`0600` credential files stay readable.
 
 ## CLI reference
 
@@ -124,7 +127,7 @@ Any image with the Claude CLI on `PATH` works:
 FROM ralph-sandbox:latest
 USER root
 RUN pip3 install --break-system-packages numpy pandas
-USER ralph
+USER node
 ```
 
 ```bash

--- a/docs/DOCKER_SANDBOX.md
+++ b/docs/DOCKER_SANDBOX.md
@@ -1,0 +1,143 @@
+# Docker Sandbox Execution
+
+`ralph --sandbox docker` runs the Claude Code CLI inside an isolated Docker
+container instead of directly on your machine (Issue #74, first slice of the
+Phase 6.0 sandbox epic #49).
+
+## Architecture
+
+Ralph's orchestration stays on the host; only Claude's execution is
+containerized:
+
+```
+HOST                                      CONTAINER (persistent)
+ralph_loop.sh ── docker exec ──────────▶  claude -p "..." (per iteration)
+  ├─ rate limiting / circuit breaker        │
+  ├─ response analysis / exit detection     ▼
+  ├─ status.json (ralph-monitor)          /workspace  ◀── bind mount (rw) ── project dir
+  └─ cleanup on exit / Ctrl+C
+```
+
+- **One persistent container** is started before the loop (`docker run -d ...
+  sleep infinity`) and reused by every iteration via `docker exec` — no
+  per-loop startup cost, and Claude's in-container session state survives
+  across iterations (session continuity works).
+- **The project directory is bind-mounted read-write at `/workspace`**, so
+  file changes land on the host immediately. No file synchronization layer is
+  needed (cloud-sandbox sync is Issue #76).
+- **`ralph-monitor` works unchanged** — `status.json` is written host-side and
+  gains a `sandbox` field (`provider`, `container_id`, `status`).
+- **No silent fallback**: if sandbox setup fails (no Docker, missing image,
+  bad config), Ralph exits with an error rather than running Claude on the
+  host you asked it to protect.
+
+## Setup
+
+Docker must be installed and the daemon running. Build the default image:
+
+```bash
+# From a source checkout
+docker build -t ralph-sandbox .
+
+# Or from a global install (install.sh copies the Dockerfile to ~/.ralph)
+docker build -t ralph-sandbox ~/.ralph
+```
+
+The default image is `node:20-slim` plus git, jq, python3, and the Claude Code
+CLI, running as a non-root `ralph` user.
+
+## CLI reference
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--sandbox docker` | (off) | Enable Docker sandbox execution |
+| `--sandbox-image IMAGE` | `ralph-sandbox:latest` | Container image (must have `claude` on PATH) |
+| `--sandbox-memory SIZE` | `4g` | Memory limit (`docker run --memory` format) |
+| `--sandbox-cpus NUM` | `2` | CPU limit (decimals allowed, e.g. `1.5`) |
+| `--sandbox-network MODE` | `bridge` | `none`, `bridge`, or `host` |
+
+`e2b`, `daytona`, and `cloudflare` providers are planned (issues #75, #79,
+#80) and currently rejected with a clear error. The sub-flags require a
+provider (either `--sandbox docker` or `SANDBOX_PROVIDER` in `.ralphrc`).
+
+`.ralphrc` equivalents (CLI flags override):
+
+```bash
+SANDBOX_PROVIDER="docker"
+SANDBOX_DOCKER_IMAGE="ralph-sandbox:latest"
+SANDBOX_DOCKER_MEMORY="4g"
+SANDBOX_DOCKER_CPUS="2"
+SANDBOX_DOCKER_NETWORK="bridge"
+```
+
+Environment variables of the same names take precedence over `.ralphrc`, and
+`--monitor` (tmux) forwards all sandbox flags to the loop pane.
+
+## Credentials
+
+Handled by `setup_docker_credentials()` in `lib/sandbox_docker.sh`, in order:
+
+1. **`ANTHROPIC_API_KEY` set** — written to a `0600` env-file under `.ralph/`
+   and passed via `docker run --env-file`. The value is never logged; the file
+   is deleted on cleanup. (`docker secret` is not used — it requires Swarm
+   mode and does not work with plain `docker run`.)
+2. **Host `~/.claude/.credentials.json` exists** — *copied* into a
+   container-scoped directory (`.ralph/.docker_claude_home`) that is mounted
+   as the container's `HOME`. The container can refresh its own session state
+   there without ever touching the host's real `~/.claude`. Removed on
+   cleanup.
+3. **Neither** — a warning is logged and the loop continues (useful for
+   custom images with authentication baked in).
+
+## Network modes
+
+- `bridge` (default) — container can reach the Claude API; normal isolation
+  from the host network.
+- `host` — shares the host network namespace; less isolation, occasionally
+  needed for localhost services.
+- `none` — full network isolation. **This blocks the Claude API**, so it only
+  makes sense for images that route through a proxy or have offline tooling;
+  the help text and docs call this out.
+
+## Lifecycle and failure handling
+
+- **Startup**: `init_docker_sandbox` (config validation, daemon check, image
+  presence check with build/pull guidance) → `setup_docker_credentials` →
+  `start_sandbox_container`. Any failure aborts the run.
+- **Per iteration**: the built Claude command array is wrapped as
+  `docker exec -i -w /workspace <container> claude ...`. Both `--live`
+  (stream-json) and background modes work through the wrapper.
+- **Timeout (exit 124)**: the host-side timeout kills only the `docker exec`
+  client; the container is restarted (`docker restart -t 5`) to reap the
+  orphaned in-container process before the next iteration.
+- **Exit**: the container is stopped and removed, and credential artifacts are
+  deleted — on graceful completion, circuit-breaker halt, errors, and
+  SIGINT/SIGTERM. Cleanup is idempotent.
+- **State**: `.ralph/.docker_sandbox_state` (JSON, atomic temp+`mv` writes)
+  tracks image, limits, container id, and status.
+
+## Custom images
+
+Any image with the Claude CLI on `PATH` works:
+
+```dockerfile
+FROM ralph-sandbox:latest
+USER root
+RUN pip3 install --break-system-packages numpy pandas
+USER ralph
+```
+
+```bash
+docker build -t my-ml-sandbox .
+ralph --sandbox docker --sandbox-image my-ml-sandbox
+```
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| `Docker daemon is not reachable` | Start the Docker service (`sudo systemctl start docker`, or Docker Desktop) |
+| `Sandbox image 'ralph-sandbox:latest' not found` | `docker build -t ralph-sandbox ~/.ralph` (or the repo root) |
+| Claude auth errors inside the container | Export `ANTHROPIC_API_KEY`, or log in on the host first so `~/.claude/.credentials.json` exists |
+| Loop hangs then times out with `--sandbox-network none` | Expected — `none` blocks the Claude API; use `bridge` |
+| Orphaned container after a hard kill (`kill -9`) | `docker ps --filter name=ralph-sandbox` then `docker rm -f <id>`; normal exits and Ctrl+C clean up automatically |

--- a/install.sh
+++ b/install.sh
@@ -95,6 +95,14 @@ check_dependencies() {
         log "WARN" "tmux not found. Install for integrated monitoring: apt-get install tmux / brew install tmux"
     fi
 
+    # Check Docker (optional — only needed for `ralph --sandbox docker`, Issue #74)
+    if command -v docker &> /dev/null; then
+        log "INFO" "Docker found — sandbox execution available (ralph --sandbox docker)"
+        log "INFO" "  Build the default sandbox image: docker build -t ralph-sandbox \$RALPH_HOME"
+    else
+        log "INFO" "Docker not found (optional). Install it to use sandboxed execution: ralph --sandbox docker"
+    fi
+
     log "SUCCESS" "Dependencies check completed"
 }
 
@@ -121,6 +129,11 @@ install_scripts() {
 
     # Copy lib scripts (response_analyzer.sh, circuit_breaker.sh)
     cp -r "$SCRIPT_DIR/lib/"* "$RALPH_HOME/lib/"
+
+    # Copy the sandbox image build context (Issue #74) so installed users can
+    # build the default image: docker build -t ralph-sandbox $RALPH_HOME
+    cp "$SCRIPT_DIR/Dockerfile" "$RALPH_HOME/Dockerfile" 2>/dev/null || true
+    cp "$SCRIPT_DIR/.dockerignore" "$RALPH_HOME/.dockerignore" 2>/dev/null || true
     
     # Create the main ralph command
     cat > "$INSTALL_DIR/ralph" << 'EOF'

--- a/lib/enable_core.sh
+++ b/lib/enable_core.sh
@@ -740,6 +740,16 @@ CLAUDE_AUTO_UPDATE=true
 # variables or PATH entries defined in a non-bash shell config (e.g. ~/.zshrc).
 # Leave commented out unless needed.
 #RALPH_SHELL_INIT_FILE="~/.zshrc"
+
+# Docker sandbox execution (optional, Issue #74)
+# Run Claude Code inside an isolated Docker container instead of on the host.
+# Build the default image first: docker build -t ralph-sandbox ~/.ralph
+# Uncomment to enable; CLI flags (--sandbox, --sandbox-image, ...) override these.
+#SANDBOX_PROVIDER="docker"
+#SANDBOX_DOCKER_IMAGE="ralph-sandbox:latest"
+#SANDBOX_DOCKER_MEMORY="4g"
+#SANDBOX_DOCKER_CPUS="2"
+#SANDBOX_DOCKER_NETWORK="bridge"
 RALPHRCEOF
 }
 

--- a/lib/sandbox_docker.sh
+++ b/lib/sandbox_docker.sh
@@ -286,8 +286,10 @@ start_sandbox_container() {
     # Capture stderr separately: a successful `docker run -d` can still emit
     # warnings (e.g. "kernel does not support swap limit capabilities"), and
     # merging them into stdout would corrupt the recorded container id.
+    # (mkdir: start can be called without setup_docker_credentials — tests do)
+    mkdir -p "$SANDBOX_RUNTIME_DIR" && chmod 700 "$SANDBOX_RUNTIME_DIR"
     local container_id run_stderr
-    run_stderr=$(mktemp) || return 1
+    run_stderr=$(mktemp "$SANDBOX_RUNTIME_DIR/docker-run-stderr.XXXXXX") || return 1
     if ! container_id=$(docker "${run_args[@]}" 2>"$run_stderr"); then
         _sandbox_log "ERROR" "Failed to start sandbox container: $(cat "$run_stderr" 2>/dev/null)"
         rm -f "$run_stderr"

--- a/lib/sandbox_docker.sh
+++ b/lib/sandbox_docker.sh
@@ -201,15 +201,25 @@ init_docker_sandbox() {
 # --- credentials ---------------------------------------------------------------
 
 # setup_docker_credentials
-# Prepares credential handoff for the container, preferring an explicit API key:
+# Prepares the container-scoped home directory (always mounted as the
+# container's HOME — the container runs as the host uid, which usually has no
+# passwd entry in the image, so it needs a writable home regardless of
+# credential mode) and the credential handoff:
 #   1. ANTHROPIC_API_KEY set       → 0600 env-file passed via --env-file
-#   2. host ~/.claude credentials  → copied into a container-scoped claude home
-#                                    (mounted as $HOME/.claude inside the
-#                                    container; host credentials never mounted)
+#   2. host ~/.claude credentials  → copied into the container-scoped home
+#                                    (the host's real ~/.claude is never mounted)
 #   3. neither                     → warn and continue (the image may have its
 #                                    own auth baked in)
-# The API key value is never logged.
+# The host ~/.gitconfig is also seeded (when present) so autonomous commits
+# inside the container have an identity. The API key value is never logged.
 setup_docker_credentials() {
+    rm -rf "$SANDBOX_CLAUDE_HOME"
+    mkdir -p "$SANDBOX_CLAUDE_HOME/.claude" || return 1
+    chmod 700 "$SANDBOX_CLAUDE_HOME" "$SANDBOX_CLAUDE_HOME/.claude"
+    if [[ -f "$HOME/.gitconfig" ]]; then
+        cp "$HOME/.gitconfig" "$SANDBOX_CLAUDE_HOME/.gitconfig" 2>/dev/null || true
+    fi
+
     if [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
         rm -f "$SANDBOX_ENV_FILE"
         # Create with restrictive permissions BEFORE writing the secret
@@ -222,9 +232,6 @@ setup_docker_credentials() {
     fi
 
     if [[ -f "$HOME/.claude/.credentials.json" ]]; then
-        rm -rf "$SANDBOX_CLAUDE_HOME"
-        mkdir -p "$SANDBOX_CLAUDE_HOME/.claude" || return 1
-        chmod 700 "$SANDBOX_CLAUDE_HOME" "$SANDBOX_CLAUDE_HOME/.claude"
         cp "$HOME/.claude/.credentials.json" "$SANDBOX_CLAUDE_HOME/.claude/.credentials.json" || return 1
         chmod 600 "$SANDBOX_CLAUDE_HOME/.claude/.credentials.json"
         _sandbox_log "INFO" "Sandbox credentials: seeded container claude home from host credentials"
@@ -247,7 +254,12 @@ start_sandbox_container() {
     project_dir="$(pwd)"
     local name="ralph-sandbox-$$-$(date +%s)"
 
+    # Run as the HOST uid:gid — otherwise files the container writes into the
+    # bind-mounted /workspace are owned by the image's user (uid 1000), and a
+    # host uid ≠ 1000 cannot read the 0600 seeded credentials. The host uid has
+    # no passwd entry in most images, hence the explicit HOME mount below.
     local -a run_args=(run -d --init --name "$name"
+        --user "$(id -u):$(id -g)"
         -v "$project_dir:/workspace"
         -w /workspace
         --memory "$SANDBOX_DOCKER_MEMORY"
@@ -258,8 +270,7 @@ start_sandbox_container() {
         run_args+=(--env-file "$SANDBOX_ENV_FILE")
     fi
     if [[ -d "$SANDBOX_CLAUDE_HOME" ]]; then
-        # Mount the container-scoped claude home and point HOME at it so the
-        # Claude CLI finds credentials regardless of the image's user setup.
+        # Writable container HOME (credentials, claude session state, gitconfig)
         run_args+=(-v "$SANDBOX_CLAUDE_HOME:/ralph-home" -e HOME=/ralph-home)
     fi
 
@@ -277,11 +288,47 @@ start_sandbox_container() {
     return 0
 }
 
+# ensure_sandbox_container
+# Liveness probe + recovery, called before each exec. A container can die
+# between iterations (OOM kill under --memory, daemon restart, manual rm):
+#   running        → no-op
+#   stopped        → docker start (state and exec env are preserved)
+#   gone entirely  → start a fresh container (state file gets the new id)
+# Returns 1 only when no container was ever started or recovery failed.
+ensure_sandbox_container() {
+    local container_id
+    container_id=$(sandbox_state_get '.container_id')
+    if [[ -z "$container_id" ]]; then
+        _sandbox_log "ERROR" "No sandbox container recorded (start_sandbox_container first)"
+        return 1
+    fi
+
+    # `|| running=""` keeps the probe safe under errexit callers — a missing
+    # container makes docker inspect exit 1, which must mean "recover", not "abort"
+    local running
+    running=$(docker inspect -f '{{.State.Running}}' "$container_id" 2>/dev/null) || running=""
+    if [[ "$running" == "true" ]]; then
+        return 0
+    fi
+
+    _sandbox_log "WARN" "Sandbox container not running (possible OOM kill or daemon restart) — attempting recovery"
+    if docker start "$container_id" >/dev/null 2>&1; then
+        _sandbox_log "INFO" "Sandbox container restarted: ${container_id:0:12}"
+        return 0
+    fi
+
+    _sandbox_log "WARN" "Sandbox container is gone — starting a replacement"
+    _sandbox_apply '.container_id = "" | .status = "lost"' || true
+    start_sandbox_container
+}
+
 # build_sandbox_exec_args <command> [args...]
 # Populates the global SANDBOX_EXEC_ARGS array with the docker exec wrapping of
 # the given command (same global-array convention as CLAUDE_CMD_ARGS).
 # Environment from `docker run` (--env-file, HOME) is part of the container
-# config and is inherited by exec'd processes.
+# config and is inherited by exec'd processes; host-only env vars are NOT
+# forwarded — anything the in-container CLI needs must arrive via argv, the
+# env-file, or the image itself.
 build_sandbox_exec_args() {
     local container_id
     container_id=$(sandbox_state_get '.container_id')
@@ -366,6 +413,7 @@ export -f validate_sandbox_config
 export -f init_docker_sandbox
 export -f setup_docker_credentials
 export -f start_sandbox_container
+export -f ensure_sandbox_container
 export -f build_sandbox_exec_args
 export -f handle_sandbox_timeout
 export -f stop_sandbox_container

--- a/lib/sandbox_docker.sh
+++ b/lib/sandbox_docker.sh
@@ -32,8 +32,13 @@ source "$(dirname "${BASH_SOURCE[0]}")/date_utils.sh"
 # Use RALPH_DIR if set by the main script, otherwise default to .ralph
 RALPH_DIR="${RALPH_DIR:-.ralph}"
 DOCKER_SANDBOX_STATE_FILE="${DOCKER_SANDBOX_STATE_FILE:-$RALPH_DIR/.docker_sandbox_state}"
-SANDBOX_ENV_FILE="${SANDBOX_ENV_FILE:-$RALPH_DIR/.docker_sandbox_env}"
-SANDBOX_CLAUDE_HOME="${SANDBOX_CLAUDE_HOME:-$RALPH_DIR/.docker_claude_home}"
+# Credential artifacts must live OUTSIDE the project directory: the project is
+# bind-mounted read-write into the container, so anything under it would be
+# readable by the sandboxed process as workspace files and could be swept into
+# a commit. Only the (secret-free) state file stays in $RALPH_DIR.
+SANDBOX_RUNTIME_DIR="${SANDBOX_RUNTIME_DIR:-${TMPDIR:-/tmp}/ralph-sandbox-$$}"
+SANDBOX_ENV_FILE="${SANDBOX_ENV_FILE:-$SANDBOX_RUNTIME_DIR/env}"
+SANDBOX_CLAUDE_HOME="${SANDBOX_CLAUDE_HOME:-$SANDBOX_RUNTIME_DIR/claude_home}"
 
 # Sandbox configuration defaults (overridable via .ralphrc, env, or CLI flags)
 SANDBOX_PROVIDER="${SANDBOX_PROVIDER:-}"
@@ -213,6 +218,8 @@ init_docker_sandbox() {
 # The host ~/.gitconfig is also seeded (when present) so autonomous commits
 # inside the container have an identity. The API key value is never logged.
 setup_docker_credentials() {
+    mkdir -p "$SANDBOX_RUNTIME_DIR" || return 1
+    chmod 700 "$SANDBOX_RUNTIME_DIR"
     rm -rf "$SANDBOX_CLAUDE_HOME"
     mkdir -p "$SANDBOX_CLAUDE_HOME/.claude" || return 1
     chmod 700 "$SANDBOX_CLAUDE_HOME" "$SANDBOX_CLAUDE_HOME/.claude"
@@ -276,9 +283,24 @@ start_sandbox_container() {
 
     run_args+=("$SANDBOX_DOCKER_IMAGE" sleep infinity)
 
-    local container_id
-    if ! container_id=$(docker "${run_args[@]}" 2>&1); then
-        _sandbox_log "ERROR" "Failed to start sandbox container: $container_id"
+    # Capture stderr separately: a successful `docker run -d` can still emit
+    # warnings (e.g. "kernel does not support swap limit capabilities"), and
+    # merging them into stdout would corrupt the recorded container id.
+    local container_id run_stderr
+    run_stderr=$(mktemp) || return 1
+    if ! container_id=$(docker "${run_args[@]}" 2>"$run_stderr"); then
+        _sandbox_log "ERROR" "Failed to start sandbox container: $(cat "$run_stderr" 2>/dev/null)"
+        rm -f "$run_stderr"
+        return 1
+    fi
+    if [[ -s "$run_stderr" ]]; then
+        _sandbox_log "WARN" "docker run warning: $(head -1 "$run_stderr")"
+    fi
+    rm -f "$run_stderr"
+    # The id is the last stdout line (defensive against future docker chatter)
+    container_id=$(printf '%s\n' "$container_id" | tail -1)
+    if [[ -z "$container_id" ]]; then
+        _sandbox_log "ERROR" "docker run returned no container id"
         return 1
     fi
 
@@ -385,6 +407,7 @@ cleanup_docker_sandbox() {
     fi
     rm -f "$SANDBOX_ENV_FILE" 2>/dev/null
     rm -rf "$SANDBOX_CLAUDE_HOME" 2>/dev/null
+    rmdir "$SANDBOX_RUNTIME_DIR" 2>/dev/null || true
     if [[ -f "$DOCKER_SANDBOX_STATE_FILE" ]]; then
         _sandbox_apply '.container_id = "" | .status = "cleaned"' || true
     fi

--- a/lib/sandbox_docker.sh
+++ b/lib/sandbox_docker.sh
@@ -1,0 +1,374 @@
+#!/bin/bash
+# Docker Sandbox Execution for Ralph (Issue #74)
+#
+# Runs the Claude Code CLI inside a local Docker container instead of directly
+# on the host. Ralph's orchestration (loop control, rate limiting, circuit
+# breaker, response analysis, status.json) stays on the host; only the Claude
+# execution — the part that edits files and runs commands autonomously — is
+# containerized. The project directory is bind-mounted read-write at
+# /workspace, so file changes land on the host directly and ralph-monitor
+# keeps working unchanged.
+#
+# Design notes:
+#   - A single persistent container is started before the loop and reused by
+#     every iteration via `docker exec` (no per-loop startup cost; Claude's
+#     in-container session state survives across iterations).
+#   - State lives in $RALPH_DIR/.docker_sandbox_state (JSON), mutated through
+#     a temp file + mv so a crashed jq never leaves half-written state — the
+#     same convention as lib/github_lifecycle.sh / lib/queue_manager.sh.
+#   - Credentials: ANTHROPIC_API_KEY is handed off via a 0600 env-file passed
+#     to `docker run --env-file` (visible only at container-create time, never
+#     logged). Without an API key, the host's ~/.claude/.credentials.json is
+#     COPIED into a container-scoped claude home so the container never writes
+#     to the host's real ~/.claude. (`docker secret` is NOT used — it requires
+#     Swarm mode and does not work with plain `docker run`.)
+#   - A host-side timeout (exit 124) kills only the `docker exec` client; the
+#     process inside the container keeps running. handle_sandbox_timeout
+#     restarts the container to reap orphaned processes.
+
+# Source date utilities for cross-platform ISO timestamps
+source "$(dirname "${BASH_SOURCE[0]}")/date_utils.sh"
+
+# Use RALPH_DIR if set by the main script, otherwise default to .ralph
+RALPH_DIR="${RALPH_DIR:-.ralph}"
+DOCKER_SANDBOX_STATE_FILE="${DOCKER_SANDBOX_STATE_FILE:-$RALPH_DIR/.docker_sandbox_state}"
+SANDBOX_ENV_FILE="${SANDBOX_ENV_FILE:-$RALPH_DIR/.docker_sandbox_env}"
+SANDBOX_CLAUDE_HOME="${SANDBOX_CLAUDE_HOME:-$RALPH_DIR/.docker_claude_home}"
+
+# Sandbox configuration defaults (overridable via .ralphrc, env, or CLI flags)
+SANDBOX_PROVIDER="${SANDBOX_PROVIDER:-}"
+SANDBOX_DOCKER_IMAGE="${SANDBOX_DOCKER_IMAGE:-ralph-sandbox:latest}"
+SANDBOX_DOCKER_MEMORY="${SANDBOX_DOCKER_MEMORY:-4g}"
+SANDBOX_DOCKER_CPUS="${SANDBOX_DOCKER_CPUS:-2}"
+SANDBOX_DOCKER_NETWORK="${SANDBOX_DOCKER_NETWORK:-bridge}"
+
+# Default image name, used to tailor the "image missing" guidance
+SANDBOX_DEFAULT_IMAGE="ralph-sandbox:latest"
+
+# --- logging ----------------------------------------------------------------
+
+# _sandbox_log <level> <message>
+# Prefer the main script's log_status() when available; otherwise fall back to
+# stderr so the lib is usable (and testable) standalone.
+_sandbox_log() {
+    local level="$1"
+    local message="$2"
+    if declare -F log_status >/dev/null 2>&1; then
+        log_status "$level" "$message" >&2
+    else
+        echo "[$level] $message" >&2
+    fi
+}
+
+# --- state primitives -------------------------------------------------------
+
+# _sandbox_apply <jq-program> [jq args...]
+# Atomically mutate the sandbox state file with a jq program (temp file + mv).
+# Always refreshes .updated_at. Returns 1 if the state file is missing or jq
+# fails (leaving the original state untouched).
+_sandbox_apply() {
+    local program=$1
+    shift
+    [[ -f "$DOCKER_SANDBOX_STATE_FILE" ]] || return 1
+    local now tmp
+    now=$(get_iso_timestamp)
+    tmp=$(mktemp "${DOCKER_SANDBOX_STATE_FILE}.XXXXXX" 2>/dev/null) || return 1
+    if jq --arg now "$now" "$@" "($program) | .updated_at = \$now" \
+        "$DOCKER_SANDBOX_STATE_FILE" > "$tmp" 2>/dev/null; then
+        mv "$tmp" "$DOCKER_SANDBOX_STATE_FILE" || { rm -f "$tmp"; return 1; }
+        return 0
+    fi
+    rm -f "$tmp"
+    return 1
+}
+
+# sandbox_state_get <jq-path>
+# Print a value from the sandbox state file ("" if missing/null).
+sandbox_state_get() {
+    local path=$1
+    [[ -f "$DOCKER_SANDBOX_STATE_FILE" ]] || return 1
+    jq -r "$path // empty" "$DOCKER_SANDBOX_STATE_FILE" 2>/dev/null
+}
+
+# --- availability and validation ---------------------------------------------
+
+# docker_is_available
+# Returns 0 when the docker CLI exists AND the daemon responds.
+docker_is_available() {
+    if ! command -v docker &>/dev/null; then
+        _sandbox_log "ERROR" "Docker CLI not found. Install Docker: https://docs.docker.com/get-docker/"
+        return 1
+    fi
+    if ! docker info >/dev/null 2>&1; then
+        _sandbox_log "ERROR" "Docker daemon is not reachable. Is the Docker service running?"
+        return 1
+    fi
+    return 0
+}
+
+# validate_sandbox_config
+# Validates the SANDBOX_* configuration values. Prints the offending setting
+# on failure so CLI users get an actionable message.
+validate_sandbox_config() {
+    if [[ "$SANDBOX_PROVIDER" != "docker" ]]; then
+        echo "Error: unsupported sandbox provider '$SANDBOX_PROVIDER' (supported: docker)" >&2
+        return 1
+    fi
+    # Image references allow [registry/]name[:tag][@digest] characters only —
+    # this also blocks shell metacharacters from reaching the docker command.
+    if [[ -z "$SANDBOX_DOCKER_IMAGE" || ! "$SANDBOX_DOCKER_IMAGE" =~ ^[a-zA-Z0-9][a-zA-Z0-9._/:@-]*$ ]]; then
+        echo "Error: invalid sandbox image '$SANDBOX_DOCKER_IMAGE'" >&2
+        return 1
+    fi
+    # Docker memory format: integer with optional b/k/m/g suffix
+    if [[ ! "$SANDBOX_DOCKER_MEMORY" =~ ^[0-9]+[bkmgBKMG]?$ ]]; then
+        echo "Error: invalid sandbox memory limit '$SANDBOX_DOCKER_MEMORY' (expected e.g. 4g, 512m)" >&2
+        return 1
+    fi
+    # Docker --cpus accepts decimal values (e.g. 1.5)
+    if [[ ! "$SANDBOX_DOCKER_CPUS" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
+        echo "Error: invalid sandbox cpus limit '$SANDBOX_DOCKER_CPUS' (expected e.g. 2 or 1.5)" >&2
+        return 1
+    fi
+    case "$SANDBOX_DOCKER_NETWORK" in
+        none|bridge|host) ;;
+        *)
+            echo "Error: invalid sandbox network mode '$SANDBOX_DOCKER_NETWORK' (expected: none, bridge, or host)" >&2
+            return 1
+            ;;
+    esac
+    return 0
+}
+
+# --- initialization -----------------------------------------------------------
+
+# init_docker_sandbox
+# Validates config + environment and writes the initial sandbox state file.
+# Fails hard (return 1) on any problem — the caller must NOT fall back to
+# host execution when the user asked for sandboxing.
+init_docker_sandbox() {
+    if ! validate_sandbox_config; then
+        return 1
+    fi
+    if ! docker_is_available; then
+        return 1
+    fi
+
+    # The image must exist locally before the loop starts burning API calls
+    if ! docker image inspect "$SANDBOX_DOCKER_IMAGE" >/dev/null 2>&1; then
+        if [[ "$SANDBOX_DOCKER_IMAGE" == "$SANDBOX_DEFAULT_IMAGE" ]]; then
+            _sandbox_log "ERROR" "Sandbox image '$SANDBOX_DOCKER_IMAGE' not found."
+            echo "Build the default Ralph sandbox image first:" >&2
+            echo "  docker build -t ralph-sandbox \"\${RALPH_HOME:-\$HOME/.ralph}\"" >&2
+            echo "(or from a Ralph source checkout: docker build -t ralph-sandbox .)" >&2
+        else
+            _sandbox_log "ERROR" "Sandbox image '$SANDBOX_DOCKER_IMAGE' not found."
+            echo "Pull or build it first, e.g.: docker pull $SANDBOX_DOCKER_IMAGE" >&2
+        fi
+        return 1
+    fi
+
+    local now tmp
+    now=$(get_iso_timestamp)
+    tmp=$(mktemp "${DOCKER_SANDBOX_STATE_FILE}.XXXXXX" 2>/dev/null) || return 1
+    if jq -n \
+        --arg now "$now" \
+        --arg image "$SANDBOX_DOCKER_IMAGE" \
+        --arg memory "$SANDBOX_DOCKER_MEMORY" \
+        --arg cpus "$SANDBOX_DOCKER_CPUS" \
+        --arg network "$SANDBOX_DOCKER_NETWORK" \
+        '{
+            provider: "docker",
+            image: $image,
+            memory: $memory,
+            cpus: $cpus,
+            network: $network,
+            container_id: "",
+            status: "initialized",
+            created_at: $now,
+            updated_at: $now
+        }' > "$tmp" 2>/dev/null; then
+        mv "$tmp" "$DOCKER_SANDBOX_STATE_FILE" || { rm -f "$tmp"; return 1; }
+    else
+        rm -f "$tmp"
+        return 1
+    fi
+
+    _sandbox_log "INFO" "Docker sandbox initialized (image: $SANDBOX_DOCKER_IMAGE, network: $SANDBOX_DOCKER_NETWORK)"
+    return 0
+}
+
+# --- credentials ---------------------------------------------------------------
+
+# setup_docker_credentials
+# Prepares credential handoff for the container, preferring an explicit API key:
+#   1. ANTHROPIC_API_KEY set       → 0600 env-file passed via --env-file
+#   2. host ~/.claude credentials  → copied into a container-scoped claude home
+#                                    (mounted as $HOME/.claude inside the
+#                                    container; host credentials never mounted)
+#   3. neither                     → warn and continue (the image may have its
+#                                    own auth baked in)
+# The API key value is never logged.
+setup_docker_credentials() {
+    if [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
+        rm -f "$SANDBOX_ENV_FILE"
+        # Create with restrictive permissions BEFORE writing the secret
+        ( umask 177 && printf 'ANTHROPIC_API_KEY=%s\n' "$ANTHROPIC_API_KEY" > "$SANDBOX_ENV_FILE" ) || {
+            _sandbox_log "ERROR" "Failed to write sandbox env-file"
+            return 1
+        }
+        _sandbox_log "INFO" "Sandbox credentials: ANTHROPIC_API_KEY via env-file"
+        return 0
+    fi
+
+    if [[ -f "$HOME/.claude/.credentials.json" ]]; then
+        rm -rf "$SANDBOX_CLAUDE_HOME"
+        mkdir -p "$SANDBOX_CLAUDE_HOME/.claude" || return 1
+        chmod 700 "$SANDBOX_CLAUDE_HOME" "$SANDBOX_CLAUDE_HOME/.claude"
+        cp "$HOME/.claude/.credentials.json" "$SANDBOX_CLAUDE_HOME/.claude/.credentials.json" || return 1
+        chmod 600 "$SANDBOX_CLAUDE_HOME/.claude/.credentials.json"
+        _sandbox_log "INFO" "Sandbox credentials: seeded container claude home from host credentials"
+        return 0
+    fi
+
+    _sandbox_log "WARN" "No credentials found (ANTHROPIC_API_KEY unset, no ~/.claude/.credentials.json). Claude may fail to authenticate in the sandbox."
+    return 0
+}
+
+# --- container lifecycle --------------------------------------------------------
+
+# start_sandbox_container
+# Starts the persistent sandbox container: project dir bind-mounted read-write
+# at /workspace, resource limits and network mode applied, kept alive with
+# `sleep infinity` so iterations can `docker exec` into it. Records the
+# container id in the state file.
+start_sandbox_container() {
+    local project_dir
+    project_dir="$(pwd)"
+    local name="ralph-sandbox-$$-$(date +%s)"
+
+    local -a run_args=(run -d --init --name "$name"
+        -v "$project_dir:/workspace"
+        -w /workspace
+        --memory "$SANDBOX_DOCKER_MEMORY"
+        --cpus "$SANDBOX_DOCKER_CPUS"
+        --network "$SANDBOX_DOCKER_NETWORK")
+
+    if [[ -f "$SANDBOX_ENV_FILE" ]]; then
+        run_args+=(--env-file "$SANDBOX_ENV_FILE")
+    fi
+    if [[ -d "$SANDBOX_CLAUDE_HOME" ]]; then
+        # Mount the container-scoped claude home and point HOME at it so the
+        # Claude CLI finds credentials regardless of the image's user setup.
+        run_args+=(-v "$SANDBOX_CLAUDE_HOME:/ralph-home" -e HOME=/ralph-home)
+    fi
+
+    run_args+=("$SANDBOX_DOCKER_IMAGE" sleep infinity)
+
+    local container_id
+    if ! container_id=$(docker "${run_args[@]}" 2>&1); then
+        _sandbox_log "ERROR" "Failed to start sandbox container: $container_id"
+        return 1
+    fi
+
+    _sandbox_apply '.container_id = $cid | .status = "running" | .name = $name' \
+        --arg cid "$container_id" --arg name "$name" || return 1
+    _sandbox_log "SUCCESS" "Sandbox container started: ${container_id:0:12} (image: $SANDBOX_DOCKER_IMAGE)"
+    return 0
+}
+
+# build_sandbox_exec_args <command> [args...]
+# Populates the global SANDBOX_EXEC_ARGS array with the docker exec wrapping of
+# the given command (same global-array convention as CLAUDE_CMD_ARGS).
+# Environment from `docker run` (--env-file, HOME) is part of the container
+# config and is inherited by exec'd processes.
+build_sandbox_exec_args() {
+    local container_id
+    container_id=$(sandbox_state_get '.container_id')
+    if [[ -z "$container_id" ]]; then
+        _sandbox_log "ERROR" "No running sandbox container (start_sandbox_container first)"
+        return 1
+    fi
+    SANDBOX_EXEC_ARGS=(docker exec -i -w /workspace "$container_id" "$@")
+    return 0
+}
+
+# handle_sandbox_timeout
+# A host-side timeout kills the `docker exec` client but NOT the process inside
+# the container. Restart the container to reap orphaned processes so the next
+# iteration starts clean. No-op when no container is recorded.
+handle_sandbox_timeout() {
+    local container_id
+    container_id=$(sandbox_state_get '.container_id')
+    [[ -z "$container_id" ]] && return 0
+    _sandbox_log "WARN" "Sandbox timeout: restarting container to reap orphaned processes"
+    if ! docker restart -t 5 "$container_id" >/dev/null 2>&1; then
+        _sandbox_log "WARN" "Failed to restart sandbox container ${container_id:0:12}"
+    fi
+    return 0
+}
+
+# stop_sandbox_container
+# Gracefully stop and remove the sandbox container, clearing it from state.
+stop_sandbox_container() {
+    local container_id
+    container_id=$(sandbox_state_get '.container_id')
+    [[ -z "$container_id" ]] && return 0
+    docker stop -t 10 "$container_id" >/dev/null 2>&1 || \
+        _sandbox_log "WARN" "Failed to stop sandbox container ${container_id:0:12}"
+    docker rm -f "$container_id" >/dev/null 2>&1 || \
+        _sandbox_log "WARN" "Failed to remove sandbox container ${container_id:0:12}"
+    _sandbox_apply '.container_id = "" | .status = "stopped"' || true
+    _sandbox_log "INFO" "Sandbox container stopped"
+    return 0
+}
+
+# cleanup_docker_sandbox
+# Full teardown: container, credential env-file, and seeded claude home.
+# Idempotent and safe to call from traps, before init, or repeatedly — it
+# always returns 0 so cleanup paths never mask the real exit status.
+cleanup_docker_sandbox() {
+    local container_id=""
+    if [[ -f "$DOCKER_SANDBOX_STATE_FILE" ]]; then
+        container_id=$(sandbox_state_get '.container_id')
+    fi
+    if [[ -n "$container_id" ]]; then
+        docker stop -t 10 "$container_id" >/dev/null 2>&1 || true
+        docker rm -f "$container_id" >/dev/null 2>&1 || true
+    fi
+    rm -f "$SANDBOX_ENV_FILE" 2>/dev/null
+    rm -rf "$SANDBOX_CLAUDE_HOME" 2>/dev/null
+    if [[ -f "$DOCKER_SANDBOX_STATE_FILE" ]]; then
+        _sandbox_apply '.container_id = "" | .status = "cleaned"' || true
+    fi
+    return 0
+}
+
+# --- status -----------------------------------------------------------------
+
+# get_sandbox_status
+# Emits a JSON object for embedding in status.json:
+#   {"provider": "docker", "container_id": "...", "status": "running"}
+# Prints {"provider": "none"} when the sandbox was never initialized.
+get_sandbox_status() {
+    if [[ ! -f "$DOCKER_SANDBOX_STATE_FILE" ]]; then
+        echo '{"provider": "none"}'
+        return 0
+    fi
+    jq -c '{provider, container_id, status}' "$DOCKER_SANDBOX_STATE_FILE" 2>/dev/null \
+        || echo '{"provider": "none"}'
+    return 0
+}
+
+# Export public functions for use by ralph_loop.sh
+export -f docker_is_available
+export -f validate_sandbox_config
+export -f init_docker_sandbox
+export -f setup_docker_credentials
+export -f start_sandbox_container
+export -f build_sandbox_exec_args
+export -f handle_sandbox_timeout
+export -f stop_sandbox_container
+export -f cleanup_docker_sandbox
+export -f get_sandbox_status
+export -f sandbox_state_get

--- a/ralph_loop.sh
+++ b/ralph_loop.sh
@@ -1664,7 +1664,6 @@ rollback_to_backup() {
     return 0
 }
 
-# Main execution function
 # wrap_claude_command_for_sandbox - Route CLAUDE_CMD_ARGS through the sandbox (Issue #74)
 #
 # Replaces the global CLAUDE_CMD_ARGS array with its `docker exec` wrapping so
@@ -1680,6 +1679,7 @@ wrap_claude_command_for_sandbox() {
     return 0
 }
 
+# Main execution function
 execute_claude_code() {
     local timestamp=$(date '+%Y-%m-%d_%H-%M-%S')
     local output_file="$LOG_DIR/claude_output_${timestamp}.log"

--- a/ralph_loop.sh
+++ b/ralph_loop.sh
@@ -8,6 +8,16 @@
 # via --allowedTools flag in CLAUDE_CMD_ARGS, which is the proper approach.
 # Exporting sandbox variables without a verified sandbox would be misleading.
 
+# Issue #74: capture sandbox environment state BEFORE sourcing the libraries —
+# lib/sandbox_docker.sh sets defaults for these at source time, so capturing
+# after (like the main _env_* block below) would treat lib defaults as
+# user-provided environment values and break .ralphrc overrides.
+_env_SANDBOX_PROVIDER="${SANDBOX_PROVIDER:-}"
+_env_SANDBOX_DOCKER_IMAGE="${SANDBOX_DOCKER_IMAGE:-}"
+_env_SANDBOX_DOCKER_MEMORY="${SANDBOX_DOCKER_MEMORY:-}"
+_env_SANDBOX_DOCKER_CPUS="${SANDBOX_DOCKER_CPUS:-}"
+_env_SANDBOX_DOCKER_NETWORK="${SANDBOX_DOCKER_NETWORK:-}"
+
 # Source library components
 SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
 source "$SCRIPT_DIR/lib/date_utils.sh" || { echo "FATAL: Failed to source lib/date_utils.sh" >&2; exit 1; }
@@ -17,6 +27,7 @@ source "$SCRIPT_DIR/lib/circuit_breaker.sh" || { echo "FATAL: Failed to source l
 source "$SCRIPT_DIR/lib/file_protection.sh" || { echo "FATAL: Failed to source lib/file_protection.sh" >&2; exit 1; }
 source "$SCRIPT_DIR/lib/log_utils.sh" || { echo "FATAL: Failed to source lib/log_utils.sh" >&2; exit 1; }
 source "$SCRIPT_DIR/lib/github_lifecycle.sh" || { echo "FATAL: Failed to source lib/github_lifecycle.sh" >&2; exit 1; }
+source "$SCRIPT_DIR/lib/sandbox_docker.sh" || { echo "FATAL: Failed to source lib/sandbox_docker.sh" >&2; exit 1; }
 
 # Configuration
 # Ralph-specific files live in .ralph/ subfolder
@@ -105,6 +116,13 @@ DRAFT_PR="${DRAFT_PR:-false}"                          # Create the PR as a draf
 CREATE_FOLLOWUPS="${CREATE_FOLLOWUPS:-false}"          # Open a follow-up issue for discovered TODOs
 FOLLOWUP_LABEL="${FOLLOWUP_LABEL:-tech-debt}"          # Label applied to follow-up issues
 ADD_COMPLETION_LABELS="${ADD_COMPLETION_LABELS:-}"     # Comma-separated labels added to the issue on close
+# Issue #74: Docker sandbox execution (lib/sandbox_docker.sh sets the same
+# defaults at source time; repeated here so the configuration surface is visible)
+SANDBOX_PROVIDER="${SANDBOX_PROVIDER:-}"                          # "" = host execution; "docker" = sandboxed
+SANDBOX_DOCKER_IMAGE="${SANDBOX_DOCKER_IMAGE:-ralph-sandbox:latest}"  # Container image for sandboxed execution
+SANDBOX_DOCKER_MEMORY="${SANDBOX_DOCKER_MEMORY:-4g}"              # Container memory limit
+SANDBOX_DOCKER_CPUS="${SANDBOX_DOCKER_CPUS:-2}"                   # Container CPU limit
+SANDBOX_DOCKER_NETWORK="${SANDBOX_DOCKER_NETWORK:-bridge}"        # none | bridge | host (bridge: Claude API reachable)
 
 # Session management configuration (Phase 1.2)
 # Note: SESSION_EXPIRATION_SECONDS is defined in lib/response_analyzer.sh (86400 = 24 hours)
@@ -292,6 +310,11 @@ load_ralphrc() {
     [[ -n "$_env_CREATE_FOLLOWUPS" ]] && CREATE_FOLLOWUPS="$_env_CREATE_FOLLOWUPS"
     [[ -n "$_env_FOLLOWUP_LABEL" ]] && FOLLOWUP_LABEL="$_env_FOLLOWUP_LABEL"
     [[ -n "$_env_ADD_COMPLETION_LABELS" ]] && ADD_COMPLETION_LABELS="$_env_ADD_COMPLETION_LABELS"
+    [[ -n "$_env_SANDBOX_PROVIDER" ]] && SANDBOX_PROVIDER="$_env_SANDBOX_PROVIDER"
+    [[ -n "$_env_SANDBOX_DOCKER_IMAGE" ]] && SANDBOX_DOCKER_IMAGE="$_env_SANDBOX_DOCKER_IMAGE"
+    [[ -n "$_env_SANDBOX_DOCKER_MEMORY" ]] && SANDBOX_DOCKER_MEMORY="$_env_SANDBOX_DOCKER_MEMORY"
+    [[ -n "$_env_SANDBOX_DOCKER_CPUS" ]] && SANDBOX_DOCKER_CPUS="$_env_SANDBOX_DOCKER_CPUS"
+    [[ -n "$_env_SANDBOX_DOCKER_NETWORK" ]] && SANDBOX_DOCKER_NETWORK="$_env_SANDBOX_DOCKER_NETWORK"
 
     RALPHRC_LOADED=true
     return 0
@@ -516,6 +539,14 @@ setup_tmux_session() {
         [[ "$FOLLOWUP_LABEL" != "tech-debt" ]] && ralph_cmd="$ralph_cmd --followup-label '$FOLLOWUP_LABEL'"
         [[ -n "$ADD_COMPLETION_LABELS" ]] && ralph_cmd="$ralph_cmd --add-label '$ADD_COMPLETION_LABELS'"
     fi
+    # Forward Docker sandbox flags (Issue #74) so --monitor preserves them
+    if [[ -n "${SANDBOX_PROVIDER:-}" ]]; then
+        ralph_cmd="$ralph_cmd --sandbox $SANDBOX_PROVIDER"
+        [[ "${SANDBOX_DOCKER_IMAGE:-ralph-sandbox:latest}" != "ralph-sandbox:latest" ]] && ralph_cmd="$ralph_cmd --sandbox-image '$SANDBOX_DOCKER_IMAGE'"
+        [[ "${SANDBOX_DOCKER_MEMORY:-4g}" != "4g" ]] && ralph_cmd="$ralph_cmd --sandbox-memory $SANDBOX_DOCKER_MEMORY"
+        [[ "${SANDBOX_DOCKER_CPUS:-2}" != "2" ]] && ralph_cmd="$ralph_cmd --sandbox-cpus $SANDBOX_DOCKER_CPUS"
+        [[ "${SANDBOX_DOCKER_NETWORK:-bridge}" != "bridge" ]] && ralph_cmd="$ralph_cmd --sandbox-network $SANDBOX_DOCKER_NETWORK"
+    fi
 
     # Chain tmux kill-session after the loop command so the entire tmux
     # session is torn down when the Ralph loop exits (graceful completion,
@@ -612,6 +643,12 @@ update_status() {
     
     local tokens_used
     tokens_used=$(cat "$TOKEN_COUNT_FILE" 2>/dev/null || echo "0")
+    # Issue #74: surface sandbox state for ralph-monitor (read before the
+    # heredoc per the project convention — no lazy $() inside cat >)
+    local sandbox_json='{"provider": "none"}'
+    if [[ -n "${SANDBOX_PROVIDER:-}" ]] && declare -F get_sandbox_status >/dev/null 2>&1; then
+        sandbox_json=$(get_sandbox_status)
+    fi
     cat > "$STATUS_FILE" << STATUSEOF
 {
     "timestamp": "$(get_iso_timestamp)",
@@ -623,6 +660,7 @@ update_status() {
     "last_action": "$last_action",
     "status": "$status",
     "exit_reason": "$exit_reason",
+    "sandbox": $sandbox_json,
     "next_reset": "$(get_next_hour_time)"
 }
 STATUSEOF
@@ -1627,6 +1665,21 @@ rollback_to_backup() {
 }
 
 # Main execution function
+# wrap_claude_command_for_sandbox - Route CLAUDE_CMD_ARGS through the sandbox (Issue #74)
+#
+# Replaces the global CLAUDE_CMD_ARGS array with its `docker exec` wrapping so
+# the Claude CLI runs inside the persistent sandbox container. The array-in/
+# array-out shape keeps both execution paths (live stream-json pipeline and
+# background mode) working unchanged. Returns 1 when no container is running —
+# callers must treat that as fatal rather than falling back to host execution.
+wrap_claude_command_for_sandbox() {
+    if ! build_sandbox_exec_args "${CLAUDE_CMD_ARGS[@]}"; then
+        return 1
+    fi
+    CLAUDE_CMD_ARGS=("${SANDBOX_EXEC_ARGS[@]}")
+    return 0
+}
+
 execute_claude_code() {
     local timestamp=$(date '+%Y-%m-%d_%H-%M-%S')
     local output_file="$LOG_DIR/claude_output_${timestamp}.log"
@@ -1688,6 +1741,21 @@ execute_claude_code() {
             log_status "ERROR" "Live mode requires a built Claude command. Falling back to background mode."
             LIVE_OUTPUT=false
         fi
+    fi
+
+    # Issue #74: route execution through the Docker sandbox. The user asked for
+    # isolation, so a failure here is fatal — NEVER silently fall back to
+    # executing Claude on the host.
+    if [[ "$SANDBOX_PROVIDER" == "docker" ]]; then
+        if [[ "$use_modern_cli" != "true" ]]; then
+            log_status "ERROR" "Sandbox mode requires the modern CLI command; refusing host-side legacy fallback"
+            return 1
+        fi
+        if ! wrap_claude_command_for_sandbox; then
+            log_status "ERROR" "Failed to wrap Claude command for sandbox execution"
+            return 1
+        fi
+        log_status "INFO" "🐳 Executing in Docker sandbox (image: $SANDBOX_DOCKER_IMAGE)"
     fi
 
     # Execute Claude Code
@@ -2145,6 +2213,12 @@ EOF
         if [[ $exit_code -eq 124 ]]; then
             log_status "WARN" "⏱️ Claude Code execution timed out (not an API limit)"
 
+            # Issue #74: a host-side timeout kills only the docker exec client;
+            # restart the container so orphaned in-container processes are reaped
+            if [[ "$SANDBOX_PROVIDER" == "docker" ]]; then
+                handle_sandbox_timeout
+            fi
+
             # Check git for actual changes made during the timed-out execution
             local timeout_loop_start_sha=""
             local timeout_current_sha=""
@@ -2258,6 +2332,13 @@ cleanup() {
     if [[ "$_CLEANUP_DONE" == "true" ]]; then return; fi
     _CLEANUP_DONE=true
 
+    # Tear down the Docker sandbox on any exit path so no orphaned containers
+    # or credential files are left behind (Issue #74). cleanup_docker_sandbox
+    # is idempotent, so running here AND after the main loop is safe.
+    if [[ "${SANDBOX_PROVIDER:-}" == "docker" ]] && declare -F cleanup_docker_sandbox >/dev/null 2>&1; then
+        cleanup_docker_sandbox
+    fi
+
     # Only record "interrupted" status for abnormal exits (non-zero exit code)
     # Normal exit (code 0) preserves the status already written by the main loop
     if [[ $loop_count -gt 0 && $trap_exit_code -ne 0 ]]; then
@@ -2315,6 +2396,21 @@ main() {
     [[ "${_cli_CREATE_FOLLOWUPS:-false}" == "true" ]] && CREATE_FOLLOWUPS=true
     [[ -n "${_cli_FOLLOWUP_LABEL:-}" ]] && FOLLOWUP_LABEL="$_cli_FOLLOWUP_LABEL"
     [[ -n "${_cli_ADD_COMPLETION_LABELS:-}" ]] && ADD_COMPLETION_LABELS="$_cli_ADD_COMPLETION_LABELS"
+    # Docker sandbox flags (Issue #74) — CLI overrides .ralphrc
+    [[ -n "${_cli_SANDBOX_PROVIDER:-}" ]] && SANDBOX_PROVIDER="$_cli_SANDBOX_PROVIDER"
+    [[ -n "${_cli_SANDBOX_IMAGE:-}" ]] && SANDBOX_DOCKER_IMAGE="$_cli_SANDBOX_IMAGE"
+    [[ -n "${_cli_SANDBOX_MEMORY:-}" ]] && SANDBOX_DOCKER_MEMORY="$_cli_SANDBOX_MEMORY"
+    [[ -n "${_cli_SANDBOX_CPUS:-}" ]] && SANDBOX_DOCKER_CPUS="$_cli_SANDBOX_CPUS"
+    [[ -n "${_cli_SANDBOX_NETWORK:-}" ]] && SANDBOX_DOCKER_NETWORK="$_cli_SANDBOX_NETWORK"
+
+    # Sandbox sub-flags are meaningless without a provider (Issue #74). Checked
+    # here (not at parse time) because .ralphrc may legitimately supply
+    # SANDBOX_PROVIDER while the CLI only overrides e.g. the image.
+    if [[ -z "$SANDBOX_PROVIDER" ]] && \
+       [[ -n "${_cli_SANDBOX_IMAGE:-}${_cli_SANDBOX_MEMORY:-}${_cli_SANDBOX_CPUS:-}${_cli_SANDBOX_NETWORK:-}" ]]; then
+        log_status "ERROR" "--sandbox-image/--sandbox-memory/--sandbox-cpus/--sandbox-network require --sandbox docker"
+        exit 1
+    fi
 
     # Source user shell init file if configured (e.g. ~/.zshrc for zsh environments)
     # This allows non-bash shells or non-standard setups to export PATH/env vars
@@ -2329,15 +2425,21 @@ main() {
         fi
     fi
 
-    # Validate Claude Code CLI is available before starting
-    if ! validate_claude_command; then
-        log_status "ERROR" "Claude Code CLI not found: $CLAUDE_CODE_CMD"
-        exit 1
-    fi
+    # Validate Claude Code CLI is available before starting. In sandbox mode
+    # Claude runs inside the container (the image pins its own CLI), so host
+    # validation/version checks are skipped (Issue #74).
+    if [[ "$SANDBOX_PROVIDER" == "docker" ]]; then
+        log_status "INFO" "Sandbox mode: skipping host Claude CLI validation (container provides the CLI)"
+    else
+        if ! validate_claude_command; then
+            log_status "ERROR" "Claude Code CLI not found: $CLAUDE_CODE_CMD"
+            exit 1
+        fi
 
-    # Check CLI version compatibility and auto-update (Issue #190)
-    check_claude_version
-    check_claude_updates
+        # Check CLI version compatibility and auto-update (Issue #190)
+        check_claude_version
+        check_claude_updates
+    fi
 
     log_status "SUCCESS" "🚀 Ralph loop starting with Claude Code"
     log_status "INFO" "Max calls per hour: $MAX_CALLS_PER_HOUR"
@@ -2375,6 +2477,18 @@ main() {
         echo "$(get_integrity_report)"
         echo ""
         exit 1
+    fi
+
+    # Start the Docker sandbox before entering the loop (Issue #74). One
+    # persistent container serves every iteration via docker exec. Any failure
+    # is fatal — the user asked for isolation, so host fallback is forbidden.
+    if [[ "$SANDBOX_PROVIDER" == "docker" ]]; then
+        log_status "INFO" "🐳 Docker sandbox mode enabled (image: $SANDBOX_DOCKER_IMAGE, network: $SANDBOX_DOCKER_NETWORK)"
+        if ! init_docker_sandbox || ! setup_docker_credentials || ! start_sandbox_container; then
+            log_status "ERROR" "Docker sandbox setup failed — refusing to fall back to host execution"
+            cleanup_docker_sandbox
+            exit 1
+        fi
     fi
 
     # Initialize session tracking before entering the loop
@@ -2599,6 +2713,12 @@ main() {
         
         log_status "LOOP" "=== Completed Loop #$loop_count ==="
     done
+
+    # Tear down the sandbox on every normal loop exit (break paths). The
+    # SIGINT/SIGTERM trap covers interrupts; cleanup is idempotent (Issue #74).
+    if [[ "$SANDBOX_PROVIDER" == "docker" ]]; then
+        cleanup_docker_sandbox
+    fi
 }
 
 # Help function
@@ -2651,6 +2771,16 @@ GitHub issue lifecycle (Issue #73; all opt-in, require --github-issue):
     --create-followups      Open a follow-up issue for TODO/FIXME markers added during dev
     --followup-label LABEL  Label for follow-up issues (default: $FOLLOWUP_LABEL)
     --add-label LABEL       Label to add to the issue on close (repeatable)
+
+Sandbox execution (Issue #74; isolates Claude in a Docker container):
+    --sandbox PROVIDER      Run Claude Code inside a sandbox: docker
+                            (e2b, daytona, cloudflare planned — see issues #75/#79/#80)
+    --sandbox-image IMAGE   Container image (default: $SANDBOX_DOCKER_IMAGE)
+                            Build the default: docker build -t ralph-sandbox .
+    --sandbox-memory SIZE   Container memory limit (default: $SANDBOX_DOCKER_MEMORY)
+    --sandbox-cpus NUM      Container CPU limit (default: $SANDBOX_DOCKER_CPUS)
+    --sandbox-network MODE  Container network: none, bridge, host (default: $SANDBOX_DOCKER_NETWORK)
+                            Note: 'none' blocks the Claude API — only for pre-authenticated images
 
 Modern CLI Options (Phase 1.1):
     --output-format FORMAT  Set Claude output format: json or text (default: $CLAUDE_OUTPUT_FORMAT)
@@ -2877,6 +3007,64 @@ while [[ $# -gt 0 ]]; do
                 ADD_COMPLETION_LABELS="$2"
             fi
             _cli_ADD_COMPLETION_LABELS="$ADD_COMPLETION_LABELS"
+            shift 2
+            ;;
+        --sandbox)
+            # Docker sandbox execution (Issue #74)
+            case "${2:-}" in
+                docker)
+                    SANDBOX_PROVIDER="docker"
+                    _cli_SANDBOX_PROVIDER="docker"
+                    ;;
+                e2b|daytona|cloudflare)
+                    echo "Error: --sandbox $2 is not yet implemented (see issues #75, #79, #80). Supported: docker"
+                    exit 1
+                    ;;
+                *)
+                    echo "Error: --sandbox requires a provider. Supported: docker"
+                    exit 1
+                    ;;
+            esac
+            shift 2
+            ;;
+        --sandbox-image)
+            if [[ -z "${2:-}" || ! "$2" =~ ^[a-zA-Z0-9][a-zA-Z0-9._/:@-]*$ ]]; then
+                echo "Error: --sandbox-image requires a valid image reference (e.g. node:20)"
+                exit 1
+            fi
+            SANDBOX_DOCKER_IMAGE="$2"
+            _cli_SANDBOX_IMAGE="$2"
+            shift 2
+            ;;
+        --sandbox-memory)
+            if [[ ! "${2:-}" =~ ^[0-9]+[bkmgBKMG]?$ ]]; then
+                echo "Error: --sandbox-memory must be a Docker memory limit (e.g. 4g, 512m)"
+                exit 1
+            fi
+            SANDBOX_DOCKER_MEMORY="$2"
+            _cli_SANDBOX_MEMORY="$2"
+            shift 2
+            ;;
+        --sandbox-cpus)
+            if [[ ! "${2:-}" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
+                echo "Error: --sandbox-cpus must be numeric (e.g. 2 or 1.5)"
+                exit 1
+            fi
+            SANDBOX_DOCKER_CPUS="$2"
+            _cli_SANDBOX_CPUS="$2"
+            shift 2
+            ;;
+        --sandbox-network)
+            case "${2:-}" in
+                none|bridge|host)
+                    SANDBOX_DOCKER_NETWORK="$2"
+                    _cli_SANDBOX_NETWORK="$2"
+                    ;;
+                *)
+                    echo "Error: --sandbox-network must be none, bridge, or host"
+                    exit 1
+                    ;;
+            esac
             shift 2
             ;;
         --queue-status)

--- a/ralph_loop.sh
+++ b/ralph_loop.sh
@@ -1672,6 +1672,12 @@ rollback_to_backup() {
 # background mode) working unchanged. Returns 1 when no container is running —
 # callers must treat that as fatal rather than falling back to host execution.
 wrap_claude_command_for_sandbox() {
+    # Liveness + recovery first: the container can die between iterations
+    # (OOM kill under --memory, daemon restart) and exec against a dead
+    # container would burn loops until the circuit breaker opens.
+    if ! ensure_sandbox_container; then
+        return 1
+    fi
     if ! build_sandbox_exec_args "${CLAUDE_CMD_ARGS[@]}"; then
         return 1
     fi
@@ -2409,6 +2415,14 @@ main() {
     if [[ -z "$SANDBOX_PROVIDER" ]] && \
        [[ -n "${_cli_SANDBOX_IMAGE:-}${_cli_SANDBOX_MEMORY:-}${_cli_SANDBOX_CPUS:-}${_cli_SANDBOX_NETWORK:-}" ]]; then
         log_status "ERROR" "--sandbox-image/--sandbox-memory/--sandbox-cpus/--sandbox-network require --sandbox docker"
+        exit 1
+    fi
+
+    # SANDBOX_PROVIDER can arrive via env/.ralphrc, bypassing the CLI's parse-time
+    # validation. An unsupported value (typo, not-yet-implemented provider) must
+    # halt — silently executing on the host would defeat the requested isolation.
+    if [[ -n "$SANDBOX_PROVIDER" && "$SANDBOX_PROVIDER" != "docker" ]]; then
+        log_status "ERROR" "Unsupported sandbox provider '$SANDBOX_PROVIDER' (supported: docker). Refusing host execution."
         exit 1
     fi
 

--- a/ralph_loop.sh
+++ b/ralph_loop.sh
@@ -539,14 +539,15 @@ setup_tmux_session() {
         [[ "$FOLLOWUP_LABEL" != "tech-debt" ]] && ralph_cmd="$ralph_cmd --followup-label '$FOLLOWUP_LABEL'"
         [[ -n "$ADD_COMPLETION_LABELS" ]] && ralph_cmd="$ralph_cmd --add-label '$ADD_COMPLETION_LABELS'"
     fi
-    # Forward Docker sandbox flags (Issue #74) so --monitor preserves them
-    if [[ -n "${SANDBOX_PROVIDER:-}" ]]; then
-        ralph_cmd="$ralph_cmd --sandbox $SANDBOX_PROVIDER"
-        [[ "${SANDBOX_DOCKER_IMAGE:-ralph-sandbox:latest}" != "ralph-sandbox:latest" ]] && ralph_cmd="$ralph_cmd --sandbox-image '$SANDBOX_DOCKER_IMAGE'"
-        [[ "${SANDBOX_DOCKER_MEMORY:-4g}" != "4g" ]] && ralph_cmd="$ralph_cmd --sandbox-memory $SANDBOX_DOCKER_MEMORY"
-        [[ "${SANDBOX_DOCKER_CPUS:-2}" != "2" ]] && ralph_cmd="$ralph_cmd --sandbox-cpus $SANDBOX_DOCKER_CPUS"
-        [[ "${SANDBOX_DOCKER_NETWORK:-bridge}" != "bridge" ]] && ralph_cmd="$ralph_cmd --sandbox-network $SANDBOX_DOCKER_NETWORK"
-    fi
+    # Forward Docker sandbox flags (Issue #74) so --monitor preserves them.
+    # Sub-flags forward independently of the provider: this runs BEFORE main()
+    # loads .ralphrc, which may be what supplies SANDBOX_PROVIDER — the child
+    # re-validates the sub-flag/provider pairing at its own startup.
+    [[ -n "${SANDBOX_PROVIDER:-}" ]] && ralph_cmd="$ralph_cmd --sandbox $SANDBOX_PROVIDER"
+    [[ "${SANDBOX_DOCKER_IMAGE:-ralph-sandbox:latest}" != "ralph-sandbox:latest" ]] && ralph_cmd="$ralph_cmd --sandbox-image '$SANDBOX_DOCKER_IMAGE'"
+    [[ "${SANDBOX_DOCKER_MEMORY:-4g}" != "4g" ]] && ralph_cmd="$ralph_cmd --sandbox-memory $SANDBOX_DOCKER_MEMORY"
+    [[ "${SANDBOX_DOCKER_CPUS:-2}" != "2" ]] && ralph_cmd="$ralph_cmd --sandbox-cpus $SANDBOX_DOCKER_CPUS"
+    [[ "${SANDBOX_DOCKER_NETWORK:-bridge}" != "bridge" ]] && ralph_cmd="$ralph_cmd --sandbox-network $SANDBOX_DOCKER_NETWORK"
 
     # Chain tmux kill-session after the loop command so the entire tmux
     # session is torn down when the Ralph loop exits (graceful completion,
@@ -1678,7 +1679,12 @@ wrap_claude_command_for_sandbox() {
     if ! ensure_sandbox_container; then
         return 1
     fi
-    if ! build_sandbox_exec_args "${CLAUDE_CMD_ARGS[@]}"; then
+    # Inside the container the CLI is always `claude` on PATH. Host-specific
+    # CLAUDE_CODE_CMD values (absolute paths like /opt/homebrew/bin/claude,
+    # npx wrappers) don't exist in the image, so argv[0] is rewritten.
+    local -a container_cmd=("${CLAUDE_CMD_ARGS[@]}")
+    container_cmd[0]="claude"
+    if ! build_sandbox_exec_args "${container_cmd[@]}"; then
         return 1
     fi
     CLAUDE_CMD_ARGS=("${SANDBOX_EXEC_ARGS[@]}")

--- a/templates/ralphrc.template
+++ b/templates/ralphrc.template
@@ -114,3 +114,16 @@ RALPH_VERBOSE=false
 
 # Custom agent file (relative to .ralph/)
 # AGENT_FILE="@AGENT.md"
+
+# =============================================================================
+# DOCKER SANDBOX EXECUTION (optional, Issue #74)
+# =============================================================================
+
+# Run Claude Code inside an isolated Docker container instead of on the host.
+# Build the default image first: docker build -t ralph-sandbox ~/.ralph
+# CLI flags (--sandbox, --sandbox-image, ...) override these values.
+# SANDBOX_PROVIDER="docker"
+# SANDBOX_DOCKER_IMAGE="ralph-sandbox:latest"
+# SANDBOX_DOCKER_MEMORY="4g"
+# SANDBOX_DOCKER_CPUS="2"
+# SANDBOX_DOCKER_NETWORK="bridge"   # none | bridge | host ('none' blocks the Claude API)

--- a/tests/e2e/test_sandbox_loop.bats
+++ b/tests/e2e/test_sandbox_loop.bats
@@ -1,0 +1,95 @@
+#!/usr/bin/env bats
+# E2E tests: full Ralph loop in Docker sandbox mode (Issue #74)
+#
+# Runs ralph_loop.sh as a TRUE SUBPROCESS with both the mock claude CLI and a
+# mock docker on PATH. The docker mock delegates `docker exec` to the wrapped
+# command (which is the mock claude), proving the loop's command routing
+# end-to-end: main() sandbox init → docker run → per-iteration docker exec →
+# container cleanup on graceful exit. Covers the main() wiring that the
+# sourced-function integration tests cannot reach.
+
+load '../helpers/test_helper'
+load 'helpers/e2e_helper'
+
+setup() {
+    setup_e2e_project
+    install_mock_docker
+}
+
+teardown() {
+    teardown_e2e_project
+}
+
+# Mock docker: records every invocation, reports a healthy daemon/image, and
+# delegates `exec` to the wrapped command so the mock claude actually runs.
+install_mock_docker() {
+    cat > "$E2E_DIR/bin/docker" << EOF
+#!/usr/bin/env bash
+DOCKER_LOG="$MOCK_DIR/docker_calls.log"
+EOF
+    cat >> "$E2E_DIR/bin/docker" << 'EOF'
+printf '%s\n' "$*" >> "$DOCKER_LOG"
+case "$1" in
+    info)  exit 0 ;;
+    image) exit 0 ;;
+    run)   echo "e2emockcontainer"; exit 0 ;;
+    exec)
+        # argv: exec -i -w /workspace <container-id> <claude-path> [args...]
+        shift 5
+        exec "$@"
+        ;;
+    stop|rm|restart) exit 0 ;;
+esac
+exit 0
+EOF
+    chmod +x "$E2E_DIR/bin/docker"
+    export PATH="$E2E_DIR/bin:$PATH"
+}
+
+docker_calls() { cat "$MOCK_DIR/docker_calls.log" 2>/dev/null; }
+
+@test "E2E: sandbox loop routes execution through docker exec and cleans up" {
+    queue_response 1 "COMPLETE" "true" "All planned work has shipped."
+    queue_productive_effect 1
+    queue_response 2 "COMPLETE" "true" "Confirming: nothing left to build."
+    queue_productive_effect 2
+
+    run run_ralph --sandbox docker
+
+    assert_success
+    # The loop ran to graceful completion entirely through the sandbox
+    assert_equal "$(mock_call_count)" "2"
+    assert_equal "$(status_field exit_reason)" "completion_signals"
+    assert_equal "$(status_field status)" "completed"
+    # status.json surfaces the sandbox for ralph-monitor
+    assert_equal "$(status_field sandbox.provider)" "docker"
+
+    # One persistent container: a single docker run, one exec per iteration
+    [[ $(docker_calls | grep -c '^run ') -eq 1 ]]
+    [[ $(docker_calls | grep -c '^exec ') -eq 2 ]]
+    # Workspace bind mount and image are part of the run command
+    docker_calls | grep '^run ' | grep -q -- "-v $PROJECT_DIR:/workspace"
+    docker_calls | grep '^run ' | grep -q "ralph-sandbox:latest"
+    # Normal exit tore the container down
+    docker_calls | grep -q '^stop '
+    docker_calls | grep -q '^rm '
+
+    # Side effects from the (sandboxed) claude landed in the project workspace
+    assert_file_exists "src/work_1.txt"
+}
+
+@test "E2E: sandbox setup failure halts before any API call (no host fallback)" {
+    # Simulate an unreachable docker daemon
+    cat > "$E2E_DIR/bin/docker" << 'EOF'
+#!/usr/bin/env bash
+echo "Cannot connect to the Docker daemon" >&2
+exit 1
+EOF
+    chmod +x "$E2E_DIR/bin/docker"
+
+    run run_ralph --sandbox docker
+
+    [ "$status" -ne 0 ]
+    assert_equal "$(mock_call_count)" "0"
+    [[ "$output" == *"refusing to fall back to host execution"* ]]
+}

--- a/tests/e2e/test_sandbox_loop.bats
+++ b/tests/e2e/test_sandbox_loop.bats
@@ -30,9 +30,10 @@ EOF
     cat >> "$E2E_DIR/bin/docker" << 'EOF'
 printf '%s\n' "$*" >> "$DOCKER_LOG"
 case "$1" in
-    info)  exit 0 ;;
-    image) exit 0 ;;
-    run)   echo "e2emockcontainer"; exit 0 ;;
+    info)    exit 0 ;;
+    image)   exit 0 ;;
+    inspect) echo "true"; exit 0 ;;
+    run)     echo "e2emockcontainer"; exit 0 ;;
     exec)
         # argv: exec -i -w /workspace <container-id> <claude-path> [args...]
         shift 5

--- a/tests/integration/test_docker_execution.bats
+++ b/tests/integration/test_docker_execution.bats
@@ -91,6 +91,21 @@ _source_ralph() {
     [[ "${CLAUDE_CMD_ARGS[${#CLAUDE_CMD_ARGS[@]}-1]}" == "multi word prompt with 'quotes'" ]]
 }
 
+@test "wrap_claude_command_for_sandbox rewrites host-specific claude paths to the container CLI" {
+    _mock_docker
+    export SANDBOX_PROVIDER=docker
+    _source_ralph
+    init_docker_sandbox
+    start_sandbox_container
+
+    # A host-only path (or npx wrapper) does not exist inside the image
+    CLAUDE_CMD_ARGS=(/opt/homebrew/bin/claude --output-format json -p "hi")
+    wrap_claude_command_for_sandbox
+
+    [[ "${CLAUDE_CMD_ARGS[*]}" != *"/opt/homebrew"* ]]
+    [[ "${CLAUDE_CMD_ARGS[*]}" == *"abc123containerid claude --output-format json"* ]]
+}
+
 @test "wrap_claude_command_for_sandbox fails without a running container" {
     _mock_docker
     export SANDBOX_PROVIDER=docker

--- a/tests/integration/test_docker_execution.bats
+++ b/tests/integration/test_docker_execution.bats
@@ -1,0 +1,192 @@
+#!/usr/bin/env bats
+# Integration tests for Docker sandbox execution wiring (Issue #74)
+#
+# Part 1 sources ralph_loop.sh (the BASH_SOURCE guard prevents main from
+# running) and exercises the sandbox integration points with a PATH-mocked
+# docker: wrap_claude_command_for_sandbox and the sandbox field in
+# update_status's status.json.
+#
+# Part 2 runs against a REAL Docker daemon when one is available (skipped
+# otherwise): container lifecycle, exec wrapping, and the workspace bind
+# mount. These catch real docker argument/quoting bugs the mocks cannot.
+
+load '../helpers/test_helper'
+
+PROJECT_ROOT="${BATS_TEST_DIRNAME}/../.."
+
+setup() {
+    TEST_DIR="$(mktemp -d "${BATS_TEST_TMPDIR}/dockerexec.XXXXXX")"
+    cd "$TEST_DIR"
+
+    # Isolate HOME so host ~/.claude never leaks into tests
+    export HOME="$TEST_DIR/home"
+    mkdir -p "$HOME"
+
+    # Minimal ralph project layout (sourcing ralph_loop.sh mkdirs LOG_DIR)
+    export RALPH_DIR=".ralph"
+    mkdir -p "$RALPH_DIR/logs"
+    echo "# Test Prompt" > "$RALPH_DIR/PROMPT.md"
+    echo "0" > "$RALPH_DIR/.call_count"
+}
+
+teardown() {
+    cd /
+    [[ -n "$TEST_DIR" && -d "$TEST_DIR" ]] && rm -rf "$TEST_DIR"
+}
+
+# Mock docker recording args (same shape as tests/unit/test_sandbox_docker.bats)
+_mock_docker() {
+    mkdir -p "$TEST_DIR/mock_bin"
+    cat > "$TEST_DIR/mock_bin/docker" << EOF
+#!/bin/bash
+printf '%s\n' "\$*" >> "$TEST_DIR/docker_args"
+case "\$1" in
+    info) exit 0 ;;
+    image) exit 0 ;;
+    run) echo "abc123containerid"; exit 0 ;;
+    inspect) echo "running"; exit 0 ;;
+esac
+exit 0
+EOF
+    chmod +x "$TEST_DIR/mock_bin/docker"
+    export PATH="$TEST_DIR/mock_bin:$PATH"
+}
+
+# Source ralph_loop.sh without running main (BASH_SOURCE guard). Top-level
+# assignments run at source time, which is why we cd into TEST_DIR first.
+_source_ralph() {
+    source "$PROJECT_ROOT/ralph_loop.sh"
+}
+
+# -----------------------------------------------------------------------------
+# wrap_claude_command_for_sandbox
+# -----------------------------------------------------------------------------
+
+@test "wrap_claude_command_for_sandbox wraps CLAUDE_CMD_ARGS in docker exec" {
+    _mock_docker
+    export SANDBOX_PROVIDER=docker
+    _source_ralph
+    init_docker_sandbox
+    start_sandbox_container
+
+    CLAUDE_CMD_ARGS=(claude --output-format json -p "build the thing")
+    wrap_claude_command_for_sandbox
+
+    [[ "${CLAUDE_CMD_ARGS[0]}" == "docker" ]]
+    [[ "${CLAUDE_CMD_ARGS[1]}" == "exec" ]]
+    [[ "${CLAUDE_CMD_ARGS[*]}" == *"abc123containerid claude --output-format json -p build the thing"* ]]
+}
+
+@test "wrap_claude_command_for_sandbox preserves argument boundaries" {
+    _mock_docker
+    export SANDBOX_PROVIDER=docker
+    _source_ralph
+    init_docker_sandbox
+    start_sandbox_container
+
+    CLAUDE_CMD_ARGS=(claude -p "multi word prompt with 'quotes'")
+    wrap_claude_command_for_sandbox
+
+    # Last element must still be the intact prompt string
+    [[ "${CLAUDE_CMD_ARGS[${#CLAUDE_CMD_ARGS[@]}-1]}" == "multi word prompt with 'quotes'" ]]
+}
+
+@test "wrap_claude_command_for_sandbox fails without a running container" {
+    _mock_docker
+    export SANDBOX_PROVIDER=docker
+    _source_ralph
+    init_docker_sandbox
+
+    CLAUDE_CMD_ARGS=(claude -p "x")
+    run wrap_claude_command_for_sandbox
+    [ "$status" -ne 0 ]
+}
+
+# -----------------------------------------------------------------------------
+# update_status sandbox field
+# -----------------------------------------------------------------------------
+
+@test "update_status embeds sandbox status when sandbox is active" {
+    _mock_docker
+    export SANDBOX_PROVIDER=docker
+    _source_ralph
+    init_docker_sandbox
+    start_sandbox_container
+
+    update_status 3 7 "executing" "running"
+
+    [[ -f "$RALPH_DIR/status.json" ]]
+    jq -e . "$RALPH_DIR/status.json" >/dev/null
+    [[ "$(jq -r '.sandbox.provider' "$RALPH_DIR/status.json")" == "docker" ]]
+    [[ "$(jq -r '.sandbox.container_id' "$RALPH_DIR/status.json")" == "abc123containerid" ]]
+    [[ "$(jq -r '.sandbox.status' "$RALPH_DIR/status.json")" == "running" ]]
+}
+
+@test "update_status reports sandbox provider none when disabled" {
+    _mock_docker
+    _source_ralph
+
+    update_status 1 1 "executing" "running"
+
+    jq -e . "$RALPH_DIR/status.json" >/dev/null
+    [[ "$(jq -r '.sandbox.provider' "$RALPH_DIR/status.json")" == "none" ]]
+}
+
+# -----------------------------------------------------------------------------
+# Real Docker (skipped when no usable daemon)
+# -----------------------------------------------------------------------------
+
+_require_real_docker() {
+    command -v docker &>/dev/null || skip "docker not installed"
+    docker info >/dev/null 2>&1 || skip "docker daemon not reachable"
+    # Use a tiny image that is almost always present or fast to pull
+    if ! docker image inspect alpine:latest >/dev/null 2>&1; then
+        docker pull -q alpine:latest >/dev/null 2>&1 || skip "cannot pull alpine:latest"
+    fi
+}
+
+@test "real docker: container lifecycle start, exec, cleanup" {
+    _require_real_docker
+    export SANDBOX_PROVIDER=docker
+    export SANDBOX_DOCKER_IMAGE="alpine:latest"
+    source "$PROJECT_ROOT/lib/sandbox_docker.sh"
+
+    init_docker_sandbox
+    start_sandbox_container
+    local cid
+    cid=$(sandbox_state_get '.container_id')
+    [[ -n "$cid" ]]
+
+    # The container is alive and execs run inside it
+    build_sandbox_exec_args sh -c 'echo in-container'
+    run "${SANDBOX_EXEC_ARGS[@]}"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"in-container"* ]]
+
+    cleanup_docker_sandbox
+    # Container must be gone
+    run docker inspect "$cid"
+    [ "$status" -ne 0 ]
+}
+
+@test "real docker: workspace bind mount is read-write from both sides" {
+    _require_real_docker
+    export SANDBOX_PROVIDER=docker
+    export SANDBOX_DOCKER_IMAGE="alpine:latest"
+    source "$PROJECT_ROOT/lib/sandbox_docker.sh"
+
+    init_docker_sandbox
+    start_sandbox_container
+
+    echo "host-content" > host_file.txt
+    build_sandbox_exec_args sh -c 'cat /workspace/host_file.txt && echo container-content > /workspace/container_file.txt'
+    run "${SANDBOX_EXEC_ARGS[@]}"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"host-content"* ]]
+
+    # File written inside the container landed on the host
+    [[ -f container_file.txt ]]
+    grep -q "container-content" container_file.txt
+
+    cleanup_docker_sandbox
+}

--- a/tests/integration/test_docker_execution.bats
+++ b/tests/integration/test_docker_execution.bats
@@ -44,7 +44,7 @@ case "\$1" in
     info) exit 0 ;;
     image) exit 0 ;;
     run) echo "abc123containerid"; exit 0 ;;
-    inspect) echo "running"; exit 0 ;;
+    inspect) echo "true"; exit 0 ;;   # docker inspect -f '{{.State.Running}}'
 esac
 exit 0
 EOF

--- a/tests/integration/test_tmux_integration.bats
+++ b/tests/integration/test_tmux_integration.bats
@@ -158,14 +158,15 @@ setup_tmux_session() {
         [[ "${FOLLOWUP_LABEL:-tech-debt}" != "tech-debt" ]] && ralph_cmd="$ralph_cmd --followup-label '$FOLLOWUP_LABEL'"
         [[ -n "${ADD_COMPLETION_LABELS:-}" ]] && ralph_cmd="$ralph_cmd --add-label '$ADD_COMPLETION_LABELS'"
     fi
-    # Forward Docker sandbox flags (Issue #74) so --monitor preserves them
-    if [[ -n "${SANDBOX_PROVIDER:-}" ]]; then
-        ralph_cmd="$ralph_cmd --sandbox $SANDBOX_PROVIDER"
-        [[ "${SANDBOX_DOCKER_IMAGE:-ralph-sandbox:latest}" != "ralph-sandbox:latest" ]] && ralph_cmd="$ralph_cmd --sandbox-image '$SANDBOX_DOCKER_IMAGE'"
-        [[ "${SANDBOX_DOCKER_MEMORY:-4g}" != "4g" ]] && ralph_cmd="$ralph_cmd --sandbox-memory $SANDBOX_DOCKER_MEMORY"
-        [[ "${SANDBOX_DOCKER_CPUS:-2}" != "2" ]] && ralph_cmd="$ralph_cmd --sandbox-cpus $SANDBOX_DOCKER_CPUS"
-        [[ "${SANDBOX_DOCKER_NETWORK:-bridge}" != "bridge" ]] && ralph_cmd="$ralph_cmd --sandbox-network $SANDBOX_DOCKER_NETWORK"
-    fi
+    # Forward Docker sandbox flags (Issue #74) so --monitor preserves them.
+    # Sub-flags forward independently of the provider: this runs BEFORE main()
+    # loads .ralphrc, which may be what supplies SANDBOX_PROVIDER — the child
+    # re-validates the sub-flag/provider pairing at its own startup.
+    [[ -n "${SANDBOX_PROVIDER:-}" ]] && ralph_cmd="$ralph_cmd --sandbox $SANDBOX_PROVIDER"
+    [[ "${SANDBOX_DOCKER_IMAGE:-ralph-sandbox:latest}" != "ralph-sandbox:latest" ]] && ralph_cmd="$ralph_cmd --sandbox-image '$SANDBOX_DOCKER_IMAGE'"
+    [[ "${SANDBOX_DOCKER_MEMORY:-4g}" != "4g" ]] && ralph_cmd="$ralph_cmd --sandbox-memory $SANDBOX_DOCKER_MEMORY"
+    [[ "${SANDBOX_DOCKER_CPUS:-2}" != "2" ]] && ralph_cmd="$ralph_cmd --sandbox-cpus $SANDBOX_DOCKER_CPUS"
+    [[ "${SANDBOX_DOCKER_NETWORK:-bridge}" != "bridge" ]] && ralph_cmd="$ralph_cmd --sandbox-network $SANDBOX_DOCKER_NETWORK"
 
     tmux send-keys -t "$session_name:${base_win}.${pane0}" "$ralph_cmd; tmux kill-session -t $session_name 2>/dev/null" Enter
 
@@ -530,6 +531,21 @@ assert_tmux_called_with() {
     local pane0_line
     pane0_line=$(grep -E "tmux send-keys -t [^ ]+\.0" "$TMUX_CALL_LOG" | head -1)
     [[ "$pane0_line" != *"--sandbox"* ]]
+}
+
+@test "setup_tmux_session forwards sandbox sub-flags even when provider comes from .ralphrc" {
+    # setup_tmux_session runs before main() loads .ralphrc — a CLI sub-flag
+    # override must survive into the child even though SANDBOX_PROVIDER is
+    # not yet set in this process (the child reads it from .ralphrc)
+    export SANDBOX_DOCKER_IMAGE="node:20"
+
+    run setup_tmux_session
+    [ "$status" -eq 0 ]
+
+    local pane0_line
+    pane0_line=$(grep -E "tmux send-keys -t [^ ]+\.0" "$TMUX_CALL_LOG" | head -1)
+    [[ "$pane0_line" == *"--sandbox-image 'node:20'"* ]]
+    [[ "$pane0_line" != *"--sandbox docker"* ]]
 }
 
 # ==============================================================================

--- a/tests/integration/test_tmux_integration.bats
+++ b/tests/integration/test_tmux_integration.bats
@@ -158,6 +158,14 @@ setup_tmux_session() {
         [[ "${FOLLOWUP_LABEL:-tech-debt}" != "tech-debt" ]] && ralph_cmd="$ralph_cmd --followup-label '$FOLLOWUP_LABEL'"
         [[ -n "${ADD_COMPLETION_LABELS:-}" ]] && ralph_cmd="$ralph_cmd --add-label '$ADD_COMPLETION_LABELS'"
     fi
+    # Forward Docker sandbox flags (Issue #74) so --monitor preserves them
+    if [[ -n "${SANDBOX_PROVIDER:-}" ]]; then
+        ralph_cmd="$ralph_cmd --sandbox $SANDBOX_PROVIDER"
+        [[ "${SANDBOX_DOCKER_IMAGE:-ralph-sandbox:latest}" != "ralph-sandbox:latest" ]] && ralph_cmd="$ralph_cmd --sandbox-image '$SANDBOX_DOCKER_IMAGE'"
+        [[ "${SANDBOX_DOCKER_MEMORY:-4g}" != "4g" ]] && ralph_cmd="$ralph_cmd --sandbox-memory $SANDBOX_DOCKER_MEMORY"
+        [[ "${SANDBOX_DOCKER_CPUS:-2}" != "2" ]] && ralph_cmd="$ralph_cmd --sandbox-cpus $SANDBOX_DOCKER_CPUS"
+        [[ "${SANDBOX_DOCKER_NETWORK:-bridge}" != "bridge" ]] && ralph_cmd="$ralph_cmd --sandbox-network $SANDBOX_DOCKER_NETWORK"
+    fi
 
     tmux send-keys -t "$session_name:${base_win}.${pane0}" "$ralph_cmd; tmux kill-session -t $session_name 2>/dev/null" Enter
 
@@ -490,6 +498,38 @@ assert_tmux_called_with() {
     pane0_line=$(grep -E "tmux send-keys -t [^ ]+\.0" "$TMUX_CALL_LOG" | head -1)
     [[ "$pane0_line" != *"--github-issue"* ]]
     [[ "$pane0_line" != *"--auto-close"* ]]
+}
+
+# ==============================================================================
+# Issue #74: --monitor forwards Docker sandbox flags to the loop command
+# ==============================================================================
+
+@test "setup_tmux_session forwards sandbox flags to loop command" {
+    export SANDBOX_PROVIDER=docker
+    export SANDBOX_DOCKER_IMAGE="node:20"
+    export SANDBOX_DOCKER_MEMORY="2g"
+    export SANDBOX_DOCKER_CPUS="1.5"
+    export SANDBOX_DOCKER_NETWORK="none"
+
+    run setup_tmux_session
+    [ "$status" -eq 0 ]
+
+    local pane0_line
+    pane0_line=$(grep -E "tmux send-keys -t [^ ]+\.0" "$TMUX_CALL_LOG" | head -1)
+    [[ "$pane0_line" == *"--sandbox docker"* ]]
+    [[ "$pane0_line" == *"--sandbox-image 'node:20'"* ]]
+    [[ "$pane0_line" == *"--sandbox-memory 2g"* ]]
+    [[ "$pane0_line" == *"--sandbox-cpus 1.5"* ]]
+    [[ "$pane0_line" == *"--sandbox-network none"* ]]
+}
+
+@test "setup_tmux_session omits sandbox flags when sandbox disabled" {
+    run setup_tmux_session
+    [ "$status" -eq 0 ]
+
+    local pane0_line
+    pane0_line=$(grep -E "tmux send-keys -t [^ ]+\.0" "$TMUX_CALL_LOG" | head -1)
+    [[ "$pane0_line" != *"--sandbox"* ]]
 }
 
 # ==============================================================================

--- a/tests/unit/test_cli_modern.bats
+++ b/tests/unit/test_cli_modern.bats
@@ -1991,3 +1991,71 @@ EOF
     [[ "${CLAUDE_CMD_ARGS[*]}" != *"--model"* ]]
     [[ "${CLAUDE_CMD_ARGS[*]}" != *"--effort"* ]]
 }
+
+# ==============================================================================
+# Issue #74: --sandbox docker CLI flags
+# ==============================================================================
+
+@test "issue #74: --sandbox docker is accepted" {
+    run bash -c "source ${BATS_TEST_DIRNAME}/../../ralph_loop.sh --sandbox docker --help 2>&1 || true"
+    [[ "$output" != *"Unknown option"* ]]
+    [[ "$output" != *"Error"* ]]
+}
+
+@test "issue #74: --sandbox e2b is rejected as not yet implemented" {
+    run bash -c "source ${BATS_TEST_DIRNAME}/../../ralph_loop.sh --sandbox e2b 2>&1"
+    [[ $status -ne 0 ]]
+    [[ "$output" == *"not yet implemented"* ]]
+}
+
+@test "issue #74: --sandbox rejects unknown providers" {
+    run bash -c "source ${BATS_TEST_DIRNAME}/../../ralph_loop.sh --sandbox podman 2>&1"
+    [[ $status -ne 0 ]]
+    [[ "$output" == *"docker"* ]]
+}
+
+@test "issue #74: sandbox sub-flags are accepted alongside --sandbox docker" {
+    local flags="--sandbox docker --sandbox-image node:20 --sandbox-memory 2g --sandbox-cpus 1.5 --sandbox-network none"
+    run bash -c "source ${BATS_TEST_DIRNAME}/../../ralph_loop.sh $flags --help 2>&1 || true"
+    [[ "$output" != *"Unknown option"* ]]
+    [[ "$output" != *"Error"* ]]
+}
+
+@test "issue #74: --sandbox-image rejects shell metacharacters" {
+    run bash -c "source ${BATS_TEST_DIRNAME}/../../ralph_loop.sh --sandbox docker --sandbox-image 'evil;rm -rf /' 2>&1"
+    [[ $status -ne 0 ]]
+    [[ "$output" == *"image"* ]]
+}
+
+@test "issue #74: --sandbox-memory rejects malformed values" {
+    run bash -c "source ${BATS_TEST_DIRNAME}/../../ralph_loop.sh --sandbox docker --sandbox-memory lots 2>&1"
+    [[ $status -ne 0 ]]
+    [[ "$output" == *"memory"* ]]
+}
+
+@test "issue #74: --sandbox-cpus rejects non-numeric values" {
+    run bash -c "source ${BATS_TEST_DIRNAME}/../../ralph_loop.sh --sandbox docker --sandbox-cpus two 2>&1"
+    [[ $status -ne 0 ]]
+    [[ "$output" == *"cpus"* ]]
+}
+
+@test "issue #74: --sandbox-network rejects unknown modes" {
+    run bash -c "source ${BATS_TEST_DIRNAME}/../../ralph_loop.sh --sandbox docker --sandbox-network vpn 2>&1"
+    [[ $status -ne 0 ]]
+    [[ "$output" == *"network"* ]]
+}
+
+@test "issue #74: sandbox sub-flag without --sandbox errors at startup" {
+    run bash "${BATS_TEST_DIRNAME}/../../ralph_loop.sh" --sandbox-image node:20
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"--sandbox"* ]]
+}
+
+@test "issue #74: help text documents the sandbox flags" {
+    run bash -c "source ${BATS_TEST_DIRNAME}/../../ralph_loop.sh --help 2>&1 || true"
+    [[ "$output" == *"--sandbox PROVIDER"* ]]
+    [[ "$output" == *"--sandbox-image"* ]]
+    [[ "$output" == *"--sandbox-memory"* ]]
+    [[ "$output" == *"--sandbox-cpus"* ]]
+    [[ "$output" == *"--sandbox-network"* ]]
+}

--- a/tests/unit/test_cli_modern.bats
+++ b/tests/unit/test_cli_modern.bats
@@ -2059,3 +2059,11 @@ EOF
     [[ "$output" == *"--sandbox-cpus"* ]]
     [[ "$output" == *"--sandbox-network"* ]]
 }
+
+@test "issue #74: unsupported provider from environment halts instead of host fallback" {
+    # SANDBOX_PROVIDER can arrive via env/.ralphrc, bypassing CLI validation —
+    # a typo or unimplemented provider must never silently execute on the host
+    SANDBOX_PROVIDER=e2b run bash "${BATS_TEST_DIRNAME}/../../ralph_loop.sh"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"nsupported sandbox provider"* ]]
+}

--- a/tests/unit/test_sandbox_docker.bats
+++ b/tests/unit/test_sandbox_docker.bats
@@ -345,16 +345,16 @@ _docker_args() { cat "$TEST_DIR/docker_args" 2>/dev/null; }
 
 @test "setup_docker_credentials: writes 600 env-file from ANTHROPIC_API_KEY" {
     _mock_docker ok
-    export ANTHROPIC_API_KEY="sk-ant-secret123"
+    export ANTHROPIC_API_KEY="sk-ant-test-placeholder"
     setup_docker_credentials
     [[ -f "$SANDBOX_ENV_FILE" ]]
     assert_equal "$(stat -c %a "$SANDBOX_ENV_FILE" 2>/dev/null || stat -f %Lp "$SANDBOX_ENV_FILE")" "600"
-    grep -q "ANTHROPIC_API_KEY=sk-ant-secret123" "$SANDBOX_ENV_FILE"
+    grep -q "ANTHROPIC_API_KEY=sk-ant-test-placeholder" "$SANDBOX_ENV_FILE"
 }
 
 @test "setup_docker_credentials: env-file is passed to docker run" {
     _mock_docker ok
-    export ANTHROPIC_API_KEY="sk-ant-secret123"
+    export ANTHROPIC_API_KEY="sk-ant-test-placeholder"
     init_docker_sandbox
     setup_docker_credentials
     start_sandbox_container
@@ -365,16 +365,16 @@ _docker_args() { cat "$TEST_DIR/docker_args" 2>/dev/null; }
 
 @test "setup_docker_credentials: never logs the API key value" {
     _mock_docker ok
-    export ANTHROPIC_API_KEY="sk-ant-secret123"
+    export ANTHROPIC_API_KEY="sk-ant-test-placeholder"
     run setup_docker_credentials
     assert_success
-    [[ "$output" != *"sk-ant-secret123"* ]]
+    [[ "$output" != *"sk-ant-test-placeholder"* ]]
 }
 
 @test "setup_docker_credentials: seeds container claude home from host credentials" {
     _mock_docker ok
     mkdir -p "$HOME/.claude"
-    echo '{"token":"oauth-secret"}' > "$HOME/.claude/.credentials.json"
+    echo '{"token":"test-placeholder-token"}' > "$HOME/.claude/.credentials.json"
     setup_docker_credentials
     [[ -f "$SANDBOX_CLAUDE_HOME/.claude/.credentials.json" ]]
     assert_equal "$(stat -c %a "$SANDBOX_CLAUDE_HOME/.claude/.credentials.json" 2>/dev/null || stat -f %Lp "$SANDBOX_CLAUDE_HOME/.claude/.credentials.json")" "600"
@@ -383,7 +383,7 @@ _docker_args() { cat "$TEST_DIR/docker_args" 2>/dev/null; }
 @test "setup_docker_credentials: claude home is mounted with HOME override" {
     _mock_docker ok
     mkdir -p "$HOME/.claude"
-    echo '{"token":"oauth-secret"}' > "$HOME/.claude/.credentials.json"
+    echo '{"token":"test-placeholder-token"}' > "$HOME/.claude/.credentials.json"
     init_docker_sandbox
     setup_docker_credentials
     start_sandbox_container
@@ -518,9 +518,9 @@ _docker_args() { cat "$TEST_DIR/docker_args" 2>/dev/null; }
 
 @test "cleanup_docker_sandbox: removes container, env-file, and claude home" {
     _mock_docker ok
-    export ANTHROPIC_API_KEY="sk-ant-secret123"
+    export ANTHROPIC_API_KEY="sk-ant-test-placeholder"
     mkdir -p "$HOME/.claude"
-    echo '{"token":"oauth-secret"}' > "$HOME/.claude/.credentials.json"
+    echo '{"token":"test-placeholder-token"}' > "$HOME/.claude/.credentials.json"
     init_docker_sandbox
     setup_docker_credentials
     start_sandbox_container

--- a/tests/unit/test_sandbox_docker.bats
+++ b/tests/unit/test_sandbox_docker.bats
@@ -1,0 +1,455 @@
+#!/usr/bin/env bats
+# Unit tests for lib/sandbox_docker.sh (Issue #74)
+#
+# Covers the Docker sandbox module: config validation, daemon availability,
+# sandbox init (state file + image presence check), container lifecycle
+# (start/stop/cleanup), secure credential handoff (env-file / seeded claude
+# home), exec-arg wrapping, timeout recovery, and the status JSON emitted for
+# status.json.
+#
+# The `docker` mock records its args to a file so assertions survive `run`'s
+# subshell boundary — same pattern as test_github_lifecycle.bats's gh mock.
+
+load '../helpers/test_helper'
+
+PROJECT_ROOT="${BATS_TEST_DIRNAME}/../.."
+
+setup() {
+    TEST_DIR="$(mktemp -d "${BATS_TEST_TMPDIR}/sandbox.XXXXXX")"
+    cd "$TEST_DIR"
+
+    export RALPH_DIR="$TEST_DIR/.ralph"
+    export DOCKER_SANDBOX_STATE_FILE="$RALPH_DIR/.docker_sandbox_state"
+    mkdir -p "$RALPH_DIR"
+
+    # Isolate HOME so host ~/.claude never leaks into credential tests
+    export HOME="$TEST_DIR/home"
+    mkdir -p "$HOME"
+
+    # Clean default sandbox configuration
+    export SANDBOX_PROVIDER="docker"
+    export SANDBOX_DOCKER_IMAGE="ralph-sandbox:latest"
+    export SANDBOX_DOCKER_MEMORY="4g"
+    export SANDBOX_DOCKER_CPUS="2"
+    export SANDBOX_DOCKER_NETWORK="bridge"
+    unset ANTHROPIC_API_KEY
+
+    source "$PROJECT_ROOT/lib/sandbox_docker.sh"
+}
+
+teardown() {
+    cd /
+    [[ -n "$TEST_DIR" && -d "$TEST_DIR" ]] && rm -rf "$TEST_DIR"
+}
+
+# Build a mock docker that records each invocation's args and can simulate
+# failure modes. $1 = "ok" | "no-daemon" | "no-image" | "run-fail".
+_mock_docker() {
+    local mode="${1:-ok}"
+    mkdir -p "$TEST_DIR/mock_bin"
+    cat > "$TEST_DIR/mock_bin/docker" << EOF
+#!/bin/bash
+printf '%s\n' "\$*" >> "$TEST_DIR/docker_args"
+case "\$1" in
+    info)
+        if [[ "$mode" == "no-daemon" ]]; then
+            echo "Cannot connect to the Docker daemon" >&2
+            exit 1
+        fi
+        exit 0 ;;
+    image)
+        # docker image inspect <image>
+        if [[ "$mode" == "no-image" ]]; then
+            echo "Error: No such image" >&2
+            exit 1
+        fi
+        exit 0 ;;
+    run)
+        if [[ "$mode" == "run-fail" ]]; then
+            echo "docker: Error response from daemon" >&2
+            exit 125
+        fi
+        echo "abc123containerid"
+        exit 0 ;;
+    inspect)
+        echo "running"
+        exit 0 ;;
+esac
+exit 0
+EOF
+    chmod +x "$TEST_DIR/mock_bin/docker"
+    export PATH="$TEST_DIR/mock_bin:$PATH"
+}
+
+_docker_args() { cat "$TEST_DIR/docker_args" 2>/dev/null; }
+
+# -----------------------------------------------------------------------------
+# validate_sandbox_config
+# -----------------------------------------------------------------------------
+
+@test "validate_sandbox_config: accepts clean defaults" {
+    run validate_sandbox_config
+    assert_success
+}
+
+@test "validate_sandbox_config: rejects unknown provider" {
+    export SANDBOX_PROVIDER="podman"
+    run validate_sandbox_config
+    assert_failure
+    [[ "$output" == *"provider"* ]]
+}
+
+@test "validate_sandbox_config: rejects empty image" {
+    export SANDBOX_DOCKER_IMAGE=""
+    run validate_sandbox_config
+    assert_failure
+    [[ "$output" == *"image"* ]]
+}
+
+@test "validate_sandbox_config: rejects image with shell metacharacters" {
+    export SANDBOX_DOCKER_IMAGE='evil;rm -rf /'
+    run validate_sandbox_config
+    assert_failure
+    [[ "$output" == *"image"* ]]
+}
+
+@test "validate_sandbox_config: accepts registry-qualified image with tag" {
+    export SANDBOX_DOCKER_IMAGE="ghcr.io/frankbria/ralph-sandbox:v1.2"
+    run validate_sandbox_config
+    assert_success
+}
+
+@test "validate_sandbox_config: rejects malformed memory limit" {
+    export SANDBOX_DOCKER_MEMORY="lots"
+    run validate_sandbox_config
+    assert_failure
+    [[ "$output" == *"memory"* ]]
+}
+
+@test "validate_sandbox_config: accepts docker memory formats" {
+    for mem in 4g 512m 1024k 2048; do
+        export SANDBOX_DOCKER_MEMORY="$mem"
+        run validate_sandbox_config
+        assert_success
+    done
+}
+
+@test "validate_sandbox_config: rejects non-numeric cpus" {
+    export SANDBOX_DOCKER_CPUS="two"
+    run validate_sandbox_config
+    assert_failure
+    [[ "$output" == *"cpus"* ]]
+}
+
+@test "validate_sandbox_config: accepts fractional cpus" {
+    export SANDBOX_DOCKER_CPUS="1.5"
+    run validate_sandbox_config
+    assert_success
+}
+
+@test "validate_sandbox_config: rejects unknown network mode" {
+    export SANDBOX_DOCKER_NETWORK="vpn"
+    run validate_sandbox_config
+    assert_failure
+    [[ "$output" == *"network"* ]]
+}
+
+@test "validate_sandbox_config: accepts none, bridge, and host networks" {
+    for net in none bridge host; do
+        export SANDBOX_DOCKER_NETWORK="$net"
+        run validate_sandbox_config
+        assert_success
+    done
+}
+
+# -----------------------------------------------------------------------------
+# docker_is_available
+# -----------------------------------------------------------------------------
+
+@test "docker_is_available: succeeds when docker CLI and daemon respond" {
+    _mock_docker ok
+    run docker_is_available
+    assert_success
+}
+
+@test "docker_is_available: fails when daemon is unreachable" {
+    _mock_docker no-daemon
+    run docker_is_available
+    assert_failure
+}
+
+@test "docker_is_available: fails when docker CLI is not on PATH" {
+    local original_path="$PATH"
+    PATH="/usr/bin:/bin"
+    if command -v docker &>/dev/null; then
+        PATH="$original_path"
+        skip "Cannot hide docker from PATH in this environment"
+    fi
+    run docker_is_available
+    PATH="$original_path"
+    assert_failure
+}
+
+# -----------------------------------------------------------------------------
+# init_docker_sandbox
+# -----------------------------------------------------------------------------
+
+@test "init_docker_sandbox: writes state file with config" {
+    _mock_docker ok
+    run init_docker_sandbox
+    assert_success
+    [[ -f "$DOCKER_SANDBOX_STATE_FILE" ]]
+    assert_equal "$(jq -r '.provider' "$DOCKER_SANDBOX_STATE_FILE")" "docker"
+    assert_equal "$(jq -r '.image' "$DOCKER_SANDBOX_STATE_FILE")" "ralph-sandbox:latest"
+    assert_equal "$(jq -r '.status' "$DOCKER_SANDBOX_STATE_FILE")" "initialized"
+    assert_equal "$(jq -r '.container_id' "$DOCKER_SANDBOX_STATE_FILE")" ""
+}
+
+@test "init_docker_sandbox: fails when daemon is unreachable" {
+    _mock_docker no-daemon
+    run init_docker_sandbox
+    assert_failure
+    [[ "$output" == *"daemon"* || "$output" == *"Docker"* ]]
+}
+
+@test "init_docker_sandbox: missing default image suggests docker build" {
+    _mock_docker no-image
+    run init_docker_sandbox
+    assert_failure
+    [[ "$output" == *"docker build"* ]]
+}
+
+@test "init_docker_sandbox: missing custom image suggests docker pull" {
+    _mock_docker no-image
+    export SANDBOX_DOCKER_IMAGE="python:3.11"
+    run init_docker_sandbox
+    assert_failure
+    [[ "$output" == *"python:3.11"* ]]
+}
+
+@test "init_docker_sandbox: fails on invalid config" {
+    _mock_docker ok
+    export SANDBOX_DOCKER_NETWORK="vpn"
+    run init_docker_sandbox
+    assert_failure
+}
+
+# -----------------------------------------------------------------------------
+# start_sandbox_container
+# -----------------------------------------------------------------------------
+
+@test "start_sandbox_container: runs detached with workspace mount and limits" {
+    _mock_docker ok
+    init_docker_sandbox
+    start_sandbox_container
+    local run_line
+    run_line=$(_docker_args | grep '^run ')
+    [[ "$run_line" == *"-d"* ]]
+    [[ "$run_line" == *"-v $TEST_DIR:/workspace"* ]]
+    [[ "$run_line" == *"-w /workspace"* ]]
+    [[ "$run_line" == *"--memory 4g"* ]]
+    [[ "$run_line" == *"--cpus 2"* ]]
+    [[ "$run_line" == *"--network bridge"* ]]
+    [[ "$run_line" == *"ralph-sandbox:latest"* ]]
+    [[ "$run_line" == *"sleep infinity"* ]]
+}
+
+@test "start_sandbox_container: records container id and running status" {
+    _mock_docker ok
+    init_docker_sandbox
+    start_sandbox_container
+    assert_equal "$(jq -r '.container_id' "$DOCKER_SANDBOX_STATE_FILE")" "abc123containerid"
+    assert_equal "$(jq -r '.status' "$DOCKER_SANDBOX_STATE_FILE")" "running"
+}
+
+@test "start_sandbox_container: uses custom image" {
+    _mock_docker ok
+    export SANDBOX_DOCKER_IMAGE="node:20"
+    init_docker_sandbox
+    start_sandbox_container
+    local run_line
+    run_line=$(_docker_args | grep '^run ')
+    [[ "$run_line" == *" node:20 "* ]]
+}
+
+@test "start_sandbox_container: fails when docker run fails" {
+    _mock_docker run-fail
+    init_docker_sandbox
+    run start_sandbox_container
+    assert_failure
+}
+
+# -----------------------------------------------------------------------------
+# setup_docker_credentials
+# -----------------------------------------------------------------------------
+
+@test "setup_docker_credentials: writes 600 env-file from ANTHROPIC_API_KEY" {
+    _mock_docker ok
+    export ANTHROPIC_API_KEY="sk-ant-secret123"
+    setup_docker_credentials
+    [[ -f "$RALPH_DIR/.docker_sandbox_env" ]]
+    assert_equal "$(stat -c %a "$RALPH_DIR/.docker_sandbox_env" 2>/dev/null || stat -f %Lp "$RALPH_DIR/.docker_sandbox_env")" "600"
+    grep -q "ANTHROPIC_API_KEY=sk-ant-secret123" "$RALPH_DIR/.docker_sandbox_env"
+}
+
+@test "setup_docker_credentials: env-file is passed to docker run" {
+    _mock_docker ok
+    export ANTHROPIC_API_KEY="sk-ant-secret123"
+    init_docker_sandbox
+    setup_docker_credentials
+    start_sandbox_container
+    local run_line
+    run_line=$(_docker_args | grep '^run ')
+    [[ "$run_line" == *"--env-file $RALPH_DIR/.docker_sandbox_env"* ]]
+}
+
+@test "setup_docker_credentials: never logs the API key value" {
+    _mock_docker ok
+    export ANTHROPIC_API_KEY="sk-ant-secret123"
+    run setup_docker_credentials
+    assert_success
+    [[ "$output" != *"sk-ant-secret123"* ]]
+}
+
+@test "setup_docker_credentials: seeds container claude home from host credentials" {
+    _mock_docker ok
+    mkdir -p "$HOME/.claude"
+    echo '{"token":"oauth-secret"}' > "$HOME/.claude/.credentials.json"
+    setup_docker_credentials
+    [[ -f "$RALPH_DIR/.docker_claude_home/.claude/.credentials.json" ]]
+    assert_equal "$(stat -c %a "$RALPH_DIR/.docker_claude_home/.claude/.credentials.json" 2>/dev/null || stat -f %Lp "$RALPH_DIR/.docker_claude_home/.claude/.credentials.json")" "600"
+}
+
+@test "setup_docker_credentials: claude home is mounted with HOME override" {
+    _mock_docker ok
+    mkdir -p "$HOME/.claude"
+    echo '{"token":"oauth-secret"}' > "$HOME/.claude/.credentials.json"
+    init_docker_sandbox
+    setup_docker_credentials
+    start_sandbox_container
+    local run_line
+    run_line=$(_docker_args | grep '^run ')
+    [[ "$run_line" == *"-v $RALPH_DIR/.docker_claude_home:/ralph-home"* ]]
+    [[ "$run_line" == *"-e HOME=/ralph-home"* ]]
+}
+
+@test "setup_docker_credentials: warns but succeeds with no credentials" {
+    _mock_docker ok
+    run setup_docker_credentials
+    assert_success
+    [[ "$output" == *"WARN"* || "$output" == *"credential"* ]]
+}
+
+# -----------------------------------------------------------------------------
+# build_sandbox_exec_args
+# -----------------------------------------------------------------------------
+
+@test "build_sandbox_exec_args: wraps command in docker exec" {
+    _mock_docker ok
+    init_docker_sandbox
+    start_sandbox_container
+    build_sandbox_exec_args claude --output-format json -p "do things"
+    assert_equal "${SANDBOX_EXEC_ARGS[0]}" "docker"
+    assert_equal "${SANDBOX_EXEC_ARGS[1]}" "exec"
+    assert_equal "${SANDBOX_EXEC_ARGS[2]}" "-i"
+    assert_equal "${SANDBOX_EXEC_ARGS[3]}" "-w"
+    assert_equal "${SANDBOX_EXEC_ARGS[4]}" "/workspace"
+    assert_equal "${SANDBOX_EXEC_ARGS[5]}" "abc123containerid"
+    assert_equal "${SANDBOX_EXEC_ARGS[6]}" "claude"
+    assert_equal "${SANDBOX_EXEC_ARGS[9]}" "-p"
+    assert_equal "${SANDBOX_EXEC_ARGS[10]}" "do things"
+}
+
+@test "build_sandbox_exec_args: fails when no container is running" {
+    _mock_docker ok
+    init_docker_sandbox
+    run build_sandbox_exec_args claude -p "x"
+    assert_failure
+}
+
+# -----------------------------------------------------------------------------
+# handle_sandbox_timeout
+# -----------------------------------------------------------------------------
+
+@test "handle_sandbox_timeout: restarts the container to kill orphaned exec" {
+    _mock_docker ok
+    init_docker_sandbox
+    start_sandbox_container
+    run handle_sandbox_timeout
+    assert_success
+    _docker_args | grep -q '^restart .*abc123containerid'
+}
+
+@test "handle_sandbox_timeout: no-op without a container" {
+    _mock_docker ok
+    init_docker_sandbox
+    run handle_sandbox_timeout
+    assert_success
+    ! _docker_args | grep -q '^restart'
+}
+
+# -----------------------------------------------------------------------------
+# stop / cleanup
+# -----------------------------------------------------------------------------
+
+@test "stop_sandbox_container: stops and removes the container" {
+    _mock_docker ok
+    init_docker_sandbox
+    start_sandbox_container
+    stop_sandbox_container
+    _docker_args | grep -q '^stop .*abc123containerid'
+    _docker_args | grep -q '^rm .*abc123containerid'
+    assert_equal "$(jq -r '.status' "$DOCKER_SANDBOX_STATE_FILE")" "stopped"
+    assert_equal "$(jq -r '.container_id' "$DOCKER_SANDBOX_STATE_FILE")" ""
+}
+
+@test "cleanup_docker_sandbox: removes container, env-file, and claude home" {
+    _mock_docker ok
+    export ANTHROPIC_API_KEY="sk-ant-secret123"
+    mkdir -p "$HOME/.claude"
+    echo '{"token":"oauth-secret"}' > "$HOME/.claude/.credentials.json"
+    init_docker_sandbox
+    setup_docker_credentials
+    start_sandbox_container
+    cleanup_docker_sandbox
+    [[ ! -f "$RALPH_DIR/.docker_sandbox_env" ]]
+    [[ ! -d "$RALPH_DIR/.docker_claude_home" ]]
+    _docker_args | grep -q '^rm .*abc123containerid'
+    assert_equal "$(jq -r '.status' "$DOCKER_SANDBOX_STATE_FILE")" "cleaned"
+}
+
+@test "cleanup_docker_sandbox: is idempotent" {
+    _mock_docker ok
+    init_docker_sandbox
+    cleanup_docker_sandbox
+    run cleanup_docker_sandbox
+    assert_success
+}
+
+@test "cleanup_docker_sandbox: safe to call before init" {
+    _mock_docker ok
+    run cleanup_docker_sandbox
+    assert_success
+}
+
+# -----------------------------------------------------------------------------
+# get_sandbox_status
+# -----------------------------------------------------------------------------
+
+@test "get_sandbox_status: emits JSON with provider, container id, and status" {
+    _mock_docker ok
+    init_docker_sandbox
+    start_sandbox_container
+    run get_sandbox_status
+    assert_success
+    echo "$output" | jq -e . >/dev/null
+    assert_equal "$(echo "$output" | jq -r '.provider')" "docker"
+    assert_equal "$(echo "$output" | jq -r '.container_id')" "abc123containerid"
+    assert_equal "$(echo "$output" | jq -r '.status')" "running"
+}
+
+@test "get_sandbox_status: reports none when sandbox never initialized" {
+    run get_sandbox_status
+    assert_success
+    assert_equal "$(echo "$output" | jq -r '.provider')" "none"
+}

--- a/tests/unit/test_sandbox_docker.bats
+++ b/tests/unit/test_sandbox_docker.bats
@@ -22,6 +22,12 @@ setup() {
     export DOCKER_SANDBOX_STATE_FILE="$RALPH_DIR/.docker_sandbox_state"
     mkdir -p "$RALPH_DIR"
 
+    # Credential artifacts live OUTSIDE the workspace (bind-mount safety);
+    # tests pin them to an inspectable location
+    export SANDBOX_RUNTIME_DIR="$TEST_DIR/runtime"
+    export SANDBOX_ENV_FILE="$SANDBOX_RUNTIME_DIR/env"
+    export SANDBOX_CLAUDE_HOME="$SANDBOX_RUNTIME_DIR/claude_home"
+
     # Isolate HOME so host ~/.claude never leaks into credential tests
     export HOME="$TEST_DIR/home"
     mkdir -p "$HOME"
@@ -68,6 +74,9 @@ case "\$1" in
         if [[ "$mode" == "run-fail" ]]; then
             echo "docker: Error response from daemon" >&2
             exit 125
+        fi
+        if [[ "$mode" == "run-warning" ]]; then
+            echo "WARNING: Your kernel does not support swap limit capabilities" >&2
         fi
         echo "abc123containerid"
         exit 0 ;;
@@ -285,7 +294,7 @@ _docker_args() { cat "$TEST_DIR/docker_args" 2>/dev/null; }
     start_sandbox_container
     local run_line
     run_line=$(_docker_args | grep '^run ')
-    [[ "$run_line" == *"-v $RALPH_DIR/.docker_claude_home:/ralph-home"* ]]
+    [[ "$run_line" == *"-v $SANDBOX_CLAUDE_HOME:/ralph-home"* ]]
     [[ "$run_line" == *"-e HOME=/ralph-home"* ]]
 }
 
@@ -314,6 +323,22 @@ _docker_args() { cat "$TEST_DIR/docker_args" 2>/dev/null; }
     assert_failure
 }
 
+@test "start_sandbox_container: daemon warnings on stderr do not contaminate the container id" {
+    _mock_docker run-warning
+    init_docker_sandbox
+    start_sandbox_container
+    assert_equal "$(jq -r '.container_id' "$DOCKER_SANDBOX_STATE_FILE")" "abc123containerid"
+}
+
+@test "credential artifacts default to a location outside the workspace" {
+    # Fresh shell without the test overrides: the lib's own defaults must not
+    # place secrets inside the bind-mounted project directory
+    run bash -c "cd '$TEST_DIR' && unset SANDBOX_RUNTIME_DIR SANDBOX_ENV_FILE SANDBOX_CLAUDE_HOME && source '$PROJECT_ROOT/lib/sandbox_docker.sh' && printf '%s\n%s\n' \"\$SANDBOX_ENV_FILE\" \"\$SANDBOX_CLAUDE_HOME\""
+    assert_success
+    [[ "${lines[0]}" != "$TEST_DIR"* ]]
+    [[ "${lines[1]}" != "$TEST_DIR"* ]]
+}
+
 # -----------------------------------------------------------------------------
 # setup_docker_credentials
 # -----------------------------------------------------------------------------
@@ -322,9 +347,9 @@ _docker_args() { cat "$TEST_DIR/docker_args" 2>/dev/null; }
     _mock_docker ok
     export ANTHROPIC_API_KEY="sk-ant-secret123"
     setup_docker_credentials
-    [[ -f "$RALPH_DIR/.docker_sandbox_env" ]]
-    assert_equal "$(stat -c %a "$RALPH_DIR/.docker_sandbox_env" 2>/dev/null || stat -f %Lp "$RALPH_DIR/.docker_sandbox_env")" "600"
-    grep -q "ANTHROPIC_API_KEY=sk-ant-secret123" "$RALPH_DIR/.docker_sandbox_env"
+    [[ -f "$SANDBOX_ENV_FILE" ]]
+    assert_equal "$(stat -c %a "$SANDBOX_ENV_FILE" 2>/dev/null || stat -f %Lp "$SANDBOX_ENV_FILE")" "600"
+    grep -q "ANTHROPIC_API_KEY=sk-ant-secret123" "$SANDBOX_ENV_FILE"
 }
 
 @test "setup_docker_credentials: env-file is passed to docker run" {
@@ -335,7 +360,7 @@ _docker_args() { cat "$TEST_DIR/docker_args" 2>/dev/null; }
     start_sandbox_container
     local run_line
     run_line=$(_docker_args | grep '^run ')
-    [[ "$run_line" == *"--env-file $RALPH_DIR/.docker_sandbox_env"* ]]
+    [[ "$run_line" == *"--env-file $SANDBOX_ENV_FILE"* ]]
 }
 
 @test "setup_docker_credentials: never logs the API key value" {
@@ -351,8 +376,8 @@ _docker_args() { cat "$TEST_DIR/docker_args" 2>/dev/null; }
     mkdir -p "$HOME/.claude"
     echo '{"token":"oauth-secret"}' > "$HOME/.claude/.credentials.json"
     setup_docker_credentials
-    [[ -f "$RALPH_DIR/.docker_claude_home/.claude/.credentials.json" ]]
-    assert_equal "$(stat -c %a "$RALPH_DIR/.docker_claude_home/.claude/.credentials.json" 2>/dev/null || stat -f %Lp "$RALPH_DIR/.docker_claude_home/.claude/.credentials.json")" "600"
+    [[ -f "$SANDBOX_CLAUDE_HOME/.claude/.credentials.json" ]]
+    assert_equal "$(stat -c %a "$SANDBOX_CLAUDE_HOME/.claude/.credentials.json" 2>/dev/null || stat -f %Lp "$SANDBOX_CLAUDE_HOME/.claude/.credentials.json")" "600"
 }
 
 @test "setup_docker_credentials: claude home is mounted with HOME override" {
@@ -364,7 +389,7 @@ _docker_args() { cat "$TEST_DIR/docker_args" 2>/dev/null; }
     start_sandbox_container
     local run_line
     run_line=$(_docker_args | grep '^run ')
-    [[ "$run_line" == *"-v $RALPH_DIR/.docker_claude_home:/ralph-home"* ]]
+    [[ "$run_line" == *"-v $SANDBOX_CLAUDE_HOME:/ralph-home"* ]]
     [[ "$run_line" == *"-e HOME=/ralph-home"* ]]
 }
 
@@ -378,14 +403,14 @@ _docker_args() { cat "$TEST_DIR/docker_args" 2>/dev/null; }
 @test "setup_docker_credentials: creates the sandbox home even without credentials" {
     _mock_docker ok
     setup_docker_credentials
-    [[ -d "$RALPH_DIR/.docker_claude_home/.claude" ]]
+    [[ -d "$SANDBOX_CLAUDE_HOME/.claude" ]]
 }
 
 @test "setup_docker_credentials: seeds gitconfig so in-container commits work" {
     _mock_docker ok
     printf '[user]\n\temail = t@t.io\n\tname = T\n' > "$HOME/.gitconfig"
     setup_docker_credentials
-    grep -q "t@t.io" "$RALPH_DIR/.docker_claude_home/.gitconfig"
+    grep -q "t@t.io" "$SANDBOX_CLAUDE_HOME/.gitconfig"
 }
 
 # -----------------------------------------------------------------------------
@@ -500,8 +525,8 @@ _docker_args() { cat "$TEST_DIR/docker_args" 2>/dev/null; }
     setup_docker_credentials
     start_sandbox_container
     cleanup_docker_sandbox
-    [[ ! -f "$RALPH_DIR/.docker_sandbox_env" ]]
-    [[ ! -d "$RALPH_DIR/.docker_claude_home" ]]
+    [[ ! -f "$SANDBOX_ENV_FILE" ]]
+    [[ ! -d "$SANDBOX_CLAUDE_HOME" ]]
     _docker_args | grep -q '^rm .*abc123containerid'
     assert_equal "$(jq -r '.status' "$DOCKER_SANDBOX_STATE_FILE")" "cleaned"
 }

--- a/tests/unit/test_sandbox_docker.bats
+++ b/tests/unit/test_sandbox_docker.bats
@@ -72,7 +72,22 @@ case "\$1" in
         echo "abc123containerid"
         exit 0 ;;
     inspect)
-        echo "running"
+        # docker inspect -f '{{.State.Running}}' <cid>
+        if [[ "$mode" == "container-stopped" ]]; then
+            echo "false"
+            exit 0
+        fi
+        if [[ "$mode" == "container-gone" ]]; then
+            echo "Error: No such object" >&2
+            exit 1
+        fi
+        echo "true"
+        exit 0 ;;
+    start)
+        if [[ "$mode" == "container-gone" ]]; then
+            echo "Error: No such container" >&2
+            exit 1
+        fi
         exit 0 ;;
 esac
 exit 0
@@ -254,6 +269,26 @@ _docker_args() { cat "$TEST_DIR/docker_args" 2>/dev/null; }
     [[ "$run_line" == *"sleep infinity"* ]]
 }
 
+@test "start_sandbox_container: runs as the host uid:gid (bind-mount ownership)" {
+    _mock_docker ok
+    init_docker_sandbox
+    start_sandbox_container
+    local run_line
+    run_line=$(_docker_args | grep '^run ')
+    [[ "$run_line" == *"--user $(id -u):$(id -g)"* ]]
+}
+
+@test "start_sandbox_container: always mounts a writable sandbox home with HOME override" {
+    _mock_docker ok
+    init_docker_sandbox
+    setup_docker_credentials   # no API key, no host credentials → still creates the home
+    start_sandbox_container
+    local run_line
+    run_line=$(_docker_args | grep '^run ')
+    [[ "$run_line" == *"-v $RALPH_DIR/.docker_claude_home:/ralph-home"* ]]
+    [[ "$run_line" == *"-e HOME=/ralph-home"* ]]
+}
+
 @test "start_sandbox_container: records container id and running status" {
     _mock_docker ok
     init_docker_sandbox
@@ -338,6 +373,59 @@ _docker_args() { cat "$TEST_DIR/docker_args" 2>/dev/null; }
     run setup_docker_credentials
     assert_success
     [[ "$output" == *"WARN"* || "$output" == *"credential"* ]]
+}
+
+@test "setup_docker_credentials: creates the sandbox home even without credentials" {
+    _mock_docker ok
+    setup_docker_credentials
+    [[ -d "$RALPH_DIR/.docker_claude_home/.claude" ]]
+}
+
+@test "setup_docker_credentials: seeds gitconfig so in-container commits work" {
+    _mock_docker ok
+    printf '[user]\n\temail = t@t.io\n\tname = T\n' > "$HOME/.gitconfig"
+    setup_docker_credentials
+    grep -q "t@t.io" "$RALPH_DIR/.docker_claude_home/.gitconfig"
+}
+
+# -----------------------------------------------------------------------------
+# ensure_sandbox_container (liveness + recovery)
+# -----------------------------------------------------------------------------
+
+@test "ensure_sandbox_container: no-op when the container is running" {
+    _mock_docker ok
+    init_docker_sandbox
+    start_sandbox_container
+    run ensure_sandbox_container
+    assert_success
+    ! _docker_args | grep -q '^start '
+}
+
+@test "ensure_sandbox_container: restarts a stopped container (OOM kill recovery)" {
+    _mock_docker container-stopped
+    init_docker_sandbox
+    start_sandbox_container
+    run ensure_sandbox_container
+    assert_success
+    _docker_args | grep -q '^start .*abc123containerid'
+}
+
+@test "ensure_sandbox_container: replaces a container that no longer exists" {
+    _mock_docker container-gone
+    init_docker_sandbox
+    start_sandbox_container
+    : > "$TEST_DIR/docker_args"   # only observe recovery calls
+    ensure_sandbox_container
+    # Fresh docker run replaced the lost container
+    _docker_args | grep -q '^run '
+    assert_equal "$(jq -r '.container_id' "$DOCKER_SANDBOX_STATE_FILE")" "abc123containerid"
+}
+
+@test "ensure_sandbox_container: fails when no container was ever started" {
+    _mock_docker ok
+    init_docker_sandbox
+    run ensure_sandbox_container
+    assert_failure
 }
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements #74 (Phase 6.1, first slice of epic #49): run the Claude Code CLI inside an isolated Docker container instead of directly on the host.

**Architecture**: only Claude's execution is containerized. Ralph's orchestration (loop control, rate limiting, circuit breaker, response analysis, status.json) stays on the host; one persistent container is started before the loop and each iteration runs Claude via `docker exec` (live stream-json and background modes both work through the wrapper). The project directory is bind-mounted read-write at `/workspace`, so file changes land on the host directly, `ralph-monitor` works unchanged, and no file-sync layer is needed (that's #76).

- `lib/sandbox_docker.sh` — config validation, daemon/image checks, container lifecycle, per-exec liveness probe with OOM-kill recovery, secure credential handoff, timeout recovery (`docker restart` reaps orphaned in-container processes), atomic JSON state, status JSON for monitoring
- `ralph_loop.sh` — `--sandbox docker`, `--sandbox-image/-memory/-cpus/-network` flags (validated at parse time), env > CLI > `.ralphrc` precedence, sandbox init before the loop, idempotent cleanup on every exit path (incl. SIGINT/SIGTERM), `sandbox` field in status.json, tmux flag forwarding
- **No silent host fallback**: any sandbox setup failure (daemon down, missing image, unsupported provider — even via `.ralphrc`/env) halts before a single API call
- **Credentials**: `ANTHROPIC_API_KEY` → 0600 env-file in a per-run `/tmp` runtime dir (outside the workspace mount, never logged); else host `~/.claude/.credentials.json` is *copied* into a container-scoped HOME — the host's real `~/.claude` is never mounted. Container runs as the host uid:gid so bind-mount writes keep host ownership.
- `Dockerfile` (node:20-slim + claude CLI, non-root) + `.dockerignore`; `install.sh` copies the build context to `~/.ralph`; docs (README section, `docs/DOCKER_SANDBOX.md`, CLAUDE.md, `.ralphrc` templates)

## Acceptance Criteria

- [x] `--sandbox docker` flag launches execution in a container
- [x] Custom image support (`--sandbox-image`)
- [x] Project files accessible in container (verified against a real Docker daemon)
- [x] Output artifacts retrievable on host (real-daemon bidirectional bind-mount test)
- [x] Claude API key passed securely (0600 env-file outside the workspace; no-leak test)
- [x] ralph-monitor works (status.json stays host-side + gains a `sandbox` field)
- [x] Container cleanup on exit (normal, error, and signal paths; idempotent)
- [x] Resource limit options (`--sandbox-memory`, `--sandbox-cpus`)
- [x] Network policy options (`--sandbox-network none|bridge|host`)
- [ ] Official Ralph Docker image published — **deferred** (see Known Limitations)
- [x] Tests for Docker sandbox execution (73 new tests)

## Test Plan

- [x] TDD throughout — tests written first per step
- [x] Full suite passing: 1108 unit+integration + 15 e2e (was 1037 + 13)
- [x] Diff coverage: kcov can't instrument bats subprocesses (project standard: informational only) — manual fallback applied: every new lib function and ralph_loop path has dedicated tests, incl. a full-loop e2e with a delegating docker mock and 2 tests against a **real Docker daemon**
- [x] `bash -n` clean (no project linter; shellcheck unavailable on this machine)
- [x] Internal Claude review (advisory): 2 Major → fixed (liveness recovery, uid handling)
- [x] Cross-family review: **codex**, 3 rounds — round 1: 2 P1 fixed (env-provider host-fallback bypass, Dockerfile uid 1001); round 2: 2 findings fixed (credentials inside workspace mount, container-id contamination by daemon warnings); round 3: 2 P2 fixed (monitor-mode sub-flag forwarding, host claude path inside container)
- [x] Mutation sanity (Phase 7d): 5/5 mutations killed (liveness recovery, network validation, exec wrap, env-provider guard, post-loop cleanup)
- [x] Default image build verified: `docker build` succeeds, claude 2.1.170 runs as non-root and under a host-uid `--user` override

## Known Limitations / Intentionally Deferred

- **Official image publishing deferred** — the `Dockerfile` ships and is build-verified, but pushing to a registry needs Docker Hub/GHCR secrets and a SHA-pinned CI workflow; follow-up issue to be filed on merge. Users build locally: `docker build -t ralph-sandbox ~/.ralph`
- **`--mount`, `--read-only-root`, `--writable` flags deferred** — the rw project bind mount covers the core need; YAGNI for v1
- **Example custom images deferred** — `docs/DOCKER_SANDBOX.md` documents the `FROM ralph-sandbox` pattern instead
- **The 124-timeout branch inside `execute_claude_code` that calls `handle_sandbox_timeout` has no direct test** — the function itself is unit-tested (mutation-verified); a full timeout e2e needs a ≥60s real timeout and was judged not worth the suite slowdown
- **`--sandbox-network none` blocks the Claude API** by design — documented in help text and docs; only useful for images with their own proxy/auth
- **A `kill -9` of ralph leaves the container running** (no trap can run) — documented in troubleshooting with the manual `docker rm -f` recovery; SIGINT/SIGTERM/normal exits all clean up

## Implementation Notes

Deviations from the issue's traycer plan, with reasoning:
- `docker secret create` replaced with env-file/copied-home handoff — secrets require Swarm mode and don't work with plain `docker run`
- No `docker cp` sync layer — the bind mount makes it unnecessary; cloud sync is #76
- Bare `--image/--memory/--cpus/--network` flags renamed to `--sandbox-*` to avoid collisions with future ralph flags
- Whole-ralph-in-container model rejected in favor of exec-wrapping — keeps circuit breaker, rate limiting, analysis, and git state on the host; far more testable and incremental

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)