### PR TITLE
fix(test): bare '!' assertions are silent no-ops — convert all 22 + hygiene guard (#303)

### DIFF
--- a/tests/e2e/test_full_loop.bats
+++ b/tests/e2e/test_full_loop.bats
@@ -110,7 +110,7 @@ teardown() {
     assert_file_exists "src/work_1.txt"
     assert_file_exists "src/work_2.txt"
     assert_file_exists "src/work_3.txt"
-    ! grep -q '^- \[ \]' .ralph/fix_plan.md
+    [[ $(grep -c '^- \[ \]' .ralph/fix_plan.md) -eq 0 ]]
 }
 
 @test "E2E: three test-only loops exit with test_saturation" {
@@ -203,7 +203,7 @@ EOF
     [[ "$output" == *"Saved Claude session"* ]]
 
     # Loop 1 started fresh (no --resume); loop 2 resumed the stored session
-    ! grep -qx -- "--resume" "$MOCK_DIR/calls/argv_1.log"
+    [[ $(grep -cx -- "--resume" "$MOCK_DIR/calls/argv_1.log") -eq 0 ]]
     grep -qx -- "--resume" "$MOCK_DIR/calls/argv_2.log"
     grep -qx "e2e-sess-abc123" "$MOCK_DIR/calls/argv_2.log"
 }
@@ -249,7 +249,7 @@ EOF
     assert_success
     assert_equal "$(status_field max_calls_per_hour)" "7"
     # --no-continue: the stored session must NOT be resumed
-    ! grep -qx -- "--resume" "$MOCK_DIR/calls/argv_1.log"
+    [[ $(grep -cx -- "--resume" "$MOCK_DIR/calls/argv_1.log") -eq 0 ]]
 }
 
 # =============================================================================

--- a/tests/integration/test_prd_import.bats
+++ b/tests/integration/test_prd_import.bats
@@ -1248,7 +1248,7 @@ MOCK_GH_EOF
     grep -q '^# Add User Login' "$prd"
     grep -q 'Build login form' "$prd"
     # Comments are excluded by default (untrusted input; opt in via --include-comments)
-    ! grep -q '## Discussion' "$prd"
+    [[ $(grep -c '## Discussion' "$prd") -eq 0 ]]
 
     # No temp conversion artifacts left behind in the project
     [[ ! -f "add-user-login/.ralph_conversion_output.json" ]]
@@ -1399,7 +1399,7 @@ MOCK_CLAUDE_EOF
     # Only the conversion call happened
     [[ -f "$TEST_DIR/claude_stdin_1" ]]
     [[ ! -f "$TEST_DIR/claude_stdin_2" ]]
-    ! grep -q "Implementation Plan Generation Task" "$TEST_DIR/claude_stdin_1"
+    [[ $(grep -c "Implementation Plan Generation Task" "$TEST_DIR/claude_stdin_1") -eq 0 ]]
 
     # No generated plan artifact
     [[ ! -f "add-user-login/.ralph/specs/implementation-plan.md" ]]
@@ -1458,7 +1458,7 @@ MOCK_CLAUDE_EOF
     # Call-specific assertions: --model goes to the plan-generation call
     # (line 1) only — the conversion call (line 2) must not inherit it
     sed -n '1p' "$TEST_DIR/claude_args.log" | grep -q -- "--model opus"
-    ! sed -n '2p' "$TEST_DIR/claude_args.log" | grep -q -- "--model"
+    [[ $(sed -n '2p' "$TEST_DIR/claude_args.log" | grep -c -- "--model") -eq 0 ]]
 }
 
 # =============================================================================
@@ -1574,7 +1574,7 @@ MOCK_GH_EOF
     [[ "$output" == *"No issues match"* ]]
     # Nothing was imported
     [[ ! -d "new-bug-report" ]]
-    ! grep -q "issue view" "$TEST_DIR/gh_args.log"
+    [[ $(grep -c "issue view" "$TEST_DIR/gh_args.log") -eq 0 ]]
 }
 
 @test "ralph-import --dry-run previews matches without importing" {
@@ -1592,5 +1592,5 @@ MOCK_GH_EOF
 
     # No project was created and no issue was fetched for conversion
     [[ ! -d "old-bug" && ! -d "p0-critical-crash" && ! -d "new-bug-report" ]]
-    ! grep -q "issue view" "$TEST_DIR/gh_args.log"
+    [[ $(grep -c "issue view" "$TEST_DIR/gh_args.log") -eq 0 ]]
 }

--- a/tests/unit/test_bats_hygiene.bats
+++ b/tests/unit/test_bats_hygiene.bats
@@ -1,0 +1,32 @@
+#!/usr/bin/env bats
+# Guard: line-leading bare `! cmd` assertions are silent no-ops in bats
+# (Issue #303)
+#
+# bats-core's ERR trap does not fire for negated commands, so a failing
+# `! cmd` line in a @test body asserts nothing. Only a final-line `!`
+# affects the test via its return status — and refactors move lines — so
+# the repo rule is absolute: NO line-leading bare `!` in any .bats file.
+# Use instead:
+#   [[ $(cmd | grep -c PATTERN) -eq 0 ]]   # negative grep assertions
+#   run cmd; [ "$status" -ne 0 ]           # expected-failure commands
+#   a helper that returns 1 on unexpected success, checked at the call site
+#
+# Discovered in #75 (PR #302): 9 such assertions let 5 product mutations
+# survive undetected. This guard prevents the pattern from returning.
+
+load '../helpers/test_helper'
+
+REPO_ROOT="$BATS_TEST_DIRNAME/../.."
+
+@test "no .bats file contains a line-leading bare '!' assertion" {
+    local violations
+    # POSIX classes only — BSD grep (macOS) has no \s in ERE
+    violations=$(grep -rnE '^[[:space:]]*![[:space:]]' "$REPO_ROOT/tests" --include='*.bats' || true)
+    if [[ -n "$violations" ]]; then
+        echo "Bare '!' assertions found (silent no-ops under bats — issue #303):" >&2
+        echo "$violations" >&2
+        echo "Convert to a count-based grep, 'run' + status check, or a checked helper." >&2
+        return 1
+    fi
+    return 0
+}

--- a/tests/unit/test_cli_modern.bats
+++ b/tests/unit/test_cli_modern.bats
@@ -931,10 +931,10 @@ EOF
     live_block=$(sed -n '/Live output mode enabled/,/End of Output/p' "$script")
 
     # set +e and set -e should NOT appear in the live block
-    ! echo "$live_block" | grep -q '^[[:space:]]*set +e$'
-    ! echo "$live_block" | grep -q '^[[:space:]]*set -e'
-    ! echo "$live_block" | grep -q 'set -o pipefail'
-    ! echo "$live_block" | grep -q 'set +o pipefail'
+    [[ $(echo "$live_block" | grep -c '^[[:space:]]*set +e$') -eq 0 ]]
+    [[ $(echo "$live_block" | grep -c '^[[:space:]]*set -e') -eq 0 ]]
+    [[ $(echo "$live_block" | grep -c 'set -o pipefail') -eq 0 ]]
+    [[ $(echo "$live_block" | grep -c 'set +o pipefail') -eq 0 ]]
 }
 
 @test "live mode pipeline logs timeout events with exit code 124" {

--- a/tests/unit/test_enable_core.bats
+++ b/tests/unit/test_enable_core.bats
@@ -480,7 +480,7 @@ EOF
     assert_success
     # Should have template content, not old content
     grep -q ".ralph/.call_count" .gitignore
-    ! grep -q "my-custom-ignore" .gitignore
+    [[ $(grep -c "my-custom-ignore" .gitignore) -eq 0 ]]
 }
 
 @test "enable_ralph_in_directory succeeds when templates dir exists but .gitignore is missing" {

--- a/tests/unit/test_github_import.bats
+++ b/tests/unit/test_github_import.bats
@@ -195,7 +195,7 @@ EOF
     grep -q 'alice' out.md
     grep -q 'Here is the plan' out.md
     # Empty comment bodies are skipped
-    ! grep -q 'bot' out.md
+    [[ $(grep -c 'bot' out.md) -eq 0 ]]
 }
 
 @test "format_issue_as_prd excludes comments by default (untrusted input)" {
@@ -205,9 +205,9 @@ EOF
 
     run format_issue_as_prd issue.json out.md
     assert_success
-    ! grep -q 'Discussion' out.md
-    ! grep -q 'mallory' out.md
-    ! grep -q 'ignore previous instructions' out.md
+    [[ $(grep -c 'Discussion' out.md) -eq 0 ]]
+    [[ $(grep -c 'mallory' out.md) -eq 0 ]]
+    [[ $(grep -c 'ignore previous instructions' out.md) -eq 0 ]]
 }
 
 @test "format_issue_as_prd warns on empty body but still produces a PRD" {
@@ -502,7 +502,7 @@ JSON
     run generate_implementation_plan "issue_prd.md" "analysis.json" "plan.md"
     assert_success
 
-    ! grep -q -- "--model" "$TEST_DIR/claude_args"
+    [[ $(grep -c -- "--model" "$TEST_DIR/claude_args") -eq 0 ]]
 }
 
 @test "generate_implementation_plan sends missing elements and issue content to claude" {
@@ -556,8 +556,8 @@ MOCKEOF
 
     # Legacy path must not pass modern-only flags (codex P1): old CLIs
     # reject --strict-mcp-config / --output-format
-    ! grep -q -- "--strict-mcp-config" "$TEST_DIR/claude_args"
-    ! grep -q -- "--output-format" "$TEST_DIR/claude_args"
+    [[ $(grep -c -- "--strict-mcp-config" "$TEST_DIR/claude_args") -eq 0 ]]
+    [[ $(grep -c -- "--output-format" "$TEST_DIR/claude_args") -eq 0 ]]
 }
 
 @test "generate_implementation_plan fails on an empty plan" {

--- a/tests/unit/test_sandbox_docker.bats
+++ b/tests/unit/test_sandbox_docker.bats
@@ -423,7 +423,7 @@ _docker_args() { cat "$TEST_DIR/docker_args" 2>/dev/null; }
     start_sandbox_container
     run ensure_sandbox_container
     assert_success
-    ! _docker_args | grep -q '^start '
+    [[ $(_docker_args | grep -c '^start ') -eq 0 ]]
 }
 
 @test "ensure_sandbox_container: restarts a stopped container (OOM kill recovery)" {
@@ -498,7 +498,7 @@ _docker_args() { cat "$TEST_DIR/docker_args" 2>/dev/null; }
     init_docker_sandbox
     run handle_sandbox_timeout
     assert_success
-    ! _docker_args | grep -q '^restart'
+    [[ $(_docker_args | grep -c '^restart') -eq 0 ]]
 }
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Implements #303. bats-core's ERR trap doesn't fire for negated commands, so a mid-test `! cmd` line asserts nothing — discovered in #75 when 9 such assertions let 5 product mutations survive.

- Audit: 22 occurrences across 6 test files — every one a negative `grep` assertion
- All converted to the count-based form from PR #302: `[[ $(cmd | grep -c PAT) -eq 0 ]]` (flags like `-x`/`--` preserved; missing-file semantics unchanged — empty substitution compares equal to 0, same as the old silent pass)
- New `tests/unit/test_bats_hygiene.bats`: guard forbidding line-leading bare `!` in any `.bats` file (was RED with all 22 listed before conversion), modeled on the sha-pinning guard

## Test Plan
- [x] Guard test written first; RED with 22 offenders, GREEN after conversion
- [x] Full suite: 1268 unit+integration + 18 e2e, 100%
- [x] Mutation verification, one conversion per file, 6/6 killed:
  - sandbox_docker: running container made to call `docker start` → test fails
  - cli_modern: `set +e` injected into the live block → test fails
  - enable_core: .gitignore made to preserve old content → test fails
  - github_import: `--model` always passed → test fails
  - prd_import: conversion call made to inherit `--plan-model` → test fails
  - e2e full_loop: `--resume` made unconditional → test fails

## Known Limitations / Intentionally Deferred
- Guard scope is `.bats` files only; sourced `.bash` helpers may use `!` inside functions whose return value is checked at the call site (that pattern works correctly).

Closes #303