### PR TITLE
ci(deps): bump claude-code-action to v1.0.148; fix gh-aw dependabot ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,10 @@ updates:
       patterns:
       - "*"
   ignore:
-  - dependency-name: "github/gh-aw-actions/**" # Managed by gh aw compile. Version-locked to the gh-aw compiler; do not bump.
+  # Managed by gh aw compile. Version-locked to the gh-aw compiler; do not bump.
+  # Dependabot reports this as the bare `github/gh-aw-actions`, so the glob must
+  # match the bare name (a `/**` suffix does not) — `*` matches name + any subpath.
+  - dependency-name: "github/gh-aw-actions*"
   package-ecosystem: github-actions
   schedule:
     interval: weekly

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -63,7 +63,7 @@ jobs:
           github.event.pull_request.changed_files >= 5 ||
           steps.calc.outputs.total >= 20
         id: claude-review
-        uses: anthropics/claude-code-action@fbda2eb1bdc90d319b8d853f5deb53bca199a7c1 # v1.0.140
+        uses: anthropics/claude-code-action@d5726de019ec4498aa667642bc3a80fca83aa102 # v1.0.148
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # Explicit github_token needed for pull_request_target (OIDC doesn't work)

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@fbda2eb1bdc90d319b8d853f5deb53bca199a7c1 # v1.0.140
+        uses: anthropics/claude-code-action@d5726de019ec4498aa667642bc3a80fca83aa102 # v1.0.148
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/tests/unit/test_workflow_sha_pinning.bats
+++ b/tests/unit/test_workflow_sha_pinning.bats
@@ -105,4 +105,10 @@ extract_uses_lines() {
         fail "dependabot.yml has no ignore block (gh-aw setup pin must be excluded; Issue #287)"
     grep -qE 'dependency-name:[[:space:]]*"?github/gh-aw' "$config" || \
         fail "dependabot.yml does not ignore github/gh-aw (compiler-locked pin; Issue #287)"
+    # The glob must match the bare `github/gh-aw-actions` name that Dependabot
+    # actually reports — a `/**` suffix requires a subpath and silently fails to
+    # match, which is how the gh-aw pin still got bumped in PR #309. Require the
+    # `*` to follow the bare name directly (not after a `/`).
+    grep -qE 'dependency-name:[[:space:]]*"?github/gh-aw-actions\*' "$config" || \
+        fail "dependabot.yml gh-aw ignore must use 'github/gh-aw-actions*' so the bare repo name is matched (PR #309)"
 }


### PR DESCRIPTION
Splits the failing Dependabot group PR #309 into the parts we can safely take now vs. the part that needs a `gh aw compile`.

## What this PR does (the safe bumps)
- **`anthropics/claude-code-action` 1.0.140 → 1.0.148** in the two hand-maintained workflows (`claude.yml`, `claude-code-review.yml`).
- **Fixes the Dependabot ignore rule** for `github/gh-aw-actions`: the old glob `github/gh-aw-actions/**` never matched the bare `github/gh-aw-actions` name that Dependabot actually reports (a `/**` suffix requires a subpath), so the compiler-locked pin was never really ignored. Switched to `github/gh-aw-actions*`.
- **Strengthens the guard test** `test_workflow_sha_pinning.bats` ("dependabot ignores compiler-locked gh-aw pins") to require the bare-name-matching form, so the broken `/**`-only pattern can't regress (mutation-verified).

## What this PR intentionally leaves out (the part we can't take)
The compiled artifact `triage-incoming-issues.lock.yml` is untouched. PR #309's bump of `github/gh-aw-actions/setup` to v0.79.8 desynced the pin from the gh-aw compiler version (`v0.77.5`) baked into the lock file, which trips the guard:

```
not ok 995 gh-aw lock files keep setup pins at the compiler version
  triage-incoming-issues.lock.yml [compiler v0.77.5]:
    uses: github/gh-aw-actions/setup@c0338fe… # v0.79.8
  Fix by recompiling ('gh aw compile'), never by bumping the pin.
```

That update — plus the lock file's `actions/checkout` 6.0.2 → 6.0.3 (its only remaining 6.0.2 reference; the hand-maintained workflows are already on 6.0.3) — must go through `gh aw compile`. Tracked separately so PR #309 can be closed.

## Testing
- `bats tests/unit/test_workflow_sha_pinning.bats` — 6/6 pass
- `bats tests/unit/test_workflow_credential_hygiene.bats tests/unit/test_workflow_docker_publish.bats` — pass
- Mutation check: reverting the ignore glob to `/**` makes the strengthened guard fail as intended.

Closes the dependency-update intent of #309 for the two safe actions; the gh-aw recompile is the linked follow-up issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration for GitHub Actions
  * Updated GitHub Actions workflow to use latest pinned version
  * Enhanced unit tests for workflow SHA validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->