### PR TITLE
test(adapters): add generic provider adapter harness

### DIFF
--- a/tests/fixtures/providers/claude/capabilities.json
+++ b/tests/fixtures/providers/claude/capabilities.json
@@ -1,0 +1,9 @@
+{
+  "provider": "claude",
+  "supports_structured_output": true,
+  "supports_token_usage": true,
+  "supports_session_continuity": true,
+  "supports_tool_restrictions": true,
+  "supports_permission_denials": true,
+  "supports_rate_limit_detection": true
+}

--- a/tests/fixtures/providers/claude/normalized_success.json
+++ b/tests/fixtures/providers/claude/normalized_success.json
@@ -1,0 +1,18 @@
+{
+  "status": "COMPLETE",
+  "exit_signal": true,
+  "work_type": "IMPLEMENTATION",
+  "files_modified": 3,
+  "asking_questions": false,
+  "question_count": 0,
+  "token_usage": {
+    "input_tokens": 1200,
+    "output_tokens": 450
+  },
+  "permission_denials": [],
+  "is_error": false,
+  "rate_limit_detected": false,
+  "session_id": "claude-session-123",
+  "confidence_score": 95,
+  "work_summary": "Implemented project setup and updated tests."
+}

--- a/tests/fixtures/providers/claude/normalized_success.json
+++ b/tests/fixtures/providers/claude/normalized_success.json
@@ -1,4 +1,5 @@
 {
+  "provider": "claude",
   "status": "COMPLETE",
   "exit_signal": true,
   "work_type": "IMPLEMENTATION",

--- a/tests/helpers/provider_adapter_harness.bash
+++ b/tests/helpers/provider_adapter_harness.bash
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# Generic provider adapter test harness helpers.
+#
+# These helpers intentionally do not know about Claude, Codex, Gemini, or any
+# other provider implementation. They provide fixture-based assertions and a
+# deterministic mock CLI pattern that provider adapter tests can reuse without
+# invoking a real external agent CLI.
+
+adapter_harness_fail() {
+    local message="$1"
+
+    if declare -F fail >/dev/null 2>&1; then
+        fail "$message"
+    else
+        echo "$message"
+        return 1
+    fi
+}
+
+adapter_harness_require_command() {
+    local command_name="$1"
+
+    command -v "$command_name" >/dev/null 2>&1 || \
+        adapter_harness_fail "Required command not found: $command_name"
+}
+
+adapter_harness_assert_file_exists() {
+    local file_path="$1"
+
+    [[ -f "$file_path" ]] || adapter_harness_fail "Expected file to exist: $file_path"
+}
+
+adapter_harness_create_mock_cli() {
+    local mock_cli_path="$1"
+    local output_fixture_path="$2"
+    local argv_capture_path="$3"
+    local exit_code="${4:-0}"
+
+    adapter_harness_assert_file_exists "$output_fixture_path"
+
+    mkdir -p "$(dirname "$mock_cli_path")" "$(dirname "$argv_capture_path")"
+
+    cat > "$mock_cli_path" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${ADAPTER_HARNESS_OUTPUT_FIXTURE:?ADAPTER_HARNESS_OUTPUT_FIXTURE is required}"
+: "${ADAPTER_HARNESS_ARGV_CAPTURE:?ADAPTER_HARNESS_ARGV_CAPTURE is required}"
+: "${ADAPTER_HARNESS_EXIT_CODE:=0}"
+
+printf '%s\n' "$@" > "$ADAPTER_HARNESS_ARGV_CAPTURE"
+cat "$ADAPTER_HARNESS_OUTPUT_FIXTURE"
+exit "$ADAPTER_HARNESS_EXIT_CODE"
+EOF
+    chmod +x "$mock_cli_path"
+
+    export ADAPTER_HARNESS_OUTPUT_FIXTURE="$output_fixture_path"
+    export ADAPTER_HARNESS_ARGV_CAPTURE="$argv_capture_path"
+    export ADAPTER_HARNESS_EXIT_CODE="$exit_code"
+}
+
+adapter_harness_assert_argv_contains() {
+    local argv_capture_path="$1"
+    local expected_arg="$2"
+
+    adapter_harness_assert_file_exists "$argv_capture_path"
+
+    grep -Fx -- "$expected_arg" "$argv_capture_path" >/dev/null || \
+        adapter_harness_fail "Expected argv to contain '$expected_arg' in $argv_capture_path"
+}
+
+adapter_harness_assert_argv_not_contains() {
+    local argv_capture_path="$1"
+    local unexpected_arg="$2"
+
+    adapter_harness_assert_file_exists "$argv_capture_path"
+
+    if grep -Fx -- "$unexpected_arg" "$argv_capture_path" >/dev/null; then
+        adapter_harness_fail "Did not expect argv to contain '$unexpected_arg' in $argv_capture_path"
+    fi
+}
+
+adapter_harness_assert_json_file() {
+    local json_path="$1"
+
+    adapter_harness_require_command jq
+    adapter_harness_assert_file_exists "$json_path"
+
+    jq empty "$json_path" >/dev/null || \
+        adapter_harness_fail "Expected valid JSON file: $json_path"
+}
+
+adapter_harness_assert_json_has_key() {
+    local json_path="$1"
+    local key="$2"
+
+    adapter_harness_assert_json_file "$json_path"
+
+    jq -e --arg key "$key" 'has($key)' "$json_path" >/dev/null || \
+        adapter_harness_fail "Expected JSON key '$key' in $json_path"
+}
+
+adapter_harness_assert_json_value() {
+    local json_path="$1"
+    local jq_filter="$2"
+    local expected_value="$3"
+    local actual_value
+
+    adapter_harness_assert_json_file "$json_path"
+
+    actual_value=$(jq -r "$jq_filter" "$json_path") || \
+        adapter_harness_fail "jq filter failed for $json_path: $jq_filter"
+
+    [[ "$actual_value" == "$expected_value" ]] || \
+        adapter_harness_fail "Expected $jq_filter to be '$expected_value' but got '$actual_value'"
+}
+
+adapter_harness_assert_normalized_output_schema() {
+    local json_path="$1"
+
+    adapter_harness_assert_json_file "$json_path"
+
+    local required_keys=(
+        status
+        exit_signal
+        work_type
+        files_modified
+        asking_questions
+        question_count
+        token_usage
+        permission_denials
+        is_error
+        rate_limit_detected
+        session_id
+        confidence_score
+        work_summary
+    )
+
+    local key
+    for key in "${required_keys[@]}"; do
+        adapter_harness_assert_json_has_key "$json_path" "$key"
+    done
+
+    jq -e '
+        (.status | type == "string") and
+        (.exit_signal | type == "boolean") and
+        (.work_type | type == "string") and
+        (.files_modified | type == "number") and
+        (.asking_questions | type == "boolean") and
+        (.question_count | type == "number") and
+        (.token_usage | type == "object") and
+        (.token_usage.input_tokens | type == "number") and
+        (.token_usage.output_tokens | type == "number") and
+        (.permission_denials | type == "array") and
+        (.is_error | type == "boolean") and
+        (.rate_limit_detected | type == "boolean") and
+        ((.session_id | type == "string") or (.session_id == null)) and
+        (.confidence_score | type == "number") and
+        (.work_summary | type == "string")
+    ' "$json_path" >/dev/null || \
+        adapter_harness_fail "Normalized provider output schema check failed: $json_path"
+}
+
+adapter_harness_assert_capabilities_schema() {
+    local json_path="$1"
+
+    adapter_harness_assert_json_file "$json_path"
+
+    local required_keys=(
+        provider
+        supports_structured_output
+        supports_token_usage
+        supports_session_continuity
+        supports_tool_restrictions
+        supports_permission_denials
+        supports_rate_limit_detection
+    )
+
+    local key
+    for key in "${required_keys[@]}"; do
+        adapter_harness_assert_json_has_key "$json_path" "$key"
+    done
+
+    jq -e '
+        (.provider | type == "string") and
+        (.supports_structured_output | type == "boolean") and
+        (.supports_token_usage | type == "boolean") and
+        (.supports_session_continuity | type == "boolean") and
+        (.supports_tool_restrictions | type == "boolean") and
+        (.supports_permission_denials | type == "boolean") and
+        (.supports_rate_limit_detection | type == "boolean")
+    ' "$json_path" >/dev/null || \
+        adapter_harness_fail "Provider capabilities schema check failed: $json_path"
+}

--- a/tests/unit/test_provider_adapter_harness.bats
+++ b/tests/unit/test_provider_adapter_harness.bats
@@ -42,7 +42,7 @@ teardown() {
     printf '%s\n' "$output" > "$output_file"
 
     adapter_harness_assert_normalized_output_schema "$output_file"
-    adapter_harness_assert_json_value "$output_file" '.provider // "claude"' "claude"
+    adapter_harness_assert_json_value "$output_file" '.provider' "claude"
     adapter_harness_assert_argv_contains "$argv_capture" "--output-format"
     adapter_harness_assert_argv_contains "$argv_capture" "json"
     adapter_harness_assert_argv_contains "$argv_capture" "--model"
@@ -64,7 +64,7 @@ teardown() {
 
     run "$mock_cli" --output-format json
 
-    [ "$status" -eq 42 ]
+    assert_equal 42 "$status"
     adapter_harness_assert_argv_contains "$argv_capture" "--output-format"
     adapter_harness_assert_argv_contains "$argv_capture" "json"
 }

--- a/tests/unit/test_provider_adapter_harness.bats
+++ b/tests/unit/test_provider_adapter_harness.bats
@@ -1,0 +1,70 @@
+#!/usr/bin/env bats
+# Unit tests for generic provider adapter harness helpers.
+
+load '../helpers/test_helper'
+load '../helpers/provider_adapter_harness'
+
+setup() {
+    export TEST_TEMP_DIR="$(mktemp -d)"
+    export TEST_FIXTURES_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../fixtures/providers/claude" && pwd)"
+}
+
+teardown() {
+    cd /
+    rm -rf "$TEST_TEMP_DIR"
+}
+
+@test "provider adapter harness validates normalized Claude fixture schema" {
+    run adapter_harness_assert_normalized_output_schema "$TEST_FIXTURES_DIR/normalized_success.json"
+
+    assert_success
+}
+
+@test "provider adapter harness validates Claude capabilities fixture schema" {
+    run adapter_harness_assert_capabilities_schema "$TEST_FIXTURES_DIR/capabilities.json"
+
+    assert_success
+}
+
+@test "provider adapter harness mock CLI records argv and emits fixture output" {
+    local mock_cli="$TEST_TEMP_DIR/mock-claude"
+    local argv_capture="$TEST_TEMP_DIR/mock-claude.argv"
+    local output_file="$TEST_TEMP_DIR/mock-claude.out"
+
+    adapter_harness_create_mock_cli \
+        "$mock_cli" \
+        "$TEST_FIXTURES_DIR/normalized_success.json" \
+        "$argv_capture"
+
+    run "$mock_cli" --output-format json --model test-model -p "Implement the next task"
+
+    assert_success
+    printf '%s\n' "$output" > "$output_file"
+
+    adapter_harness_assert_normalized_output_schema "$output_file"
+    adapter_harness_assert_json_value "$output_file" '.provider // "claude"' "claude"
+    adapter_harness_assert_argv_contains "$argv_capture" "--output-format"
+    adapter_harness_assert_argv_contains "$argv_capture" "json"
+    adapter_harness_assert_argv_contains "$argv_capture" "--model"
+    adapter_harness_assert_argv_contains "$argv_capture" "test-model"
+    adapter_harness_assert_argv_contains "$argv_capture" "-p"
+    adapter_harness_assert_argv_contains "$argv_capture" "Implement the next task"
+    adapter_harness_assert_argv_not_contains "$argv_capture" "--resume"
+}
+
+@test "provider adapter harness surfaces mock CLI exit codes without real provider calls" {
+    local mock_cli="$TEST_TEMP_DIR/mock-claude-failure"
+    local argv_capture="$TEST_TEMP_DIR/mock-claude-failure.argv"
+
+    adapter_harness_create_mock_cli \
+        "$mock_cli" \
+        "$TEST_FIXTURES_DIR/normalized_success.json" \
+        "$argv_capture" \
+        42
+
+    run "$mock_cli" --output-format json
+
+    [ "$status" -eq 42 ]
+    adapter_harness_assert_argv_contains "$argv_capture" "--output-format"
+    adapter_harness_assert_argv_contains "$argv_capture" "json"
+}


### PR DESCRIPTION
## Summary

Adds a reusable BATS-based provider adapter test harness for future provider integrations.

This PR keeps the scope intentionally small:
- no new provider adapter is introduced
- no real provider CLI is invoked
- Claude remains the reference fixture shape for adapter harness testing

## Changes

- Adds `tests/helpers/provider_adapter_harness.bash`
- Adds Claude reference fixtures under `tests/fixtures/providers/claude/`
- Adds unit coverage for normalized output schema validation, capabilities schema validation, argv capture, fixture output, and mock CLI exit propagation
- Keeps provider tests deterministic by using mock commands / fixture files only

## Why

The project is moving toward a provider-adapter architecture. A shared harness should make future provider PRs easier to review and reduce duplicated BATS setup across Codex, Gemini, OpenCode, and other adapters.

## Test Plan

- [ ] `npm test`
- [ ] `npm run test:unit`

I could not run the test suite from the GitHub connector; this PR only adds deterministic BATS helpers/fixtures/tests and does not call external provider CLIs.

## Scope control

This PR does not implement Codex, Gemini, OpenCode, Droid, Kilocode, or Copilot adapters. It only adds reusable test infrastructure.

Relates to #316.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added Claude provider fixtures for declared capabilities and a normalized successful completion payload.
  * Introduced a Bash-based provider adapter test harness with assertion helpers, mock CLI generation, argv capture, and JSON/schema validation.
  * Added unit tests (using the harness and fixtures) to verify normalized output and capabilities schemas, correct CLI argument handling, and proper mocked exit-code propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->