### PR TITLE
fix(response_analyzer): guard against zero last_output_length (division by zero)

### DIFF
--- a/lib/response_analyzer.sh
+++ b/lib/response_analyzer.sh
@@ -798,11 +798,14 @@ analyze_response() {
     # 7. Analyze output length trends (detect declining engagement)
     if [[ -f "$RALPH_DIR/.last_output_length" ]]; then
         local last_length=$(cat "$RALPH_DIR/.last_output_length")
-        local length_ratio=$((output_length * 100 / last_length))
+        # Guard against missing/zero previous length (avoids division by zero)
+        if [[ "$last_length" =~ ^[0-9]+$ ]] && (( last_length > 0 )); then
+            local length_ratio=$((output_length * 100 / last_length))
 
-        if [[ $length_ratio -lt 50 ]]; then
-            # Output is less than 50% of previous - possible completion
-            ((confidence_score+=10))
+            if [[ $length_ratio -lt 50 ]]; then
+                # Output is less than 50% of previous - possible completion
+                ((confidence_score+=10))
+            fi
         fi
     fi
     echo "$output_length" > "$RALPH_DIR/.last_output_length"

--- a/tests/unit/test_exit_detection.bats
+++ b/tests/unit/test_exit_detection.bats
@@ -1432,6 +1432,64 @@ detect_progress_with_commits() {
     assert_equal "$asking" "false"
 }
 
+@test "analyze_response does not crash when .last_output_length is zero (regression PR #333: division by zero)" {
+    # Skip if git is not available (analyze_response uses git)
+    if ! command -v git &>/dev/null; then
+        skip "git not available"
+    fi
+
+    git init --quiet
+    git config user.email "test@test.com"
+    git config user.name "Test"
+    echo "init" > init.txt
+    git add init.txt
+    git commit --quiet -m "init"
+
+    source "${BATS_TEST_DIRNAME}/../../lib/response_analyzer.sh"
+    mkdir -p "$RALPH_DIR/logs"
+
+    # Simulate a prior loop that wrote a zero output length
+    # (e.g. an interrupted/crashed agent call that produced no output)
+    echo "0" > "$RALPH_DIR/.last_output_length"
+
+    local output_file="$RALPH_DIR/logs/claude_output_test.log"
+    echo "Implementing feature X. Continuing work on the next steps." > "$output_file"
+
+    run analyze_response "$output_file" 1
+
+    # Before the fix this aborted with "division by 0" mid-execution
+    assert_success
+    [ -f "$RALPH_DIR/.response_analysis" ]
+}
+
+@test "analyze_response does not crash when .last_output_length is empty/non-numeric (regression PR #333)" {
+    # Skip if git is not available (analyze_response uses git)
+    if ! command -v git &>/dev/null; then
+        skip "git not available"
+    fi
+
+    git init --quiet
+    git config user.email "test@test.com"
+    git config user.name "Test"
+    echo "init" > init.txt
+    git add init.txt
+    git commit --quiet -m "init"
+
+    source "${BATS_TEST_DIRNAME}/../../lib/response_analyzer.sh"
+    mkdir -p "$RALPH_DIR/logs"
+
+    # Empty file (also represents the non-numeric case — both fail the ^[0-9]+$ guard)
+    printf '' > "$RALPH_DIR/.last_output_length"
+
+    local output_file="$RALPH_DIR/logs/claude_output_test.log"
+    echo "Implementing feature X. Continuing work on the next steps." > "$output_file"
+
+    run analyze_response "$output_file" 1
+
+    assert_success
+    [ -f "$RALPH_DIR/.response_analysis" ]
+}
+
 # --- Stale Exit Signals Tests (Issue #194) ---
 
 @test "startup resets stale exit signals before main loop" {

--- a/tests/unit/test_exit_detection.bats
+++ b/tests/unit/test_exit_detection.bats
@@ -1519,6 +1519,43 @@ detect_progress_with_commits() {
     [ -f "$RALPH_DIR/.response_analysis" ]
 }
 
+@test "analyze_response output-decline heuristic still adds +10 when last length is a valid positive integer (PR #333 criterion 2)" {
+    # Skip if git is not available (analyze_response uses git)
+    if ! command -v git &>/dev/null; then
+        skip "git not available"
+    fi
+
+    git init --quiet
+    git config user.email "test@test.com"
+    git config user.name "Test"
+    echo "init" > init.txt
+    git add init.txt
+    git commit --quiet -m "init"
+
+    source "${BATS_TEST_DIRNAME}/../../lib/response_analyzer.sh"
+    mkdir -p "$RALPH_DIR/logs"
+
+    local output_file="$RALPH_DIR/logs/claude_output_test.log"
+    echo "Implementing feature X. Continuing work on the next steps." > "$output_file"
+
+    # Run A: previous output much larger -> ratio < 50% -> +10 confidence
+    echo "1000" > "$RALPH_DIR/.last_output_length"
+    run analyze_response "$output_file" 1
+    assert_success
+    local score_decline
+    score_decline=$(jq -r '.analysis.confidence_score' "$RALPH_DIR/.response_analysis")
+
+    # Run B: identical output/state, previous length tiny -> ratio >= 50% -> no bonus
+    echo "1" > "$RALPH_DIR/.last_output_length"
+    run analyze_response "$output_file" 2
+    assert_success
+    local score_no_decline
+    score_no_decline=$(jq -r '.analysis.confidence_score' "$RALPH_DIR/.response_analysis")
+
+    # Only the decline bonus differs between the two runs
+    assert_equal "$((score_decline - score_no_decline))" "10"
+}
+
 # --- Stale Exit Signals Tests (Issue #194) ---
 
 @test "startup resets stale exit signals before main loop" {

--- a/tests/unit/test_exit_detection.bats
+++ b/tests/unit/test_exit_detection.bats
@@ -1462,7 +1462,7 @@ detect_progress_with_commits() {
     [ -f "$RALPH_DIR/.response_analysis" ]
 }
 
-@test "analyze_response does not crash when .last_output_length is empty/non-numeric (regression PR #333)" {
+@test "analyze_response does not crash when .last_output_length is empty (regression PR #333)" {
     # Skip if git is not available (analyze_response uses git)
     if ! command -v git &>/dev/null; then
         skip "git not available"
@@ -1478,8 +1478,37 @@ detect_progress_with_commits() {
     source "${BATS_TEST_DIRNAME}/../../lib/response_analyzer.sh"
     mkdir -p "$RALPH_DIR/logs"
 
-    # Empty file (also represents the non-numeric case — both fail the ^[0-9]+$ guard)
+    # Empty file — fails the ^[0-9]+$ guard; last_length must default without dividing by zero
     printf '' > "$RALPH_DIR/.last_output_length"
+
+    local output_file="$RALPH_DIR/logs/claude_output_test.log"
+    echo "Implementing feature X. Continuing work on the next steps." > "$output_file"
+
+    run analyze_response "$output_file" 1
+
+    assert_success
+    [ -f "$RALPH_DIR/.response_analysis" ]
+}
+
+@test "analyze_response does not crash when .last_output_length is non-numeric (regression PR #333)" {
+    # Skip if git is not available (analyze_response uses git)
+    if ! command -v git &>/dev/null; then
+        skip "git not available"
+    fi
+
+    git init --quiet
+    git config user.email "test@test.com"
+    git config user.name "Test"
+    echo "init" > init.txt
+    git add init.txt
+    git commit --quiet -m "init"
+
+    source "${BATS_TEST_DIRNAME}/../../lib/response_analyzer.sh"
+    mkdir -p "$RALPH_DIR/logs"
+
+    # Real non-numeric content — exercises the ^[0-9]+$ guard's false branch with a
+    # non-empty value (distinct from the empty-file case above)
+    printf 'not-a-number\n' > "$RALPH_DIR/.last_output_length"
 
     local output_file="$RALPH_DIR/logs/claude_output_test.log"
     echo "Implementing feature X. Continuing work on the next steps." > "$output_file"


### PR DESCRIPTION
## Problem

`lib/response_analyzer.sh` aborts with a division-by-zero when `$RALPH_DIR/.last_output_length` contains `0`:

```bash
local last_length=$(cat "$RALPH_DIR/.last_output_length")
local length_ratio=$((output_length * 100 / last_length))   # last_length=0 -> division by zero
```

This happens whenever a prior loop wrote a zero/empty output length into `.last_output_length` (e.g. an interrupted or crashed agent call that produced no output). On the next loop, `analyze_response()` dies mid-execution and takes the whole loop down — the loop crashes while streaming output:

```
lib/response_analyzer.sh: line 801: output_length * 100 / last_length: division by 0 (error token is "last_length")
```

## Fix

Compute `length_ratio` only when `last_length` is a positive integer. This also guards against an empty or non-numeric file.

```diff
     if [[ -f "$RALPH_DIR/.last_output_length" ]]; then
         local last_length=$(cat "$RALPH_DIR/.last_output_length")
-        local length_ratio=$((output_length * 100 / last_length))
-
-        if [[ $length_ratio -lt 50 ]]; then
-            # Output is less than 50% of previous - possible completion
-            ((confidence_score+=10))
+        # Guard against missing/zero previous length (avoids division by zero)
+        if [[ "$last_length" =~ ^[0-9]+$ ]] && (( last_length > 0 )); then
+            local length_ratio=$((output_length * 100 / last_length))
+
+            if [[ $length_ratio -lt 50 ]]; then
+                # Output is less than 50% of previous - possible completion
+                ((confidence_score+=10))
+            fi
         fi
     fi
```

## Behavior

- No change when `last_length > 0`.
- When the file is `0` / empty / non-numeric, the "declining engagement" heuristic is skipped for that loop (no false completion signal) instead of crashing the loop.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of response analysis by safely handling missing, empty, zero, or non-numeric stored output-length values to prevent calculation errors.
* **Tests**
  * Added regression tests covering problematic stored output-length cases, ensuring the analyzer completes successfully and still generates output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->