### PR TITLE
chore(deps): add dependabot cooldown stepdown policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,11 @@ updates:
   # match the bare name (a `/**` suffix does not) — `*` matches name + any subpath.
   - dependency-name: "github/gh-aw-actions*"
   package-ecosystem: github-actions
+  cooldown:
+    default-days: 14
+    semver-major-days: 14
+    semver-minor-days: 7
+    semver-patch-days: 7
   schedule:
     interval: weekly
 version: 2


### PR DESCRIPTION
Adds a supply-chain cooldown to dependabot version updates: semver ecosystems (npm, github-actions) wait 7 days on minor/patch and 14 on major; non-semver ecosystems (pip/uv/docker/devcontainers) wait a flat 14 days. Security-advisory updates bypass cooldown automatically (GitHub behavior). Rolled out account-wide.