### PR TITLE
fix(ralph_loop): honor RALPH_DIR from the environment and .ralphrc

### DIFF
--- a/ralph_loop.sh
+++ b/ralph_loop.sh
@@ -51,7 +51,16 @@ if [[ -z "${RALPH_DIR:-}" && -f ".ralphrc" ]]; then
         -e "s/^[[:space:]]*RALPH_DIR=[[:space:]]*'\([^']*\)'.*/\1/p" \
         -e 's/^[[:space:]]*RALPH_DIR=\([^"'"'"'[:space:]#]\{1,\}\).*/\1/p' \
         ".ralphrc" 2>/dev/null | tail -n 1)
-    if [[ -n "$_rc_ralph_dir" ]]; then
+    if [[ "$_rc_ralph_dir" == *'$'* || "$_rc_ralph_dir" == *'`'* ]]; then
+        # A value carrying a shell expansion cannot be resolved without
+        # evaluating it. Applying it literally would derive paths such as
+        # "$HOME/state/PROMPT.md" here while load_ralphrc() expands the same
+        # assignment later -- reintroducing the very split this block removes.
+        # Leave RALPH_DIR untouched so the paths below keep the .ralph default.
+        echo "WARNING: RALPH_DIR in .ralphrc contains a shell expansion ($_rc_ralph_dir)." >&2
+        echo "         It cannot be applied before the state paths are derived." >&2
+        echo "         Export RALPH_DIR instead, or use a literal path." >&2
+    elif [[ -n "$_rc_ralph_dir" ]]; then
         RALPH_DIR="$_rc_ralph_dir"
     fi
     unset _rc_ralph_dir

--- a/ralph_loop.sh
+++ b/ralph_loop.sh
@@ -48,7 +48,13 @@ source "$SCRIPT_DIR/lib/sandbox_e2b.sh" || { echo "FATAL: Failed to source lib/s
 
 # Configuration
 # Ralph-specific files live in .ralph/ subfolder
-RALPH_DIR=".ralph"
+# Every sourced lib/*.sh reads RALPH_DIR with the env-respecting form
+# ("${RALPH_DIR:-.ralph}"), and they are sourced above (lines 38-47) before
+# this line runs. Resetting to a bare ".ralph" here silently discards an
+# exported RALPH_DIR for every path derived below (PROMPT_FILE, LOG_DIR,
+# STATUS_FILE, CLAUDE_SESSION_FILE, ...), splitting state across two
+# directories. See #352.
+RALPH_DIR="${RALPH_DIR:-.ralph}"
 PROMPT_FILE="$RALPH_DIR/PROMPT.md"
 LOG_DIR="$RALPH_DIR/logs"
 DOCS_DIR="$RALPH_DIR/docs/generated"

--- a/ralph_loop.sh
+++ b/ralph_loop.sh
@@ -33,6 +33,30 @@ _env_SYNC_EXCLUDE="${SYNC_EXCLUDE:-}"
 _env_SYNC_MAX_FILE_SIZE="${SYNC_MAX_FILE_SIZE:-}"
 _env_SYNC_LARGE_FILE_ACTION="${SYNC_LARGE_FILE_ACTION:-}"
 
+# Issue #352: resolve RALPH_DIR BEFORE the library source block below. Each
+# sourced lib/*.sh derives its own state paths from RALPH_DIR at source time
+# (lib/response_analyzer.sh's SESSION_FILE, for one), and the path vars in the
+# Configuration block are derived immediately after -- so a RALPH_DIR applied
+# later by load_ralphrc(), which runs far below, cannot move any of them.
+#
+# Precedence: exported environment > .ralphrc > the ".ralph" default.
+#
+# .ralphrc is scanned here rather than sourced: sourcing runs arbitrary user
+# code -- including guards that call `exit` -- before the libraries and
+# defaults it may depend on exist. load_ralphrc() remains the single place
+# that sources .ralphrc, for every other setting.
+if [[ -z "${RALPH_DIR:-}" && -f ".ralphrc" ]]; then
+    _rc_ralph_dir=$(sed -n \
+        -e 's/^[[:space:]]*RALPH_DIR=[[:space:]]*"\([^"]*\)".*/\1/p' \
+        -e "s/^[[:space:]]*RALPH_DIR=[[:space:]]*'\([^']*\)'.*/\1/p" \
+        -e 's/^[[:space:]]*RALPH_DIR=\([^"'"'"'[:space:]#]\{1,\}\).*/\1/p' \
+        ".ralphrc" 2>/dev/null | tail -n 1)
+    if [[ -n "$_rc_ralph_dir" ]]; then
+        RALPH_DIR="$_rc_ralph_dir"
+    fi
+    unset _rc_ralph_dir
+fi
+
 # Source library components
 SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
 source "$SCRIPT_DIR/lib/date_utils.sh" || { echo "FATAL: Failed to source lib/date_utils.sh" >&2; exit 1; }

--- a/tests/unit/test_ralph_dir_resolution.bats
+++ b/tests/unit/test_ralph_dir_resolution.bats
@@ -1,0 +1,72 @@
+#!/usr/bin/env bats
+# Regression tests for #352: ralph_loop.sh:51 clobbered an exported RALPH_DIR
+# with a hardcoded ".ralph", even though every sourced lib/*.sh (sourced
+# earlier, at lines 38-47) already resolves RALPH_DIR with the env-respecting
+# form ("${RALPH_DIR:-.ralph}"). This split main-script state (PROMPT_FILE,
+# LOG_DIR, STATUS_FILE, CLAUDE_SESSION_FILE, ...) into ".ralph" while the libs'
+# own state (CB_STATE_FILE, SESSION_FILE, QUEUE_FILE, ...) stayed under the
+# exported directory.
+
+load '../helpers/test_helper'
+
+PROJECT_ROOT="${BATS_TEST_DIRNAME}/../.."
+
+setup() {
+    TEST_DIR="$(mktemp -d "${BATS_TEST_TMPDIR}/ralphdir.XXXXXX")"
+    cd "$TEST_DIR"
+}
+
+teardown() {
+    rm -rf "$TEST_DIR"
+}
+
+# Sourcing ralph_loop.sh must not execute the main loop (guarded by the
+# `[[ "${BASH_SOURCE[0]}" == "${0}" ]]` check at the bottom of the file), so
+# it is safe to source it in a subshell and inspect the resulting variables.
+@test "ralph_loop.sh honors an exported RALPH_DIR (not silently reset to .ralph)" {
+    mkdir -p "$TEST_DIR/custom-state"
+    run bash -c "
+        export RALPH_DIR='$TEST_DIR/custom-state'
+        source '$PROJECT_ROOT/ralph_loop.sh'
+        echo \"RALPH_DIR=\$RALPH_DIR\"
+        echo \"PROMPT_FILE=\$PROMPT_FILE\"
+        echo \"LOG_DIR=\$LOG_DIR\"
+        echo \"CLAUDE_SESSION_FILE=\$CLAUDE_SESSION_FILE\"
+    "
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "^RALPH_DIR=$TEST_DIR/custom-state$"
+    echo "$output" | grep -q "^PROMPT_FILE=$TEST_DIR/custom-state/PROMPT.md$"
+    echo "$output" | grep -q "^LOG_DIR=$TEST_DIR/custom-state/logs$"
+    echo "$output" | grep -q "^CLAUDE_SESSION_FILE=$TEST_DIR/custom-state/.claude_session_id$"
+}
+
+@test "ralph_loop.sh and lib/response_analyzer.sh agree on the session-id file path" {
+    # This is the concrete failure mode: ralph_loop.sh's own CLAUDE_SESSION_FILE
+    # (used to decide what to --resume) and response_analyzer.sh's SESSION_FILE
+    # (written by store_session_id()) must resolve to the same path, or the
+    # main loop resumes a stale/wrong session id that store_session_id() never
+    # actually updated.
+    mkdir -p "$TEST_DIR/custom-state"
+    run bash -c "
+        export RALPH_DIR='$TEST_DIR/custom-state'
+        source '$PROJECT_ROOT/ralph_loop.sh'
+        echo \"CLAUDE_SESSION_FILE=\$CLAUDE_SESSION_FILE\"
+        echo \"SESSION_FILE=\$SESSION_FILE\"
+    "
+    [ "$status" -eq 0 ]
+    local claude_session_file session_file
+    claude_session_file=$(echo "$output" | grep '^CLAUDE_SESSION_FILE=' | cut -d= -f2-)
+    session_file=$(echo "$output" | grep '^SESSION_FILE=' | cut -d= -f2-)
+    [ -n "$claude_session_file" ]
+    [ "$claude_session_file" = "$session_file" ]
+}
+
+@test "ralph_loop.sh still defaults to .ralph when RALPH_DIR is unset" {
+    run bash -c "
+        unset RALPH_DIR
+        source '$PROJECT_ROOT/ralph_loop.sh'
+        echo \"RALPH_DIR=\$RALPH_DIR\"
+    "
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "^RALPH_DIR=\.ralph$"
+}

--- a/tests/unit/test_ralph_dir_resolution.bats
+++ b/tests/unit/test_ralph_dir_resolution.bats
@@ -70,3 +70,111 @@ teardown() {
     [ "$status" -eq 0 ]
     echo "$output" | grep -q "^RALPH_DIR=\.ralph$"
 }
+
+# --- .ralphrc-sourced RALPH_DIR (#352 follow-up) ----------------------------
+# load_ralphrc() runs far below the Configuration block, so a RALPH_DIR set in
+# .ralphrc used to arrive after every path var had already been derived from
+# ".ralph". ralph_loop.sh now scans .ralphrc for RALPH_DIR before sourcing the
+# libraries. It scans rather than sources, so a .ralphrc guard that calls
+# `exit` cannot take the read path down with it.
+
+@test "ralph_loop.sh honors RALPH_DIR set in .ralphrc when the environment does not set it" {
+    mkdir -p "$TEST_DIR/rc-state"
+    cat > "$TEST_DIR/.ralphrc" <<RC
+PROJECT_NAME="fixture"
+RALPH_DIR="$TEST_DIR/rc-state"
+RC
+    run bash -c "
+        cd '$TEST_DIR'
+        unset RALPH_DIR
+        source '$PROJECT_ROOT/ralph_loop.sh'
+        echo \"RALPH_DIR=\$RALPH_DIR\"
+        echo \"PROMPT_FILE=\$PROMPT_FILE\"
+        echo \"LOG_DIR=\$LOG_DIR\"
+    "
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "^RALPH_DIR=$TEST_DIR/rc-state$"
+    echo "$output" | grep -q "^PROMPT_FILE=$TEST_DIR/rc-state/PROMPT.md$"
+    echo "$output" | grep -q "^LOG_DIR=$TEST_DIR/rc-state/logs$"
+}
+
+@test "an exported RALPH_DIR takes precedence over the value in .ralphrc" {
+    mkdir -p "$TEST_DIR/from-env" "$TEST_DIR/from-rc"
+    cat > "$TEST_DIR/.ralphrc" <<RC
+RALPH_DIR="$TEST_DIR/from-rc"
+RC
+    run bash -c "
+        cd '$TEST_DIR'
+        export RALPH_DIR='$TEST_DIR/from-env'
+        source '$PROJECT_ROOT/ralph_loop.sh'
+        echo \"RALPH_DIR=\$RALPH_DIR\"
+    "
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "^RALPH_DIR=$TEST_DIR/from-env$"
+}
+
+@test "RALPH_DIR is read from a .ralphrc whose guard exits when sourced too early" {
+    # Mirrors a real workspace: a tripwire above the assignment aborts the shell
+    # unless RALPH_DIR already holds the expected value. Sourcing .ralphrc to
+    # learn RALPH_DIR would therefore yield nothing; scanning it works, and the
+    # guard then passes when load_ralphrc() finally does source the file.
+    mkdir -p "$TEST_DIR/guarded"
+    cat > "$TEST_DIR/.ralphrc" <<RC
+if [[ "\${RALPH_DIR:-}" != "$TEST_DIR/guarded" ]]; then
+    echo "FATAL: RALPH_DIR is '\${RALPH_DIR:-<unset>}'" >&2
+    exit 1
+fi
+RALPH_DIR="$TEST_DIR/guarded"
+RC
+    run bash -c "
+        cd '$TEST_DIR'
+        unset RALPH_DIR
+        source '$PROJECT_ROOT/ralph_loop.sh'
+        load_ralphrc
+        echo \"RALPH_DIR=\$RALPH_DIR\"
+        echo \"CLAUDE_SESSION_FILE=\$CLAUDE_SESSION_FILE\"
+    "
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "^RALPH_DIR=$TEST_DIR/guarded$"
+    echo "$output" | grep -q "^CLAUDE_SESSION_FILE=$TEST_DIR/guarded/.claude_session_id$"
+    # the guard must not have fired (count-based: a line-leading bare '!' is a
+    # silent no-op under bats -- see tests/unit/test_bats_hygiene.bats)
+    [[ $(echo "$output" | grep -c "FATAL: RALPH_DIR") -eq 0 ]]
+}
+
+@test "a commented-out RALPH_DIR in .ralphrc is ignored" {
+    cat > "$TEST_DIR/.ralphrc" <<RC
+# RALPH_DIR="$TEST_DIR/should-not-be-used"
+PROJECT_NAME="fixture"
+RC
+    run bash -c "
+        cd '$TEST_DIR'
+        unset RALPH_DIR
+        source '$PROJECT_ROOT/ralph_loop.sh'
+        echo \"RALPH_DIR=\$RALPH_DIR\"
+    "
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "^RALPH_DIR=\.ralph$"
+}
+
+@test "a .ralphrc RALPH_DIR keeps ralph_loop.sh and response_analyzer.sh on the same session file" {
+    mkdir -p "$TEST_DIR/rc-state"
+    cat > "$TEST_DIR/.ralphrc" <<RC
+RALPH_DIR="$TEST_DIR/rc-state"
+RC
+    run bash -c "
+        cd '$TEST_DIR'
+        unset RALPH_DIR
+        source '$PROJECT_ROOT/ralph_loop.sh'
+        echo \"CLAUDE_SESSION_FILE=\$CLAUDE_SESSION_FILE\"
+        echo \"SESSION_FILE=\$SESSION_FILE\"
+    "
+    [ "$status" -eq 0 ]
+    local claude_session_file session_file
+    claude_session_file=$(echo "$output" | grep '^CLAUDE_SESSION_FILE=' | cut -d= -f2-)
+    session_file=$(echo "$output" | grep '^SESSION_FILE=' | cut -d= -f2-)
+    [ -n "$claude_session_file" ]
+    [ "$claude_session_file" = "$session_file" ]
+    # Both must land under the .ralphrc directory, not merely agree on ".ralph"
+    [ "$claude_session_file" = "$TEST_DIR/rc-state/.claude_session_id" ]
+}

--- a/tests/unit/test_ralph_dir_resolution.bats
+++ b/tests/unit/test_ralph_dir_resolution.bats
@@ -137,9 +137,12 @@ RC
     [ "$status" -eq 0 ]
     echo "$output" | grep -q "^RALPH_DIR=$TEST_DIR/guarded$"
     echo "$output" | grep -q "^CLAUDE_SESSION_FILE=$TEST_DIR/guarded/.claude_session_id$"
-    # the guard must not have fired (count-based: a line-leading bare '!' is a
-    # silent no-op under bats -- see tests/unit/test_bats_hygiene.bats)
-    [[ $(echo "$output" | grep -c "FATAL: RALPH_DIR") -eq 0 ]]
+    # The guard must not have fired. Asserted via `run` + status so a failure
+    # reports what was actually captured; a line-leading bare '!' would be a
+    # silent no-op under bats (tests/unit/test_bats_hygiene.bats).
+    local captured="$output"
+    run grep -q "FATAL: RALPH_DIR" <<< "$captured"
+    [ "$status" -ne 0 ]
 }
 
 @test "a commented-out RALPH_DIR in .ralphrc is ignored" {
@@ -177,4 +180,24 @@ RC
     [ "$claude_session_file" = "$session_file" ]
     # Both must land under the .ralphrc directory, not merely agree on ".ralph"
     [ "$claude_session_file" = "$TEST_DIR/rc-state/.claude_session_id" ]
+}
+
+@test "a .ralphrc RALPH_DIR containing a shell expansion is refused, not applied literally" {
+    # Applying "$HOME/..." verbatim would derive literal paths here while
+    # load_ralphrc() expands the same assignment later -- the exact split this
+    # block exists to prevent. Fall back to the default and say why instead.
+    cat > "$TEST_DIR/.ralphrc" <<RC
+RALPH_DIR="\$HOME/ralph-state"
+RC
+    run bash -c "
+        cd '$TEST_DIR'
+        unset RALPH_DIR
+        source '$PROJECT_ROOT/ralph_loop.sh'
+        echo \"RALPH_DIR=\$RALPH_DIR\"
+        echo \"PROMPT_FILE=\$PROMPT_FILE\"
+    "
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q "^RALPH_DIR=\.ralph$"
+    echo "$output" | grep -q "^PROMPT_FILE=\.ralph/PROMPT\.md$"
+    echo "$output" | grep -q "shell expansion"
 }


### PR DESCRIPTION
## Summary

Fixes #352.

`RALPH_DIR` was honored by every sourced `lib/*.sh` but by neither path the main script uses to learn it. Two separate defects, both landing as split state.

**1. An exported `RALPH_DIR` was discarded.** `ralph_loop.sh:51` hardcoded `RALPH_DIR=".ralph"`. The libraries (`response_analyzer.sh`, `circuit_breaker.sh`, `github_lifecycle.sh`, `queue_manager.sh`, `sandbox_docker.sh`, `sandbox_e2b.sh`) are sourced above it and already use the env-respecting `"${RALPH_DIR:-.ralph}"` form, so they resolved against the exported directory while the ~14 path vars derived below line 51 (`PROMPT_FILE`, `LOG_DIR`, `STATUS_FILE`, `CLAUDE_SESSION_FILE`, ...) resolved against `.ralph`.

**2. A `RALPH_DIR` set in `.ralphrc` arrived too late to matter.** `load_ralphrc()` sources `.ralphrc` near the bottom of the file — long after both the library source block and the path derivations. The assignment therefore could not move any of them; it only affected the handful of `$RALPH_DIR/...` references evaluated later at runtime, which is its own split.

Concretely, `ralph_loop.sh`'s `CLAUDE_SESSION_FILE` (read to decide the `--resume` session id) and `response_analyzer.sh`'s `SESSION_FILE` (written by `store_session_id()`) pointed at different files. The loop then resumed a session id that `store_session_id()` never updated, so every subsequent `claude --resume <id>` used a stale value.

## Fix

`RALPH_DIR` is now resolved once, before anything derives a path from it.

- Line 51 becomes `RALPH_DIR="${RALPH_DIR:-.ralph}"`, matching every file in `lib/`.
- A new block above the library source block reads `RALPH_DIR` out of `.ralphrc` when the environment does not set it.

Precedence is **exported environment > `.ralphrc` > the `.ralph` default**.

A `.ralphrc` value that carries a shell expansion (`$`, backtick) is refused rather than applied: taking `RALPH_DIR="$HOME/state"` literally would derive `$HOME/state/PROMPT.md` here while `load_ralphrc()` expands the same assignment later, reintroducing the split this block removes -- and creating a directory literally named `$HOME`. Such a value produces a warning and keeps the `.ralph` default; exporting `RALPH_DIR` stays the supported way to use an expanded path.

`.ralphrc` is *scanned* there, not sourced. Sourcing it that early would run arbitrary user code — including guards that call `exit` — before the libraries and defaults it may depend on exist, and a guard that aborts would yield no value at all. `load_ralphrc()` remains the single place that sources `.ralphrc`, for every other setting; this block only extracts the one variable that must be known earlier. Quoted, unquoted, and commented forms are handled, and the last assignment wins, matching shell semantics.

## Test plan

`tests/unit/test_ralph_dir_resolution.bats` — 9 tests, all passing:

- [x] An exported `RALPH_DIR` resolves `PROMPT_FILE`/`LOG_DIR`/`CLAUDE_SESSION_FILE` under that path
- [x] `ralph_loop.sh`'s `CLAUDE_SESSION_FILE` and `response_analyzer.sh`'s `SESSION_FILE` agree — the concrete session-resume breakage
- [x] With `RALPH_DIR` unset and no `.ralphrc`, the default is still `.ralph`
- [x] `RALPH_DIR` set in `.ralphrc` is honored when the environment does not set it
- [x] An exported `RALPH_DIR` takes precedence over the `.ralphrc` value
- [x] `RALPH_DIR` is read from a `.ralphrc` whose guard calls `exit` when sourced too early, and that guard then passes once `load_ralphrc()` does source the file
- [x] A commented-out `RALPH_DIR` in `.ralphrc` is ignored
- [x] A `.ralphrc` `RALPH_DIR` keeps both session-file variables on the same path under that directory
- [x] A `.ralphrc` `RALPH_DIR` containing a shell expansion is refused with a warning, leaving the `.ralph` default rather than deriving literal `$HOME/...` paths

- [x] Verified the new tests fail without the corresponding fix and pass with it (tests 1, 2, 4, 6, 8 flip; 3, 5, 7 pin unchanged default behavior)
- [x] Reproduced the shell-expansion case by hand before and after the guard: before, `PROMPT_FILE` resolved to the literal `$HOME/ralphstate/PROMPT.md` while `load_ralphrc()` later expanded `RALPH_DIR` to a real path; after, the warning fires and both keep `.ralph`
- [x] Verified end to end against a real workspace that sets `RALPH_DIR=".agents"` in `.ralphrc` and guards it with a tripwire: before, the loop aborted on that tripwire unless started through a `make` target exporting the variable; after, `ralph --live` starts directly, `PROMPT_FILE` resolves to `.agents/PROMPT.md`, and both session-file variables resolve to `.agents/.claude_session_id`
